### PR TITLE
修复服务端缺少 tokens.total 时 iOS 客户端消息解码失败

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Models/Message.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Message.swift
@@ -36,6 +36,24 @@ struct Message: Codable, Identifiable {
             let read: Int
             let write: Int
         }
+
+        private enum CodingKeys: String, CodingKey {
+            case total
+            case input
+            case output
+            case reasoning
+            case cache
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            input = try c.decodeIfPresent(Int.self, forKey: .input) ?? 0
+            output = try c.decodeIfPresent(Int.self, forKey: .output) ?? 0
+            reasoning = try c.decodeIfPresent(Int.self, forKey: .reasoning) ?? 0
+            cache = try c.decodeIfPresent(CacheInfo.self, forKey: .cache)
+            // Newer OpenCode server payloads may omit `total`.
+            total = try c.decodeIfPresent(Int.self, forKey: .total) ?? (input + output + reasoning)
+        }
     }
 
     struct TimeInfo: Codable {

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -53,6 +53,19 @@ struct OpenCodeClientTests {
         #expect(message.isUser == true)
     }
 
+    @Test func messageDecodingWithoutTokenTotal() throws {
+        let json = """
+        {"id":"m2","sessionID":"s1","role":"assistant","parentID":"m1","providerID":"openai","modelID":"gpt-5.2","time":{"created":0,"completed":1},"finish":"stop","tokens":{"input":10,"output":2,"reasoning":3,"cache":{"read":0,"write":0}}}
+        """
+        let data = json.data(using: .utf8)!
+        let message = try JSONDecoder().decode(Message.self, from: data)
+        #expect(message.isAssistant == true)
+        #expect(message.tokens?.input == 10)
+        #expect(message.tokens?.output == 2)
+        #expect(message.tokens?.reasoning == 3)
+        #expect(message.tokens?.total == 15)
+    }
+
     // Regression: server.connected event has no directory; SSEEvent.directory must be optional
     @Test func sseEventDecodingWithoutDirectory() throws {
         let json = """


### PR DESCRIPTION
## 背景

  在真机联调时发现，iOS 客户端已成功连接 OpenCode 服务端（`Status: connected`），发送消息后服务端日志显示模型正常生成回复，但 App 聊天界面看不到 assistant 回复。

  ## 问题现象

  服务端日志显示：
  - `prompt_async` 正常完成
  - LLM 流式生成正常
  - 持续发布 `message.part.updated`
  - session 最终进入 `idle`

  说明服务端实际已经生成了回复。

  同时，`GET /session/:id/message` 返回的 assistant message 中 `tokens` 字段形如：

  - `input`
  - `output`
  - `reasoning`
  - `cache`

  但可能**不包含** `total` 字段。

  ## 根因分析

  iOS 客户端的 `Message.TokenInfo` 将 `total` 作为必填字段解码。

  当服务端返回的 `tokens` 缺少 `total` 时，会导致 assistant message 解码失败，进而出现“服务端有回复、客户端不显示”的现象。

  ## 修复内容

  - 为 `Message.TokenInfo` 增加自定义解码逻辑
  - 将 `tokens.total` 改为兼容缺失（可选输入）
  - 当 `total` 缺失时，使用 `input + output + reasoning` 计算兜底值
  - 保留 `total` 存在时的原有行为（优先使用服务端值）
  - 新增回归测试，覆盖 `tokens.total` 缺失场景

  ## 影响范围

  - 仅影响消息 token 信息解码逻辑
  - 不改变正常 payload 的行为
  - 修复后可恢复 assistant 回复在 Chat 中的显示

  ## 验证方式

  1. 使用返回 `tokens` 不含 `total` 的 OpenCode 服务端
  2. iOS 客户端发送消息
  3. 确认 assistant 回复可正常显示
  4. 单元测试通过：`messageDecodingWithoutTokenTotal`

  ## 兼容性说明

  这是一次服务端返回格式差异的兼容修复。
  问题更可能来自 **OpenCode 服务端版本差异 / API 字段演进**，不一定是“非原版实现”导致。