### PR TITLE
chore: default model selection to GPT-5.5

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -416,11 +416,11 @@ final class AppState {
 
     var modelPresets: [ModelPreset] = [
         ModelPreset(displayName: "GLM-5-turbo", providerID: "zai-coding-plan", modelID: "glm-5-turbo"),
-        ModelPreset(displayName: "GPT-5.4", providerID: "openai", modelID: "gpt-5.4"),
+        ModelPreset(displayName: "GPT-5.5", providerID: "openai", modelID: "gpt-5.5"),
         ModelPreset(displayName: "GPT-5.3 Codex", providerID: "openai", modelID: "gpt-5.3-codex"),
         ModelPreset(displayName: "DeepSeek", providerID: "deepseek", modelID: "deepseek-v4-pro"),
     ]
-    var selectedModelIndex: Int = 3
+    var selectedModelIndex: Int = 1
     
     var agents: [AgentInfo] = [
         AgentInfo(name: "OpenCode-Builder", description: "Build agent (OpenCode default)", mode: "all", hidden: false, native: false),
@@ -682,6 +682,8 @@ final class AppState {
         switch savedID {
         case "zai-coding-plan/glm-5.1":
             return "zai-coding-plan/glm-5-turbo"
+        case "openai/gpt-5.4":
+            return "openai/gpt-5.5"
         default:
             return savedID
         }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1621,6 +1621,52 @@ struct ModelSelectionPersistenceTests {
         #expect(state.selectedModelIndex == 0)
         #expect(state.modelPresets[state.selectedModelIndex].displayName == "GLM-5-turbo")
     }
+
+    @Test @MainActor func legacyGPT54SelectionMapsToCurrentGPT55Preset() {
+        let sessionID = "session-gpt"
+        let defaultsKey = "selectedModelBySession"
+        let legacySelection = [sessionID: "openai/gpt-5.4"]
+        let originalData = UserDefaults.standard.data(forKey: defaultsKey)
+
+        defer {
+            if let originalData {
+                UserDefaults.standard.set(originalData, forKey: defaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: defaultsKey)
+            }
+        }
+
+        let encoded = try! JSONEncoder().encode(legacySelection)
+        UserDefaults.standard.set(encoded, forKey: defaultsKey)
+
+        let state = AppState()
+        let session = Session(
+            id: sessionID,
+            slug: sessionID,
+            projectID: "p1",
+            directory: "/tmp",
+            parentID: nil,
+            title: sessionID,
+            version: "1",
+            time: .init(created: 0, updated: 100, archived: nil),
+            share: nil,
+            summary: nil
+        )
+
+        state.selectSession(session)
+
+        #expect(state.selectedModelIndex == 1)
+        #expect(state.modelPresets[state.selectedModelIndex].displayName == "GPT-5.5")
+        #expect(state.modelPresets[state.selectedModelIndex].id == "openai/gpt-5.5")
+    }
+
+    @Test @MainActor func defaultSelectionUsesGPT55Preset() {
+        let state = AppState()
+
+        #expect(state.selectedModelIndex == 1)
+        #expect(state.modelPresets[state.selectedModelIndex].displayName == "GPT-5.5")
+        #expect(state.modelPresets[state.selectedModelIndex].id == "openai/gpt-5.5")
+    }
 }
 
 struct ArchivedSessionTests {

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,11 +4,11 @@
 
 ## 当前状态
 
-- **最后更新**：2026-04-23
+- **最后更新**：2026-04-28
 - **分支**：`model/update-deepseek`（from master）
 - **编译**：✅ `xcodebuild build` 通过
 - **测试**：✅ `xcodebuild test` 通过
-- **Phase**：Model 列表更新：删除 Opus/Sonnet，添加 DeepSeek
+- **Phase**：默认模型切换到 GPT，GPT 预设升级到 5.5
 
 ## 默认工作流约定
 
@@ -67,6 +67,12 @@ OPENCODE_SERVER_PASSWORD="restart_Web@" \
 - [ ] **Model 列表更新 — 删除 Opus/Sonnet，添加 DeepSeek（2026-04-23）**：删除 `anthropic/claude-opus-4-6` 和 `anthropic/claude-sonnet-4-6`，新增 `deepseek/deepseek-v4-pro`
 
 ## 已完成（近期）
+
+- [x] **默认模型切换到 GPT-5.5（2026-04-28）**：
+  - [x] 默认发送模型从 DeepSeek 切换为 `openai/gpt-5.5`
+  - [x] GPT 预设显示名和 model ID 从 `GPT-5.4` / `gpt-5.4` 升级为 `GPT-5.5` / `gpt-5.5`
+  - [x] 为已保存旧 `openai/gpt-5.4` 选择的 session 增加兼容映射，避免模型 selector 回退
+  - [x] 新增默认选择与旧 GPT 选择迁移测试
 
 - [x] **Markdown 报告图片渲染修复（2026-04-15）**：
   - [x] 根因确认：Android 能显示报告内图片，不是 markdown 内容问题；Android 会先把相对图片路径解析成 `data:` URI 再渲染，而 iOS 聊天视图原来只做了路径解析，没有把能渲染 `data:` URL 的 image provider 接上


### PR DESCRIPTION
## Summary
- switch the iOS client's default model selection from DeepSeek to the GPT preset
- upgrade the curated GPT preset from `gpt-5.4` to `gpt-5.5` and normalize saved `openai/gpt-5.4` selections to the new preset
- add persistence coverage for the new default path and the legacy GPT selection migration, and update `docs/WORKING.md`

## Testing
- xcodebuild build -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'generic/platform=iOS Simulator'
- xcodebuild test -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4'