### PR TITLE
model: replace Opus/Sonnet with DeepSeek in model presets

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -416,10 +416,9 @@ final class AppState {
 
     var modelPresets: [ModelPreset] = [
         ModelPreset(displayName: "GLM-5-turbo", providerID: "zai-coding-plan", modelID: "glm-5-turbo"),
-        ModelPreset(displayName: "Opus 4.6", providerID: "anthropic", modelID: "claude-opus-4-6"),
-        ModelPreset(displayName: "Sonnet 4.6", providerID: "anthropic", modelID: "claude-sonnet-4-6"),
         ModelPreset(displayName: "GPT-5.4", providerID: "openai", modelID: "gpt-5.4"),
         ModelPreset(displayName: "GPT-5.3 Codex", providerID: "openai", modelID: "gpt-5.3-codex"),
+        ModelPreset(displayName: "DeepSeek", providerID: "deepseek", modelID: "deepseek-v4-pro"),
     ]
     var selectedModelIndex: Int = 3
     

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -12,8 +12,7 @@ struct ModelPreset: Codable, Identifiable {
     let modelID: String
     
     var shortName: String {
-        if displayName.contains("Opus") { return "Opus" }
-        if displayName.contains("Sonnet") { return "Sonnet" }
+        if displayName.contains("DeepSeek") { return "DeepSeek" }
         if displayName.contains("Gemini") { return "Gemini" }
         if displayName.contains("GPT") { return "GPT" }
         return displayName

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1563,14 +1563,9 @@ struct AgentInfoTests {
 
 struct ModelPresetShortNameTests {
     
-    @Test func opusShortName() {
-        let preset = ModelPreset(displayName: "Opus 4.6", providerID: "anthropic", modelID: "claude-opus-4-6")
-        #expect(preset.shortName == "Opus")
-    }
-    
-    @Test func sonnetShortName() {
-        let preset = ModelPreset(displayName: "Sonnet 4.6", providerID: "anthropic", modelID: "claude-sonnet-4-6")
-        #expect(preset.shortName == "Sonnet")
+    @Test func deepseekShortName() {
+        let preset = ModelPreset(displayName: "DeepSeek", providerID: "deepseek", modelID: "deepseek-v4-pro")
+        #expect(preset.shortName == "DeepSeek")
     }
     
     @Test func geminiShortName() {

--- a/docs/OpenCode_iOS_Client_PRD.md
+++ b/docs/OpenCode_iOS_Client_PRD.md
@@ -136,15 +136,14 @@ iPhone 采用底部 Tab Bar，三个 Tab：
 
 | 显示名称 | providerID | modelID |
 |----------|------------|---------|
-| GLM-5 | `zai-coding-plan` | `glm-5` |
-| Opus 4.6 | `anthropic` | `claude-opus-4-6` |
-| Sonnet 4.6 | `anthropic` | `claude-sonnet-4-6` |
+| GLM-5-turbo | `zai-coding-plan` | `glm-5-turbo` |
 | GPT-5.4 | `openai` | `gpt-5.4` |
 | GPT-5.3 Codex | `openai` | `gpt-5.3-codex` |
+| DeepSeek | `deepseek` | `deepseek-v4-pro` |
 
 **Agent 选择器**：下拉列表，内容从 `GET /agent` API 动态获取。过滤 `hidden != true` 的 agents 后显示。每个选项显示 agent 名称（如 `Sisyphus`），description 可作为 tooltip 或 subtitle。
 
-**iPhone 显示策略**：iPhone 上使用短名（`Opus` / `Sonnet` / `GPT` / `GLM`）以适配窄宽；iPad 上显示全称。
+**iPhone 显示策略**：iPhone 上使用短名（`DeepSeek` / `GPT` / `GLM`）以适配窄宽；iPad 上显示全称。
 
 **技术实现**：
 - 切换模型/Agent 不需要调用 API，只是改变本地状态
@@ -362,7 +361,7 @@ iOS App → 公网 VPS (SSH) → VPS:18080 → 家里 OpenCode (127.0.0.1:4096)
 
 #### 4.4.3 Model Presets
 
-**当前实现**：固定预设列表（GLM-5、Opus 4.6、Sonnet 4.6、GPT-5.4、GPT-5.3 Codex），无导入、无排序。发送消息时在 body 中携带 `model: { providerID, modelID }`。
+**当前实现**：固定预设列表（GLM-5-turbo、GPT-5.4、GPT-5.3 Codex、DeepSeek），无导入、无排序。发送消息时在 body 中携带 `model: { providerID, modelID }`。
 
 #### 4.4.3 Project (Workspace)
 

--- a/docs/OpenCode_iOS_Client_RFC.md
+++ b/docs/OpenCode_iOS_Client_RFC.md
@@ -429,7 +429,7 @@ var customProjectPath: String = ""        // "Custom path" 时用户输入的路
 - **文件预览**：iPad 上不使用 sheet。左栏选择文件、或 Chat 中点击 tool/patch 的 file path 时，更新中栏 Preview 预览对应文件
 - **刷新**：Preview 中栏右上角提供刷新按钮（重新加载文件内容），用于外部变更后的手动刷新
 - **Toolbar**：第一行统一：左（Session 列表、重命名、Compact、新建 Session）+ 右（模型下拉列表、Agent 下拉列表、Context Usage ring、**Settings 按钮**）；Settings 点击以 sheet 打开
-- **模型与 Agent 选择器**：原 chip 横向滚动改为下拉列表（Menu + Picker）。模型列表固定（GLM-5 / Opus 4.6 / Sonnet 4.6 / GPT-5.4 / GPT-5.3 Codex）；Agent 列表从 `GET /agent` 动态获取（过滤 hidden）
+- **模型与 Agent 选择器**：原 chip 横向滚动改为下拉列表（Menu + Picker）。模型列表固定（GLM-5-turbo / GPT-5.4 / GPT-5.3 Codex / DeepSeek）；Agent 列表从 `GET /agent` 动态获取（过滤 hidden）
 - **模型标签**：iPhone 上使用短名（`GLM` / `Opus` / `GPT` / `Gemini`）以适配窄宽；iPad 上显示全称
 - **实现**：`@Environment(\.horizontalSizeClass)` 分支：regular 时渲染三栏 split，小屏时渲染 `TabView`；iPad 用 `previewFilePath` 驱动中栏预览，iPhone 保留 `fileToOpenInFilesTab` 走 sheet / tab 跳转
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,11 +4,11 @@
 
 ## 当前状态
 
-- **最后更新**：2026-04-15
-- **分支**：`fix/markdown-report-images`（from master）
+- **最后更新**：2026-04-23
+- **分支**：`model/update-deepseek`（from master）
 - **编译**：✅ `xcodebuild build` 通过
 - **测试**：✅ `xcodebuild test` 通过
-- **Phase**：Markdown 报告图片渲染修复，PR 已更新待合并
+- **Phase**：Model 列表更新：删除 Opus/Sonnet，添加 DeepSeek
 
 ## 默认工作流约定
 
@@ -64,6 +64,7 @@ OPENCODE_SERVER_PASSWORD="restart_Web@" \
 ## 进行中
 
 - [ ] **PR 合并** — `design-redesign` 分支所有改动已完成并通过测试，待创建 PR 合并到 master
+- [ ] **Model 列表更新 — 删除 Opus/Sonnet，添加 DeepSeek（2026-04-23）**：删除 `anthropic/claude-opus-4-6` 和 `anthropic/claude-sonnet-4-6`，新增 `deepseek/deepseek-v4-pro`
 
 ## 已完成（近期）
 
@@ -397,16 +398,13 @@ OPENCODE_SERVER_PASSWORD="restart_Web@" \
 - **GET /agent**：✅ 返回 `[AgentInfo]`，含 name/description/mode/hidden/native 字段。iOS 端过滤 mode=subagent。
 - **Import from Server**：依赖 config/providers，解析修复后应可正常导入。
 
-当前模型预设（7 个）：
+当前模型预设（4 个）：
 | 显示名称 | providerID | modelID |
 |----------|------------|---------|
-| GLM-5（默认） | `zai-coding-plan` | `glm-5` |
-| Opus 4.6 | `anthropic` | `claude-opus-4-6` |
-| Sonnet 4.6 | `anthropic` | `claude-sonnet-4-6` |
+| GLM-5-turbo | `zai-coding-plan` | `glm-5-turbo` |
+| GPT-5.4 | `openai` | `gpt-5.4` |
 | GPT-5.3 Codex | `openai` | `gpt-5.3-codex` |
-| GPT-5.2 | `openai` | `gpt-5.2` |
-| Gemini 3.1 Pro | `google` | `gemini-3.1-pro-preview` |
-| Gemini 3 Flash | `google` | `gemini-3-flash-preview` |
+| DeepSeek | `deepseek` | `deepseek-v4-pro` |
 
 Agent prefill（5 个，OpenCode-Builder 默认）：
 - OpenCode-Builder (mode=all)


### PR DESCRIPTION
## Summary
- Remove anthropic models (Opus 4.6 / Sonnet 4.6) from iOS client model presets
- Add DeepSeek (deepseek/deepseek-v4-pro) as a new preset option
- Update ModelPreset.shortName to remove Sonnet case and add DeepSeek case
- Update tests (replace opusShortName/sonnetShortName with deepseekShortName)
- Sync docs (PRD, RFC, WORKING.md) with updated model list