### PR TITLE
fix: relax Markdown preview long-line fallback

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
@@ -93,7 +93,7 @@ struct FileContentView: View {
     }
 
     /// MarkdownUI crashes/freezes on long lines or large content. Skip it entirely for problematic files.
-    private static let markdownMaxLineLength = 1500
+    private static let markdownMaxLineLength = 5000
     private static let markdownMaxTotalLength = 60_000
 
     private func useRawTextForMarkdown(_ text: String) -> Bool {
@@ -211,7 +211,7 @@ struct MarkdownPreviewView: View {
     let markdownFilePath: String?
     let workspaceDirectory: String?
 
-    private static let maxLineLength = 1500
+    private static let maxLineLength = 5000
     private static let maxTotalLength = 60_000
 
     private var useRawTextFallback: Bool {


### PR DESCRIPTION
## Summary
- Raise the Markdown preview long-line fallback threshold from 1,500 to 5,000 characters.
- Keeps more Markdown files on the rich preview path while preserving the large-content fallback guard.

## Validation
- `xcodebuild build -project \"OpenCodeClient.xcodeproj\" -scheme \"OpenCodeClient\" -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`