### PR TITLE
feat: add local DeepSeek model preset

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -418,6 +418,7 @@ final class AppState {
         ModelPreset(displayName: "GLM-5.1", providerID: "zai-coding-plan", modelID: "glm-5.1"),
         ModelPreset(displayName: "GPT-5.5", providerID: "openai", modelID: "gpt-5.5"),
         ModelPreset(displayName: "DeepSeek V4 Flash", providerID: "deepseek", modelID: "deepseek-v4-flash"),
+        ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),
     ]
     var selectedModelIndex: Int = 2

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -14,6 +14,7 @@ struct ModelPreset: Codable, Identifiable {
     var shortName: String {
         switch displayName {
         case "DeepSeek V4 Flash": return "DS-Flash"
+        case "DeepSeek Local": return "DS-L"
         case "DeepSeek V4 Pro": return "DS-Pro"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1643,6 +1643,13 @@ struct ModelPresetShortNameTests {
 }
 
 struct ModelSelectionPersistenceTests {
+    /// Clear UserDefaults keys that persist session/model state between tests.
+    /// Without cleanup, parallel Swift Testing execution can leak state across tests.
+    init() {
+        UserDefaults.standard.removeObject(forKey: "currentSessionID")
+        UserDefaults.standard.removeObject(forKey: "selectedModelBySession")
+    }
+
     @Test @MainActor func legacyGLM51SelectionMapsToCurrentTurboPreset() {
         let sessionID = "session-glm"
         let defaultsKey = "selectedModelBySession"
@@ -1718,12 +1725,12 @@ struct ModelSelectionPersistenceTests {
         #expect(state.modelPresets[state.selectedModelIndex].id == "openai/gpt-5.5")
     }
 
-    @Test @MainActor func defaultSelectionUsesGPT55Preset() {
+    @Test @MainActor func defaultSelectionUsesDeepSeekV4Flash() {
         let state = AppState()
 
-        #expect(state.selectedModelIndex == 1)
-        #expect(state.modelPresets[state.selectedModelIndex].displayName == "GPT-5.5")
-        #expect(state.modelPresets[state.selectedModelIndex].id == "openai/gpt-5.5")
+        #expect(state.selectedModelIndex == 2)
+        #expect(state.modelPresets[state.selectedModelIndex].displayName == "DeepSeek V4 Flash")
+        #expect(state.modelPresets[state.selectedModelIndex].id == "deepseek/deepseek-v4-flash")
     }
 }
 

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1647,103 +1647,109 @@ struct ModelPresetShortNameTests {
     }
 }
 
+@Suite(.serialized)
 struct ModelSelectionPersistenceTests {
-    /// Clear UserDefaults keys that persist session/model state between tests.
-    /// Without cleanup, parallel Swift Testing execution can leak state across tests.
-    init() {
-        UserDefaults.standard.removeObject(forKey: "currentSessionID")
-        UserDefaults.standard.removeObject(forKey: "selectedModelBySession")
+    private let selectedModelDefaultsKey = "selectedModelBySession"
+    private let currentSessionDefaultsKey = "currentSessionID"
+
+    private func withIsolatedModelSelectionDefaults(_ body: () -> Void) {
+        let originalModelData = UserDefaults.standard.data(forKey: selectedModelDefaultsKey)
+        let originalSessionID = UserDefaults.standard.string(forKey: currentSessionDefaultsKey)
+
+        UserDefaults.standard.removeObject(forKey: selectedModelDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: currentSessionDefaultsKey)
+        defer {
+            if let originalModelData {
+                UserDefaults.standard.set(originalModelData, forKey: selectedModelDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedModelDefaultsKey)
+            }
+
+            if let originalSessionID {
+                UserDefaults.standard.set(originalSessionID, forKey: currentSessionDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: currentSessionDefaultsKey)
+            }
+        }
+
+        body()
     }
 
     @Test @MainActor func legacyGLM51SelectionMapsToCurrentTurboPreset() {
-        let sessionID = "session-glm"
-        let defaultsKey = "selectedModelBySession"
-        let legacySelection = [sessionID: "zai-coding-plan/glm-5.1"]
-        let originalData = UserDefaults.standard.data(forKey: defaultsKey)
+        withIsolatedModelSelectionDefaults {
+            let sessionID = "session-glm"
+            let legacySelection = [sessionID: "zai-coding-plan/glm-5.1"]
+            let encoded = try! JSONEncoder().encode(legacySelection)
+            UserDefaults.standard.set(encoded, forKey: selectedModelDefaultsKey)
 
-        defer {
-            if let originalData {
-                UserDefaults.standard.set(originalData, forKey: defaultsKey)
-            } else {
-                UserDefaults.standard.removeObject(forKey: defaultsKey)
-            }
+            let state = AppState()
+            let session = Session(
+                id: sessionID,
+                slug: sessionID,
+                projectID: "p1",
+                directory: "/tmp",
+                parentID: nil,
+                title: sessionID,
+                version: "1",
+                time: .init(created: 0, updated: 100, archived: nil),
+                share: nil,
+                summary: nil
+            )
+
+            state.selectSession(session)
+
+            #expect(state.selectedModelIndex == 0)
+            #expect(state.modelPresets[state.selectedModelIndex].displayName == "GLM-5.1")
         }
-
-        let encoded = try! JSONEncoder().encode(legacySelection)
-        UserDefaults.standard.set(encoded, forKey: defaultsKey)
-
-        let state = AppState()
-        let session = Session(
-            id: sessionID,
-            slug: sessionID,
-            projectID: "p1",
-            directory: "/tmp",
-            parentID: nil,
-            title: sessionID,
-            version: "1",
-            time: .init(created: 0, updated: 100, archived: nil),
-            share: nil,
-            summary: nil
-        )
-
-        state.selectSession(session)
-
-        #expect(state.selectedModelIndex == 0)
-        #expect(state.modelPresets[state.selectedModelIndex].displayName == "GLM-5.1")
     }
 
     @Test @MainActor func legacyGPT54SelectionMapsToCurrentGPT55Preset() {
-        let sessionID = "session-gpt"
-        let defaultsKey = "selectedModelBySession"
-        let legacySelection = [sessionID: "openai/gpt-5.4"]
-        let originalData = UserDefaults.standard.data(forKey: defaultsKey)
+        withIsolatedModelSelectionDefaults {
+            let sessionID = "session-gpt"
+            let legacySelection = [sessionID: "openai/gpt-5.4"]
+            let encoded = try! JSONEncoder().encode(legacySelection)
+            UserDefaults.standard.set(encoded, forKey: selectedModelDefaultsKey)
 
-        defer {
-            if let originalData {
-                UserDefaults.standard.set(originalData, forKey: defaultsKey)
-            } else {
-                UserDefaults.standard.removeObject(forKey: defaultsKey)
-            }
+            let state = AppState()
+            let session = Session(
+                id: sessionID,
+                slug: sessionID,
+                projectID: "p1",
+                directory: "/tmp",
+                parentID: nil,
+                title: sessionID,
+                version: "1",
+                time: .init(created: 0, updated: 100, archived: nil),
+                share: nil,
+                summary: nil
+            )
+
+            state.selectSession(session)
+
+            #expect(state.selectedModelIndex == 1)
+            #expect(state.modelPresets[state.selectedModelIndex].displayName == "GPT-5.5")
+            #expect(state.modelPresets[state.selectedModelIndex].id == "openai/gpt-5.5")
         }
-
-        let encoded = try! JSONEncoder().encode(legacySelection)
-        UserDefaults.standard.set(encoded, forKey: defaultsKey)
-
-        let state = AppState()
-        let session = Session(
-            id: sessionID,
-            slug: sessionID,
-            projectID: "p1",
-            directory: "/tmp",
-            parentID: nil,
-            title: sessionID,
-            version: "1",
-            time: .init(created: 0, updated: 100, archived: nil),
-            share: nil,
-            summary: nil
-        )
-
-        state.selectSession(session)
-
-        #expect(state.selectedModelIndex == 1)
-        #expect(state.modelPresets[state.selectedModelIndex].displayName == "GPT-5.5")
-        #expect(state.modelPresets[state.selectedModelIndex].id == "openai/gpt-5.5")
     }
 
     @Test @MainActor func defaultSelectionUsesDeepSeekV4Flash() {
-        let state = AppState()
+        withIsolatedModelSelectionDefaults {
+            let state = AppState()
 
-        #expect(state.selectedModelIndex == 2)
-        #expect(state.modelPresets[state.selectedModelIndex].displayName == "DeepSeek V4 Flash")
-        #expect(state.modelPresets[state.selectedModelIndex].id == "deepseek/deepseek-v4-flash")
+            #expect(state.selectedModelIndex == 2)
+            #expect(state.modelPresets[state.selectedModelIndex].displayName == "DeepSeek V4 Flash")
+            #expect(state.modelPresets[state.selectedModelIndex].id == "deepseek/deepseek-v4-flash")
+        }
     }
 
     @Test @MainActor func defaultPresetsIncludeDeepSeekLocal() {
-        let state = AppState()
+        withIsolatedModelSelectionDefaults {
+            let state = AppState()
 
-        #expect(state.modelPresets.contains(where: { $0.id == "ds4/deepseek-v4-flash" }))
-        let preset = state.modelPresets.first(where: { $0.id == "ds4/deepseek-v4-flash" })
-        #expect(preset?.displayName == "DeepSeek Local")
+            #expect(state.modelPresets.contains(where: { $0.id == "ds4/deepseek-v4-flash" }))
+            let preset = state.modelPresets.first(where: { $0.id == "ds4/deepseek-v4-flash" })
+            #expect(preset?.displayName == "DeepSeek Local")
+        }
     }
 }
 

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1625,6 +1625,11 @@ struct ModelPresetShortNameTests {
         let preset = ModelPreset(displayName: "DeepSeek", providerID: "deepseek", modelID: "deepseek-v4-flash")
         #expect(preset.shortName == "DeepSeek")
     }
+
+    @Test func deepseekLocalShortName() {
+        let preset = ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash")
+        #expect(preset.shortName == "DS-L")
+    }
     
     @Test func geminiShortName() {
         let preset = ModelPreset(displayName: "Gemini 3.1 Pro", providerID: "google", modelID: "gemini-3.1-pro")
@@ -1731,6 +1736,14 @@ struct ModelSelectionPersistenceTests {
         #expect(state.selectedModelIndex == 2)
         #expect(state.modelPresets[state.selectedModelIndex].displayName == "DeepSeek V4 Flash")
         #expect(state.modelPresets[state.selectedModelIndex].id == "deepseek/deepseek-v4-flash")
+    }
+
+    @Test @MainActor func defaultPresetsIncludeDeepSeekLocal() {
+        let state = AppState()
+
+        #expect(state.modelPresets.contains(where: { $0.id == "ds4/deepseek-v4-flash" }))
+        let preset = state.modelPresets.first(where: { $0.id == "ds4/deepseek-v4-flash" })
+        #expect(preset?.displayName == "DeepSeek Local")
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a DeepSeek Local model preset that routes to the local `ds4/deepseek-v4-flash` OpenCode provider.
- Show the local preset as `DS-L` in the compact model selector.
- Cover the new short name and default preset registration with Swift tests.

## Validation
- `xcodebuild build -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' CODE_SIGNING_ALLOWED=NO`

## Notes
- Default selection remains the official `deepseek/deepseek-v4-flash` preset at index 2.