### PR TITLE
Fix remote Markdown images: fit-to-screen and tap-to-preview

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
@@ -8,7 +8,6 @@ struct WorkspaceMarkdownImageProvider: ImageProvider {
     let workspaceDirectory: String?
 
     func makeImage(url: URL?) -> some View {
-        print("[WorkspaceMarkdownImageProvider] makeImage url=\(url?.absoluteString ?? "nil") scheme=\(url?.scheme ?? "nil")")
         WorkspaceMarkdownImageView(url: url, loadFileContent: loadFileContent, workspaceDirectory: workspaceDirectory)
     }
 
@@ -114,6 +113,17 @@ private struct WorkspaceMarkdownImageView: View {
     let url: URL?
     let loadFileContent: @Sendable (String) async throws -> FileContent
     let workspaceDirectory: String?
+
+    init(
+        url: URL?,
+        loadFileContent: @escaping @Sendable (String) async throws -> FileContent,
+        workspaceDirectory: String?
+    ) {
+        self.url = url
+        self.loadFileContent = loadFileContent
+        self.workspaceDirectory = workspaceDirectory
+        print("[WorkspaceMarkdownImageProvider] init image url=\(url?.absoluteString ?? "nil") scheme=\(url?.scheme ?? "nil")")
+    }
 
     #if os(visionOS)
     @Environment(\.openWindow) private var openWindow

--- a/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
@@ -193,6 +193,7 @@ private struct WorkspaceMarkdownImageView: View {
         .task(id: url?.absoluteString) {
             guard !didAttemptLoad else { return }
             didAttemptLoad = true
+            print("[WorkspaceMarkdownImageProvider] task fired url=\(url?.absoluteString ?? "nil") scheme=\(url?.scheme ?? "nil")")
 
             // 1. Data URI (base64 inline)
             if let data = WorkspaceMarkdownImageProvider.decodeDataURL(url) {

--- a/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
@@ -8,6 +8,7 @@ struct WorkspaceMarkdownImageProvider: ImageProvider {
     let workspaceDirectory: String?
 
     func makeImage(url: URL?) -> some View {
+        print("[WorkspaceMarkdownImageProvider] makeImage url=\(url?.absoluteString ?? "nil") scheme=\(url?.scheme ?? "nil")")
         WorkspaceMarkdownImageView(url: url, loadFileContent: loadFileContent, workspaceDirectory: workspaceDirectory)
     }
 

--- a/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
@@ -122,7 +122,6 @@ private struct WorkspaceMarkdownImageView: View {
         self.url = url
         self.loadFileContent = loadFileContent
         self.workspaceDirectory = workspaceDirectory
-        print("[WorkspaceMarkdownImageProvider] init image url=\(url?.absoluteString ?? "nil") scheme=\(url?.scheme ?? "nil")")
     }
 
     #if os(visionOS)
@@ -204,7 +203,6 @@ private struct WorkspaceMarkdownImageView: View {
         .task(id: url?.absoluteString) {
             guard !didAttemptLoad else { return }
             didAttemptLoad = true
-            print("[WorkspaceMarkdownImageProvider] task fired url=\(url?.absoluteString ?? "nil") scheme=\(url?.scheme ?? "nil")")
 
             // 1. Data URI (base64 inline)
             if let data = WorkspaceMarkdownImageProvider.decodeDataURL(url) {
@@ -214,33 +212,18 @@ private struct WorkspaceMarkdownImageView: View {
 
             // 2. Workspace-relative file (via OpenCode server API)
             if let path = WorkspaceMarkdownImageProvider.workspaceRelativePath(from: url, workspaceDirectory: workspaceDirectory) {
-                do {
-                    print("[WorkspaceMarkdownImageProvider] load local image path=\(path)")
-                    let content = try await loadFileContent(path)
-                    guard let data = WorkspaceMarkdownImageProvider.decodeBase64ImageData(content.content) else {
-                        print("[WorkspaceMarkdownImageProvider] failed to decode image path=\(path) type=\(content.type)")
-                        return
-                    }
+                if let content = try? await loadFileContent(path),
+                   let data = WorkspaceMarkdownImageProvider.decodeBase64ImageData(content.content) {
                     imageData = data
-                    print("[WorkspaceMarkdownImageProvider] loaded local image path=\(path) bytes=\(data.count)")
-                } catch {
-                    print("[WorkspaceMarkdownImageProvider] failed to load local image path=\(path) error=\(error.localizedDescription)")
                 }
                 return
             }
 
             // 3. Remote URL (download directly via URLSession, bypass server base64)
             if let url, let scheme = url.scheme, (scheme == "http" || scheme == "https") {
-                do {
-                    let (data, _) = try await URLSession.shared.data(from: url)
-                    if UIImage(data: data) != nil {
-                        imageData = data
-                        print("[WorkspaceMarkdownImageProvider] downloaded remote image url=\(url.absoluteString) bytes=\(data.count)")
-                    } else {
-                        print("[WorkspaceMarkdownImageProvider] downloaded data is not a valid image url=\(url.absoluteString)")
-                    }
-                } catch {
-                    print("[WorkspaceMarkdownImageProvider] failed to download remote image url=\(url.absoluteString) error=\(error.localizedDescription)")
+                if let (data, _) = try? await URLSession.shared.data(from: url),
+                   UIImage(data: data) != nil {
+                    imageData = data
                 }
             }
         }

--- a/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
@@ -194,29 +194,42 @@ private struct WorkspaceMarkdownImageView: View {
             guard !didAttemptLoad else { return }
             didAttemptLoad = true
 
+            // 1. Data URI (base64 inline)
             if let data = WorkspaceMarkdownImageProvider.decodeDataURL(url) {
                 imageData = data
                 return
             }
 
-            guard let path = WorkspaceMarkdownImageProvider.workspaceRelativePath(from: url, workspaceDirectory: workspaceDirectory) else {
-                if let url {
-                    print("[WorkspaceMarkdownImageProvider] unsupported image url=\(url.absoluteString)")
+            // 2. Workspace-relative file (via OpenCode server API)
+            if let path = WorkspaceMarkdownImageProvider.workspaceRelativePath(from: url, workspaceDirectory: workspaceDirectory) {
+                do {
+                    print("[WorkspaceMarkdownImageProvider] load local image path=\(path)")
+                    let content = try await loadFileContent(path)
+                    guard let data = WorkspaceMarkdownImageProvider.decodeBase64ImageData(content.content) else {
+                        print("[WorkspaceMarkdownImageProvider] failed to decode image path=\(path) type=\(content.type)")
+                        return
+                    }
+                    imageData = data
+                    print("[WorkspaceMarkdownImageProvider] loaded local image path=\(path) bytes=\(data.count)")
+                } catch {
+                    print("[WorkspaceMarkdownImageProvider] failed to load local image path=\(path) error=\(error.localizedDescription)")
                 }
                 return
             }
 
-            do {
-                print("[WorkspaceMarkdownImageProvider] load local image path=\(path)")
-                let content = try await loadFileContent(path)
-                guard let data = WorkspaceMarkdownImageProvider.decodeBase64ImageData(content.content) else {
-                    print("[WorkspaceMarkdownImageProvider] failed to decode image path=\(path) type=\(content.type)")
-                    return
+            // 3. Remote URL (download directly via URLSession, bypass server base64)
+            if let url, let scheme = url.scheme, (scheme == "http" || scheme == "https") {
+                do {
+                    let (data, _) = try await URLSession.shared.data(from: url)
+                    if UIImage(data: data) != nil {
+                        imageData = data
+                        print("[WorkspaceMarkdownImageProvider] downloaded remote image url=\(url.absoluteString) bytes=\(data.count)")
+                    } else {
+                        print("[WorkspaceMarkdownImageProvider] downloaded data is not a valid image url=\(url.absoluteString)")
+                    }
+                } catch {
+                    print("[WorkspaceMarkdownImageProvider] failed to download remote image url=\(url.absoluteString) error=\(error.localizedDescription)")
                 }
-                imageData = data
-                print("[WorkspaceMarkdownImageProvider] loaded local image path=\(path) bytes=\(data.count)")
-            } catch {
-                print("[WorkspaceMarkdownImageProvider] failed to load local image path=\(path) error=\(error.localizedDescription)")
             }
         }
     }

--- a/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
@@ -221,7 +221,39 @@ struct MarkdownPreviewView: View {
         return maxLine > Self.maxLineLength
     }
 
+    static func normalizeStandaloneImageBlocks(_ text: String) -> String {
+        let lines = text.components(separatedBy: "\n")
+        guard lines.count > 1 else { return text }
+
+        var normalized: [String] = []
+        normalized.reserveCapacity(lines.count)
+
+        for index in lines.indices {
+            let line = lines[index]
+            normalized.append(line)
+
+            guard isStandaloneMarkdownImageLine(line) else { continue }
+            guard index + 1 < lines.count else { continue }
+
+            let nextLine = lines[index + 1]
+            if !nextLine.trimmingCharacters(in: .whitespaces).isEmpty {
+                normalized.append("")
+            }
+        }
+
+        return normalized.joined(separator: "\n")
+    }
+
+    private static func isStandaloneMarkdownImageLine(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("!["), trimmed.hasSuffix(")") else { return false }
+        guard let closeAlt = trimmed.firstIndex(of: "]") else { return false }
+        let afterAlt = trimmed[trimmed.index(after: closeAlt)...]
+        return afterAlt.hasPrefix("(") && !afterAlt.dropFirst().isEmpty
+    }
+
     var body: some View {
+        let previewText = Self.normalizeStandaloneImageBlocks(text)
         ScrollView {
             Group {
                 if useRawTextFallback {
@@ -230,7 +262,7 @@ struct MarkdownPreviewView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else {
                     Markdown(
-                        text,
+                        previewText,
                         imageBaseURL: WorkspaceMarkdownImageProvider.imageBaseURL(markdownFilePath: markdownFilePath)
                     )
                         .markdownImageProvider(

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -711,6 +711,21 @@ struct WorkspaceMarkdownImageProviderTests {
             ) == "docs/assets/chart.png"
         )
     }
+
+    @Test func workspaceRelativePathReturnsNilForHTTPSURL() {
+        let url = URL(string: "https://upload.wikimedia.org/wikipedia/commons/0/05/Yonghe_Temple_entrance.jpg")
+        #expect(WorkspaceMarkdownImageProvider.workspaceRelativePath(from: url) == nil)
+    }
+
+    @Test func workspaceRelativePathReturnsNilForHTTPURL() {
+        let url = URL(string: "http://example.com/image.png")
+        #expect(WorkspaceMarkdownImageProvider.workspaceRelativePath(from: url) == nil)
+    }
+
+    @Test func decodeDataURLReturnsNilForHTTPSURL() {
+        let url = URL(string: "https://example.com/image.png")
+        #expect(WorkspaceMarkdownImageProvider.decodeDataURL(url) == nil)
+    }
 }
 
 // MARK: - PartStateBridge Tests

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -728,6 +728,40 @@ struct WorkspaceMarkdownImageProviderTests {
     }
 }
 
+struct MarkdownPreviewViewTests {
+
+    @Test func normalizeStandaloneImageBlocksSeparatesCaption() {
+        let markdown = """
+        ![雍和宫入口](https://example.com/yonghe.jpg)
+        *图注文字*
+        """
+
+        let normalized = MarkdownPreviewView.normalizeStandaloneImageBlocks(markdown)
+
+        #expect(normalized == """
+        ![雍和宫入口](https://example.com/yonghe.jpg)
+
+        *图注文字*
+        """)
+    }
+
+    @Test func normalizeStandaloneImageBlocksLeavesExistingBlankLine() {
+        let markdown = """
+        ![chart](assets/chart.png)
+
+        Caption
+        """
+
+        #expect(MarkdownPreviewView.normalizeStandaloneImageBlocks(markdown) == markdown)
+    }
+
+    @Test func normalizeStandaloneImageBlocksDoesNotChangeInlineImageText() {
+        let markdown = "Before ![inline](assets/icon.png) after"
+
+        #expect(MarkdownPreviewView.normalizeStandaloneImageBlocks(markdown) == markdown)
+    }
+}
+
 // MARK: - PartStateBridge Tests
 
 struct PartStateBridgeTests {

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -144,6 +144,12 @@ OPENCODE_SERVER_PASSWORD="restart_Web@" \
   - **Commit**: `5554fe9` — fix: render markdown report images on ios
   - **Commit**: `45044d4` — test: align markdown image provider data-url coverage
 
+- [x] **Markdown caption 图片块预览修复（2026-05-03）**：
+  - [x] 根因确认：`![image](url)` 后紧跟 caption 且中间没有空行时，MarkdownUI 会把图片解析为 paragraph 内的 inline image，绕过 `WorkspaceMarkdownImageProvider`，导致远程大图按原始尺寸显示且无法点击预览。
+  - [x] `MarkdownPreviewView` 渲染前将“单独一行图片 + 下一行非空文本”规范化为 image block，不改原始文件内容；真正的行内图片保持不变。
+  - [x] `WorkspaceMarkdownImageProvider` 为远程 HTTP(S) 图片增加 URLSession 直接下载路径，避免远程图片依赖 OpenCode server 的 base64 文件接口。
+  - [x] 新增 normalizer 测试与 HTTP(S) URL 路径测试；验证 `xcodebuild test` 通过。
+
 - [x] **视觉重设计 Phase 2 — Mic 按钮 + 色彩统一 + 交互修复（2026-04-01）**：
   - [x] Mic 按钮移至发送按钮上方 VStack，添加圆角描边（1.5pt brand blue）使其可识别为可点击按钮
   - [x] Brand primary 从深蓝 `(0.15, 0.25, 0.55)` 改为系统蓝 `(0.0, 0.478, 1.0)`，与 iOS accent 统一


### PR DESCRIPTION
## Summary

- Normalize single-line Markdown images before preview rendering when they are immediately followed by caption/text. This turns `![image](url)` + next-line caption into a real image block so MarkdownUI uses `WorkspaceMarkdownImageProvider` instead of the inline image path.
- Download remote HTTP(S) images directly with `URLSession` so remote images use the same `Data`-backed rendering path as local images: fit-to-screen + tap-to-preview.
- Keep true inline images unchanged.
- Update `docs/WORKING.md` with the root cause and fix.

## Root cause

MarkdownUI treats an image immediately followed by caption text (with no blank line) as an inline image inside the same paragraph. Inline images bypass `WorkspaceMarkdownImageProvider`, so high-resolution remote images render at raw size and cannot open the zoom/pan preview sheet.

## Test plan

- [x] `xcodebuild test` — all unit tests pass
- [x] Manual: original Yonghe Temple article with Wikimedia images now renders fit-to-screen and tap-to-preview after normalization
- [x] Manual: remote standalone-image test renders correctly