### PR TITLE
fix: defer session draft sync on session changes

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -586,11 +586,14 @@ struct ChatTabView: View {
                 syncDraftFromState(sessionID: state.currentSessionID)
             }
             .onChange(of: state.currentSessionID) { oldID, newID in
-                state.setDraftText(inputText, for: oldID)
-                syncDraftFromState(sessionID: newID)
-                isNearBottom = true
-                pendingBottomVisibilityTask?.cancel()
-                pendingBottomVisibilityTask = nil
+                let draftText = inputText
+                Task { @MainActor in
+                    state.setDraftText(draftText, for: oldID)
+                    syncDraftFromState(sessionID: newID)
+                    isNearBottom = true
+                    pendingBottomVisibilityTask?.cancel()
+                    pendingBottomVisibilityTask = nil
+                }
             }
             .onChange(of: inputText) { _, newValue in
                 guard !isSyncingDraft else { return }

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -15,6 +15,10 @@
 
 ## 已完成（近期）
 
+- [x] **避免 session 切换时在 view update 内同步改状态（2026-03-30）**：
+  - [x] 将 `ChatTabView` 中响应 `currentSessionID` 变化的草稿同步与滚动状态重置改为 `Task { @MainActor in }`
+  - [x] 降低运行时 `Modifying state during view update` 告警概率，不改变现有 session 切换行为
+
 - [x] **GLM-5.1 预设切回 GLM-5-turbo（2026-03-30）**：
   - [x] 将模型预设显示名从 `GLM-5.1` 更新为 `GLM-5-turbo`
   - [x] 将底层 model ID 从 `glm-5.1` 更新为 `glm-5-turbo`


### PR DESCRIPTION
## Summary
- defer the session-switch draft sync in `ChatTabView` to the next main-actor turn
- reduce `Modifying state during view update` warnings without changing session-switch behavior
- document the runtime warning fix in `docs/WORKING.md`

## Verification
- xcodebuild build -project \"OpenCodeClient/OpenCodeClient.xcodeproj\" -scheme \"OpenCodeClient\" -destination 'generic/platform=iOS Simulator'
- xcodebuild test -project \"OpenCodeClient/OpenCodeClient.xcodeproj\" -scheme \"OpenCodeClient\" -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4'