### PR TITLE
Rename GLM-5-turbo to GLM-5.1

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -415,7 +415,7 @@ final class AppState {
     var streamingReasoningPart: Part? { get { messageStore.streamingReasoningPart } set { messageStore.streamingReasoningPart = newValue } }
 
     var modelPresets: [ModelPreset] = [
-        ModelPreset(displayName: "GLM-5-turbo", providerID: "zai-coding-plan", modelID: "glm-5-turbo"),
+        ModelPreset(displayName: "GLM-5.1", providerID: "zai-coding-plan", modelID: "glm-5.1"),
         ModelPreset(displayName: "GPT-5.5", providerID: "openai", modelID: "gpt-5.5"),
         ModelPreset(displayName: "GPT-5.3 Codex", providerID: "openai", modelID: "gpt-5.3-codex"),
         ModelPreset(displayName: "DeepSeek", providerID: "deepseek", modelID: "deepseek-v4-flash"),
@@ -680,8 +680,8 @@ final class AppState {
 
     private func canonicalModelPresetID(for savedID: String) -> String {
         switch savedID {
-        case "zai-coding-plan/glm-5.1":
-            return "zai-coding-plan/glm-5-turbo"
+        case "zai-coding-plan/glm-5.1", "zai-coding-plan/glm-5-turbo":
+            return "zai-coding-plan/glm-5.1"
         case "openai/gpt-5.4":
             return "openai/gpt-5.5"
         default:

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1628,7 +1628,7 @@ struct ModelSelectionPersistenceTests {
         state.selectSession(session)
 
         #expect(state.selectedModelIndex == 0)
-        #expect(state.modelPresets[state.selectedModelIndex].displayName == "GLM-5-turbo")
+        #expect(state.modelPresets[state.selectedModelIndex].displayName == "GLM-5.1")
     }
 
     @Test @MainActor func legacyGPT54SelectionMapsToCurrentGPT55Preset() {

--- a/docs/OpenCode_iOS_Client_PRD.md
+++ b/docs/OpenCode_iOS_Client_PRD.md
@@ -136,7 +136,7 @@ iPhone 采用底部 Tab Bar，三个 Tab：
 
 | 显示名称 | providerID | modelID |
 |----------|------------|---------|
-| GLM-5-turbo | `zai-coding-plan` | `glm-5-turbo` |
+| GLM-5.1 | `zai-coding-plan` | `glm-5.1` |
 | GPT-5.4 | `openai` | `gpt-5.4` |
 | GPT-5.3 Codex | `openai` | `gpt-5.3-codex` |
 | DeepSeek | `deepseek` | `deepseek-v4-pro` |
@@ -361,7 +361,7 @@ iOS App → 公网 VPS (SSH) → VPS:18080 → 家里 OpenCode (127.0.0.1:4096)
 
 #### 4.4.3 Model Presets
 
-**当前实现**：固定预设列表（GLM-5-turbo、GPT-5.4、GPT-5.3 Codex、DeepSeek），无导入、无排序。发送消息时在 body 中携带 `model: { providerID, modelID }`。
+**当前实现**：固定预设列表（GLM-5.1、GPT-5.4、GPT-5.3 Codex、DeepSeek），无导入、无排序。发送消息时在 body 中携带 `model: { providerID, modelID }`。
 
 #### 4.4.3 Project (Workspace)
 

--- a/docs/OpenCode_iOS_Client_RFC.md
+++ b/docs/OpenCode_iOS_Client_RFC.md
@@ -429,7 +429,7 @@ var customProjectPath: String = ""        // "Custom path" 时用户输入的路
 - **文件预览**：iPad 上不使用 sheet。左栏选择文件、或 Chat 中点击 tool/patch 的 file path 时，更新中栏 Preview 预览对应文件
 - **刷新**：Preview 中栏右上角提供刷新按钮（重新加载文件内容），用于外部变更后的手动刷新
 - **Toolbar**：第一行统一：左（Session 列表、重命名、Compact、新建 Session）+ 右（模型下拉列表、Agent 下拉列表、Context Usage ring、**Settings 按钮**）；Settings 点击以 sheet 打开
-- **模型与 Agent 选择器**：原 chip 横向滚动改为下拉列表（Menu + Picker）。模型列表固定（GLM-5-turbo / GPT-5.4 / GPT-5.3 Codex / DeepSeek）；Agent 列表从 `GET /agent` 动态获取（过滤 hidden）
+- **模型与 Agent 选择器**：原 chip 横向滚动改为下拉列表（Menu + Picker）。模型列表固定（GLM-5.1 / GPT-5.4 / GPT-5.3 Codex / DeepSeek）；Agent 列表从 `GET /agent` 动态获取（过滤 hidden）
 - **模型标签**：iPhone 上使用短名（`GLM` / `Opus` / `GPT` / `Gemini`）以适配窄宽；iPad 上显示全称
 - **实现**：`@Environment(\.horizontalSizeClass)` 分支：regular 时渲染三栏 split，小屏时渲染 `TabView`；iPad 用 `previewFilePath` 驱动中栏预览，iPhone 保留 `fileToOpenInFilesTab` 走 sheet / tab 跳转
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,7 +4,7 @@
 
 ## 当前状态
 
-- **最后更新**：2026-05-02
+- **最后更新**：2026-05-03
 - **分支**：`visionos`（from master）
 - **编译**：✅ unified `OpenCodeClient` visionOS Simulator build 通过
 - **测试**：✅ iOS build/test 回归验证通过
@@ -174,6 +174,11 @@ OPENCODE_SERVER_PASSWORD="restart_Web@" \
 - [x] **避免 session 切换时在 view update 内同步改状态（2026-03-30）**：
   - [x] 将 `ChatTabView` 中响应 `currentSessionID` 变化的草稿同步与滚动状态重置改为 `Task { @MainActor in }`
   - [x] 降低运行时 `Modifying state during view update` 告警概率，不改变现有 session 切换行为
+
+- [x] **GLM-5-turbo 预设切换到 GLM-5.1（2026-05-03）**：
+  - [x] 将模型预设显示名从 `GLM-5-turbo` 更新为 `GLM-5.1`，modelID 从 `glm-5-turbo` 更新为 `glm-5.1`
+  - [x] `canonicalModelPresetID` 遗留迁移：`glm-5-turbo` 和 `glm-5.1` 均映射到新的 `glm-5.1`
+  - [x] 同步更新 PRD、RFC 文档中的模型引用
 
 - [x] **GLM-5.1 预设切回 GLM-5-turbo（2026-03-30）**：
   - [x] 将模型预设显示名从 `GLM-5.1` 更新为 `GLM-5-turbo`
@@ -467,7 +472,7 @@ OPENCODE_SERVER_PASSWORD="restart_Web@" \
 当前模型预设（4 个）：
 | 显示名称 | providerID | modelID |
 |----------|------------|---------|
-| GLM-5-turbo | `zai-coding-plan` | `glm-5-turbo` |
+| GLM-5.1 | `zai-coding-plan` | `glm-5.1` |
 | GPT-5.4 | `openai` | `gpt-5.4` |
 | GPT-5.3 Codex | `openai` | `gpt-5.3-codex` |
 | DeepSeek | `deepseek` | `deepseek-v4-pro` |


### PR DESCRIPTION
## Summary

- Update model preset displayName from `GLM-5-turbo` to `GLM-5.1` and modelID from `glm-5-turbo` to `glm-5.1`
- Add legacy migration case in `canonicalModelPresetID`: both old `glm-5.1` and `glm-5-turbo` selections map to the new `glm-5.1` preset
- Update test assertion to expect `GLM-5.1`
- Sync PRD, RFC, and WORKING docs

## Test plan

- [x] `xcodebuild test` — all unit tests pass (including `legacyGLM51SelectionMapsToCurrentTurboPreset`)