### PR TITLE
fix: restore SSE connection after server restart and handle stale session ID

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -763,6 +763,9 @@ final class AppState {
             let health = try await apiClient.health()
             isConnected = health.healthy
             serverVersion = health.version
+            if isConnected {
+                connectSSE()
+            }
         } catch {
             isConnected = false
             connectionError = error.localizedDescription
@@ -1331,12 +1334,30 @@ final class AppState {
     private func bootstrapSyncCurrentSession(reason: String) async {
         guard currentSessionID != nil else { return }
         let start = Date()
+
+        await validateAndRecoverCurrentSession()
+
         await loadMessages()
         await refreshPendingPermissions()
         await refreshPendingQuestions()
         await syncSessionStatusesFromPoll()
         let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
         Self.logger.debug("bootstrapSync reason=\(reason, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public) messages=\(self.messages.count, privacy: .public) permissions=\(self.pendingPermissions.count, privacy: .public)")
+    }
+
+    /// Check whether the current session still exists on the server.
+    /// If the session was deleted (e.g. server restarted), reset currentSessionID
+    /// so the next loadSessions call auto-selects a valid session.
+    private func validateAndRecoverCurrentSession() async {
+        guard let sid = currentSessionID else { return }
+        do {
+            _ = try await apiClient.messages(sessionID: sid, limit: 1)
+        } catch {
+            guard case APIError.httpError(let statusCode, _) = error, statusCode == 404 else { return }
+            Self.logger.debug("bootstrapSync: current session \(sid) not found on server, resetting")
+            currentSessionID = nil
+            await loadSessions()
+        }
     }
 
     private func syncSessionStatusesFromPoll(markMissingBusyAsIdle: Bool = true) async {


### PR DESCRIPTION
## Summary

Two fixes for SSE reconnection when the server restarts:

### 1. `testConnection()` now also re-establishes SSE

Before: tapping "Test Connection" in Settings called `state.refresh()` which checked health and reloaded data, but never called `connectSSE()`. If the SSE task's auto-reconnection loop had exited (or was still backing off), SSE was permanently dead even though HTTP API calls worked.

Fix: after `testConnection()` sets `isConnected = true`, it calls `connectSSE()` to ensure the SSE stream is active.

### 2. `bootstrapSyncCurrentSession` validates session before loading

Before: when SSE reconnected after a server restart that invalidated session IDs, `bootstrapSyncCurrentSession` called `loadMessages()` with the stale `currentSessionID`. This got 404 and triggered `recoverFromMissingCurrentSessionIfNeeded`, but the recovery couldn't update `currentSessionID` (it was non-nil, so `loadSessions`' auto-select didn't fire). Result: all subsequent SSE events (`message.part.updated`, `session.updated`, etc.) were silently filtered out by `sessionID == currentSessionID` checks.

Fix: a new `validateAndRecoverCurrentSession()` method checks the current session exists. On 404, it resets `currentSessionID` to nil, letting `loadSessions` auto-select a valid session.

## Testing

All unit tests pass (the one flaky failure `defaultSelectionUsesGPT55Preset` is a pre-existing UserDefaults test isolation issue, not related to this change).