### PR TITLE
fix: harden chat state against duplicate keys and empty assistant batches

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -182,7 +182,9 @@ struct ChatTabView: View {
     private var chatItems: [ChatItem] {
         // Completed activity rows interleaved after each assistant turn.
         let activities = turnActivitiesForCurrentSession(.completedOnly)
-        let activityByUserID = Dictionary(uniqueKeysWithValues: activities.map { ($0.id, $0) })
+        let activityByUserID: [String: TurnActivity] = activities.reduce(into: [:]) { result, activity in
+            result[activity.id] = activity
+        }
 
         var items: [ChatItem] = []
         var currentUserID: String? = nil
@@ -297,14 +299,16 @@ struct ChatTabView: View {
                                                 onOpenFilesTab: openFilesTab
                                             )
                                         case .assistantMerged(let msgs):
-                                            let merged = MessageWithParts(info: msgs.first!.info, parts: msgs.flatMap(\.parts))
-                                            MessageRowView(
-                                                message: merged,
-                                                sessionTodos: state.sessionTodos[merged.info.sessionID] ?? [],
-                                                workspaceDirectory: state.currentSession?.directory,
-                                                onOpenResolvedPath: openFileInChat,
-                                                onOpenFilesTab: openFilesTab
-                                            )
+                                            if let first = msgs.first {
+                                                let merged = MessageWithParts(info: first.info, parts: msgs.flatMap(\.parts))
+                                                MessageRowView(
+                                                    message: merged,
+                                                    sessionTodos: state.sessionTodos[merged.info.sessionID] ?? [],
+                                                    workspaceDirectory: state.currentSession?.directory,
+                                                    onOpenResolvedPath: openFileInChat,
+                                                    onOpenFilesTab: openFilesTab
+                                                )
+                                            }
                                         }
                                     case .activity(let a):
                                         TurnActivityRowView(activity: a)


### PR DESCRIPTION
## Summary
- prevent client crashes when server payloads contain duplicate message IDs or duplicate file status paths
- remove force-unwrap in assistant message merge rendering path
- keep behavior unchanged for normal payloads while making VPS sessions more resilient

## Changes
- in `OpenCodeClient/OpenCodeClient/AppState.swift`:
  - dedupe merged messages by `message.info.id` before assigning `messages`
  - rebuild `partsByMessage` via safe map assignment (no `Dictionary(uniqueKeysWithValues:)`)
  - rebuild `fileStatusMap` via safe loop assignment to tolerate duplicate paths
- in `OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift`:
  - build `activityByUserID` with overwrite semantics instead of `Dictionary(uniqueKeysWithValues:)`
  - replace `msgs.first!` with safe optional handling

## Why
When connecting to remote VPS opencode, inconsistent or duplicated session payloads can occur. Previous code paths could trigger fatal runtime crashes from duplicate dictionary keys or force unwrapping empty arrays. This patch converts those paths to defensive handling.

## Validation
- local build succeeds
- app launches and remains alive in simulator
- no crash reproduced on startup/session open after patch
