### PR TITLE
Classify cgnat address space as lan

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -77,6 +77,7 @@ final class AppState {
             if a == 10 || a == 127 { return true }
             if a == 192 && b == 168 { return true }
             if a == 172 && (16...31).contains(b) { return true }
+            if a == 100 && (64...127).contains(b) { return true }
             if a == 169 && b == 254 { return true }
             if host == "0.0.0.0" { return true }
             return false

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -35,6 +35,17 @@ struct OpenCodeClientTests {
         #expect(AppState.ensureServerURLHasScheme("https://example.com:443") == nil)
     }
 
+    @Test func serverURLInfoTreatsCGNATAsLocal() {
+        let cgnat = AppState.serverURLInfo("100.64.1.2:4096")
+        #expect(cgnat.isLocal == true)
+        #expect(cgnat.normalized == "http://100.64.1.2:4096")
+        #expect(cgnat.warning == L10n.t(.errorUsingLanHttp))
+
+        let publicAddress = AppState.serverURLInfo("100.128.1.2:4096")
+        #expect(publicAddress.isLocal == false)
+        #expect(publicAddress.warning == L10n.t(.errorWanRequiresHttps))
+    }
+
     @Test @MainActor func migrateLegacyDefaultServerAddress() {
         let key = "serverURL"
         let previous = UserDefaults.standard.string(forKey: key)


### PR DESCRIPTION
This PR adjusts the private/public ipv4 address classification to allow http usage in CGNAT scheme network backhauls such as tailscale