### PR TITLE
Switch default DeepSeek model from v4-pro to v4-flash

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -418,7 +418,7 @@ final class AppState {
         ModelPreset(displayName: "GLM-5-turbo", providerID: "zai-coding-plan", modelID: "glm-5-turbo"),
         ModelPreset(displayName: "GPT-5.5", providerID: "openai", modelID: "gpt-5.5"),
         ModelPreset(displayName: "GPT-5.3 Codex", providerID: "openai", modelID: "gpt-5.3-codex"),
-        ModelPreset(displayName: "DeepSeek", providerID: "deepseek", modelID: "deepseek-v4-pro"),
+        ModelPreset(displayName: "DeepSeek", providerID: "deepseek", modelID: "deepseek-v4-flash"),
     ]
     var selectedModelIndex: Int = 1
     

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1573,7 +1573,7 @@ struct AgentInfoTests {
 struct ModelPresetShortNameTests {
     
     @Test func deepseekShortName() {
-        let preset = ModelPreset(displayName: "DeepSeek", providerID: "deepseek", modelID: "deepseek-v4-pro")
+        let preset = ModelPreset(displayName: "DeepSeek", providerID: "deepseek", modelID: "deepseek-v4-flash")
         #expect(preset.shortName == "DeepSeek")
     }
     


### PR DESCRIPTION
Change the default DeepSeek model ID from `deepseek-v4-pro` to `deepseek-v4-flash`.

- `AppState.swift`: model preset updated
- `OpenCodeClientTests.swift`: test expectation updated