### PR TITLE
fix: resolve Markdown preview images relative to file

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -1180,17 +1180,12 @@ final class AppState {
 
     func loadFileContent(path: String) async throws -> FileContent {
         let resolved = PathNormalizer.resolveWorkspaceRelativePath(path, workspaceDirectory: currentSession?.directory)
-        let fc = try await apiClient.fileContent(path: resolved)
-        if fc.type == "text" {
-            let text = fc.content ?? ""
-            if text.isEmpty {
-                let base = Self.serverURLInfo(serverURL).normalized ?? "nil"
-                Self.logger.warning(
-                    "Empty file content. base=\(base, privacy: .public) raw=\(path, privacy: .public) resolved=\(resolved, privacy: .public) session=\(self.currentSessionID ?? "nil", privacy: .public)"
-                )
-            }
-        }
-        return fc
+        return try await apiClient.fileContent(path: resolved)
+    }
+
+    func loadFileContent(pathBytes: [UInt8]) async throws -> FileContent {
+        let path = String(decoding: pathBytes, as: UTF8.self)
+        return try await loadFileContent(path: path)
     }
 
     func transcribeAudio(audioFileURL: URL, language: String? = nil, onPartialTranscript: (@Sendable (String) -> Void)? = nil) async throws -> String {
@@ -1445,7 +1440,9 @@ final class AppState {
         guard isConnected else { return }
         do {
             pendingQuestions = try await apiClient.pendingQuestions()
-        } catch {}
+        } catch {
+            connectionError = error.localizedDescription
+        }
     }
 
     func connectSSE() {

--- a/OpenCodeClient/OpenCodeClient/Utils/MarkdownImageResolver.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/MarkdownImageResolver.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum MarkdownImageResolver {
+    private static let maxResolvedImageCharacters = 80_000_000
+    private static let maxResolvedMarkdownCharacters = 80_000_000
     
     /// Image extensions that should be fetched as binary content
     private static let imageExtensions: Set<String> = [
@@ -34,6 +36,8 @@ enum MarkdownImageResolver {
         var result = text
         // Process matches in reverse order to maintain correct string indices
         for match in matches.reversed() {
+            if Task.isCancelled { return text }
+
             guard let altRange = Range(match.range(at: 1), in: text),
                   let urlRange = Range(match.range(at: 2), in: text) else { continue }
             
@@ -49,12 +53,9 @@ enum MarkdownImageResolver {
             
             // Resolve relative path
             var resolvedPath = rawUrl
-            if rawUrl.hasPrefix("./") || rawUrl.hasPrefix("../") {
-                // Relative to the markdown file
-                if let mdPath = markdownFilePath {
-                    let mdDir = (mdPath as NSString).deletingLastPathComponent
-                    resolvedPath = (mdDir as NSString).appendingPathComponent(rawUrl)
-                }
+            if let mdPath = markdownFilePath, !rawUrl.hasPrefix("/") {
+                let mdDir = (mdPath as NSString).deletingLastPathComponent
+                resolvedPath = (mdDir as NSString).appendingPathComponent(rawUrl)
             }
             
             // Make workspace-relative
@@ -72,19 +73,35 @@ enum MarkdownImageResolver {
                     .replacingOccurrences(of: "\n", with: "")
                     .replacingOccurrences(of: "\r", with: "")
                     .replacingOccurrences(of: " ", with: "")
-                
-                let mimeType = "image/\(ext == "jpg" ? "jpeg" : ext)"
+
+                guard cleaned.count <= maxResolvedImageCharacters else { continue }
+
+                let mimeType = mimeType(for: ext)
                 let dataUri = "data:\(mimeType);base64,\(cleaned)"
                 
                 let replacement = "![\(alt)](\(dataUri))"
                 guard let matchRange = Range(match.range, in: result) else { continue }
+                let nextCount = result.count - result[matchRange].count + replacement.count
+                guard nextCount <= maxResolvedMarkdownCharacters else { continue }
                 result.replaceSubrange(matchRange, with: replacement)
+            } catch is CancellationError {
+                return text
             } catch {
-                // Fetch failed, leave original URL
                 continue
             }
         }
         
         return result
+    }
+
+    private static func mimeType(for fileExtension: String) -> String {
+        switch fileExtension {
+        case "jpg", "jpeg":
+            return "image/jpeg"
+        case "svg":
+            return "image/svg+xml"
+        default:
+            return "image/\(fileExtension)"
+        }
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Utils/PathNormalizer.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/PathNormalizer.swift
@@ -10,7 +10,7 @@ enum PathNormalizer {
 
     /// 规范化文件路径：去除 a/b 前缀、# 及后缀、:line:col 后缀
     static func normalize(_ path: String) -> String {
-        var s = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        var s = trimPathWhitespace(path)
 
         // Some tool payloads contain percent-encoded paths (sometimes double-encoded).
         // Decode a few times until stable so `src%2Fapp.swift` -> `src/app.swift`.
@@ -34,9 +34,7 @@ enum PathNormalizer {
         if let hash = s.firstIndex(of: "#") {
             s = String(s[..<hash])
         }
-        if let r = s.range(of: ":[0-9]+(:[0-9]+)?$", options: .regularExpression) {
-            s = String(s[..<r.lowerBound])
-        }
+        s = stripLineColumnSuffix(s)
 
         var normalizedSegments: [Substring] = []
         for segment in s.split(separator: "/", omittingEmptySubsequences: true) {
@@ -55,17 +53,65 @@ enum PathNormalizer {
         return s
     }
 
+    private static func trimPathWhitespace(_ path: String) -> String {
+        let scalars = path.unicodeScalars
+        var start = scalars.startIndex
+        var end = scalars.endIndex
+
+        while start < end, isPathWhitespace(scalars[start]) {
+            start = scalars.index(after: start)
+        }
+        while start < end {
+            let beforeEnd = scalars.index(before: end)
+            guard isPathWhitespace(scalars[beforeEnd]) else { break }
+            end = beforeEnd
+        }
+
+        return String(scalars[start..<end])
+    }
+
+    private static func isPathWhitespace(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x20:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func stripLineColumnSuffix(_ path: String) -> String {
+        guard let lastColon = path.lastIndex(of: ":") else { return path }
+        let lastValue = path[path.index(after: lastColon)...]
+        guard !lastValue.isEmpty, lastValue.allSatisfy(\.isNumber) else { return path }
+
+        let beforeLastColon = path[..<lastColon]
+        let lastSlash = path.lastIndex(of: "/")
+        if let previousColon = beforeLastColon.lastIndex(of: ":"), previousColon > (lastSlash ?? path.startIndex) {
+            let lineValue = path[path.index(after: previousColon)..<lastColon]
+            if !lineValue.isEmpty, lineValue.allSatisfy(\.isNumber) {
+                return String(path[..<previousColon])
+            }
+        }
+
+        return String(path[..<lastColon])
+    }
+
     /// Resolve an absolute/host path to workspace-relative when possible.
     ///
     /// Tool payloads sometimes carry absolute paths (e.g. "/Users/.../repo/file.swift").
     /// OpenCode server APIs generally expect workspace-relative paths.
     static func resolveWorkspaceRelativePath(_ path: String, workspaceDirectory: String?) -> String {
         let p = normalize(path)
-        guard let workspaceDirectory, !workspaceDirectory.isEmpty else { return p }
+        guard let workspaceDirectory, !workspaceDirectory.isEmpty else {
+            return p
+        }
         let dir = normalize(workspaceDirectory)
-        if p == dir { return "" }
+        if p == dir {
+            return ""
+        }
         if p.hasPrefix(dir + "/") {
-            return String(p.dropFirst(dir.count + 1))
+            let resolved = String(p.dropFirst(dir.count + 1))
+            return resolved
         }
         return p
     }

--- a/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/WorkspaceMarkdownImageProvider.swift
@@ -4,15 +4,19 @@ import NetworkImage
 import SwiftUI
 
 struct WorkspaceMarkdownImageProvider: ImageProvider {
-    let loadFileContent: @Sendable (String) async throws -> FileContent
+    static let maxBase64ImageCharacters = 80_000_000
+
+    let loadFileContent: @Sendable ([UInt8]) async throws -> FileContent
     let workspaceDirectory: String?
 
     func makeImage(url: URL?) -> some View {
-        WorkspaceMarkdownImageView(url: url, loadFileContent: loadFileContent, workspaceDirectory: workspaceDirectory)
+        return WorkspaceMarkdownImageView(url: url, loadFileContent: loadFileContent, workspaceDirectory: workspaceDirectory)
     }
 
     static func imageBaseURL(markdownFilePath: String?) -> URL? {
-        guard let markdownFilePath, !markdownFilePath.isEmpty else { return nil }
+        guard let markdownFilePath, !markdownFilePath.isEmpty else {
+            return nil
+        }
         let dir = PathNormalizer.normalize((markdownFilePath as NSString).deletingLastPathComponent)
         var components = URLComponents()
         components.scheme = "opencode-workspace"
@@ -21,7 +25,8 @@ struct WorkspaceMarkdownImageProvider: ImageProvider {
         if !components.path.hasSuffix("/") {
             components.path += "/"
         }
-        return components.url
+        let url = components.url
+        return url
     }
 
     static func workspaceRelativePath(from url: URL?, workspaceDirectory: String? = nil) -> String? {
@@ -39,7 +44,12 @@ struct WorkspaceMarkdownImageProvider: ImageProvider {
     }
 
     static func decodeBase64ImageData(_ raw: String?) -> Data? {
-        guard let raw, !raw.isEmpty else { return nil }
+        guard let raw, !raw.isEmpty else {
+            return nil
+        }
+        guard raw.count <= maxBase64ImageCharacters else {
+            return nil
+        }
         if let data = Data(base64Encoded: raw), UIImage(data: data) != nil {
             return data
         }
@@ -47,16 +57,25 @@ struct WorkspaceMarkdownImageProvider: ImageProvider {
             .replacingOccurrences(of: "\n", with: "")
             .replacingOccurrences(of: "\r", with: "")
             .replacingOccurrences(of: " ", with: "")
-        guard let data = Data(base64Encoded: cleaned), UIImage(data: data) != nil else { return nil }
+        guard cleaned.count <= maxBase64ImageCharacters else {
+            return nil
+        }
+        guard let data = Data(base64Encoded: cleaned), UIImage(data: data) != nil else {
+            return nil
+        }
         return data
     }
 
     static func decodeDataURL(_ url: URL?) -> Data? {
         guard let raw = url?.absoluteString, raw.hasPrefix("data:") else { return nil }
-        guard let comma = raw.firstIndex(of: ",") else { return nil }
+        guard let comma = raw.firstIndex(of: ",") else {
+            return nil
+        }
         let metadata = raw[..<comma]
         let payload = String(raw[raw.index(after: comma)...])
-        guard metadata.contains(";base64") else { return nil }
+        guard metadata.contains(";base64") else {
+            return nil
+        }
         return decodeBase64ImageData(payload.removingPercentEncoding ?? payload)
     }
 }
@@ -111,12 +130,12 @@ struct MarkdownImagePreviewWindow: View {
 
 private struct WorkspaceMarkdownImageView: View {
     let url: URL?
-    let loadFileContent: @Sendable (String) async throws -> FileContent
+    let loadFileContent: @Sendable ([UInt8]) async throws -> FileContent
     let workspaceDirectory: String?
 
     init(
         url: URL?,
-        loadFileContent: @escaping @Sendable (String) async throws -> FileContent,
+        loadFileContent: @escaping @Sendable ([UInt8]) async throws -> FileContent,
         workspaceDirectory: String?
     ) {
         self.url = url
@@ -154,7 +173,6 @@ private struct WorkspaceMarkdownImageView: View {
                     .aspectRatio(contentMode: .fit)
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        print("[WorkspaceMarkdownImageProvider] tapped image name=\(imageDisplayName)")
                         #if os(visionOS)
                         if let imageData {
                             openWindow(value: MarkdownImagePreviewItem(title: imageDisplayName, imageData: imageData))
@@ -201,30 +219,37 @@ private struct WorkspaceMarkdownImageView: View {
             }
         }
         .task(id: url?.absoluteString) {
-            guard !didAttemptLoad else { return }
+            guard !didAttemptLoad else {
+                return
+            }
             didAttemptLoad = true
 
-            // 1. Data URI (base64 inline)
             if let data = WorkspaceMarkdownImageProvider.decodeDataURL(url) {
                 imageData = data
                 return
             }
 
-            // 2. Workspace-relative file (via OpenCode server API)
             if let path = WorkspaceMarkdownImageProvider.workspaceRelativePath(from: url, workspaceDirectory: workspaceDirectory) {
-                if let content = try? await loadFileContent(path),
-                   let data = WorkspaceMarkdownImageProvider.decodeBase64ImageData(content.content) {
-                    imageData = data
+                let pathBytes = Array(path.utf8)
+                do {
+                    let content = try await loadFileContent(pathBytes)
+                    let contentChars = content.content?.count ?? 0
+                    if contentChars > WorkspaceMarkdownImageProvider.maxBase64ImageCharacters {
+                        return
+                    }
+                    if let data = WorkspaceMarkdownImageProvider.decodeBase64ImageData(content.content) {
+                        imageData = data
+                    }
+                } catch is CancellationError {
+                    return
+                } catch {
+                    return
                 }
                 return
             }
 
-            // 3. Remote URL (download directly via URLSession, bypass server base64)
-            if let url, let scheme = url.scheme, (scheme == "http" || scheme == "https") {
-                if let (data, _) = try? await URLSession.shared.data(from: url),
-                   UIImage(data: data) != nil {
-                    imageData = data
-                }
+            if let scheme = url?.scheme, scheme == "http" || scheme == "https" {
+                return
             }
         }
     }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -91,16 +91,20 @@ struct MessageRowView: View {
             Markdown(resolvedText ?? text)
                 .markdownImageProvider(
                     WorkspaceMarkdownImageProvider(
-                        loadFileContent: { path in try await state.loadFileContent(path: path) },
+                        loadFileContent: { pathBytes in try await state.loadFileContent(pathBytes: pathBytes) },
                         workspaceDirectory: workspaceDirectory
                     )
                 )
-                .task {
-                    resolvedText = await MarkdownImageResolver.resolveImages(
-                        in: text,
+                .task(id: text) {
+                    resolvedText = nil
+                    let sourceText = text
+                    let resolved = await MarkdownImageResolver.resolveImages(
+                        in: sourceText,
                         workspaceDirectory: workspaceDirectory,
                         fetchContent: { path in try await state.loadFileContent(path: path) }
                     )
+                    guard !Task.isCancelled, sourceText == text else { return }
+                    resolvedText = resolved
             }
         }
     }

--- a/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
@@ -97,10 +97,8 @@ struct FileContentView: View {
     private static let markdownMaxTotalLength = 60_000
 
     private func useRawTextForMarkdown(_ text: String) -> Bool {
-        if text.count > Self.markdownMaxTotalLength { return true }
-        let maxLine = text.split(separator: "\n", omittingEmptySubsequences: false)
-            .map(\.count).max() ?? 0
-        return maxLine > Self.markdownMaxLineLength
+        let stats = MarkdownPreviewView.diagnostics(for: text)
+        return text.count > Self.markdownMaxTotalLength || stats.maxLineLength > Self.markdownMaxLineLength
     }
 
     @ViewBuilder
@@ -123,7 +121,6 @@ struct FileContentView: View {
     }
 
     private func loadContent() {
-        print("[FileContentView] loadContent: path=\(filePath)")
         isLoading = true
         loadError = nil
         imageData = nil
@@ -151,7 +148,6 @@ struct FileContentView: View {
                             loadError = "No image data"
                         }
                     } else if let text = fc.text {
-                        print("[FileContentView] loaded text: len=\(text.count) isMarkdown=\(isMarkdown)")
                         content = text
                     } else if fc.content != nil, fc.type == "binary" {
                         loadError = "Binary file"
@@ -210,15 +206,61 @@ struct MarkdownPreviewView: View {
     let state: AppState
     let markdownFilePath: String?
     let workspaceDirectory: String?
+    @State private var resolvedPreviewText: String?
 
     private static let maxLineLength = 5000
     private static let maxTotalLength = 60_000
 
+    struct Diagnostics {
+        let lineCount: Int
+        let maxLineLength: Int
+        let markdownImageCount: Int
+        let htmlImageCount: Int
+        let htmlFigureCount: Int
+        let dataURLCount: Int
+        let httpURLCount: Int
+        let firstImageReference: String?
+    }
+
+    static func diagnostics(for text: String) -> Diagnostics {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        let maxLine = lines.map(\.count).max() ?? 0
+        return Diagnostics(
+            lineCount: lines.count,
+            maxLineLength: maxLine,
+            markdownImageCount: countOccurrences(of: "![", in: text),
+            htmlImageCount: countOccurrences(of: "<img", in: text),
+            htmlFigureCount: countOccurrences(of: "<figure", in: text),
+            dataURLCount: countOccurrences(of: "data:image", in: text),
+            httpURLCount: countOccurrences(of: "http://", in: text) + countOccurrences(of: "https://", in: text),
+            firstImageReference: firstImageReference(in: text)
+        )
+    }
+
+    private static func countOccurrences(of needle: String, in text: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var searchStart = text.startIndex
+        while let range = text.range(of: needle, range: searchStart..<text.endIndex) {
+            count += 1
+            searchStart = range.upperBound
+        }
+        return count
+    }
+
+    private static func firstImageReference(in text: String) -> String? {
+        for line in text.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("![") || trimmed.hasPrefix("<img") || trimmed.hasPrefix("<figure") || trimmed.hasPrefix("<a ") {
+                return String(trimmed.prefix(240))
+            }
+        }
+        return nil
+    }
+
     private var useRawTextFallback: Bool {
-        if text.count > Self.maxTotalLength { return true }
-        let maxLine = text.split(separator: "\n", omittingEmptySubsequences: false)
-            .map(\.count).max() ?? 0
-        return maxLine > Self.maxLineLength
+        let stats = Self.diagnostics(for: text)
+        return text.count > Self.maxTotalLength || stats.maxLineLength > Self.maxLineLength
     }
 
     static func normalizeStandaloneImageBlocks(_ text: String) -> String {
@@ -254,20 +296,24 @@ struct MarkdownPreviewView: View {
 
     var body: some View {
         let previewText = Self.normalizeStandaloneImageBlocks(text)
+        let displayText = resolvedPreviewText ?? previewText
         ScrollView {
             Group {
                 if useRawTextFallback {
                     Text(text)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                } else if resolvedPreviewText == nil {
+                    ProgressView("Loading preview...")
+                        .frame(maxWidth: .infinity, alignment: .center)
                 } else {
                     Markdown(
-                        previewText,
+                        displayText,
                         imageBaseURL: WorkspaceMarkdownImageProvider.imageBaseURL(markdownFilePath: markdownFilePath)
                     )
                         .markdownImageProvider(
                             WorkspaceMarkdownImageProvider(
-                                loadFileContent: { path in try await state.loadFileContent(path: path) },
+                                loadFileContent: { pathBytes in try await state.loadFileContent(pathBytes: pathBytes) },
                                 workspaceDirectory: workspaceDirectory
                             )
                         )
@@ -276,10 +322,18 @@ struct MarkdownPreviewView: View {
             }
             .padding()
         }
-        .onAppear {
-            let fallback = useRawTextFallback
-            let imageBaseURL = WorkspaceMarkdownImageProvider.imageBaseURL(markdownFilePath: markdownFilePath)?.absoluteString ?? "nil"
-            print("[MarkdownPreviewView] onAppear len=\(text.count) useRawTextFallback=\(fallback) imageBaseURL=\(imageBaseURL)")
+        .task(id: "\(markdownFilePath ?? ""):\(previewText.hashValue)") {
+            guard !useRawTextFallback else { return }
+            resolvedPreviewText = nil
+            let sourceText = previewText
+            let resolved = await MarkdownImageResolver.resolveImages(
+                in: sourceText,
+                markdownFilePath: markdownFilePath,
+                workspaceDirectory: workspaceDirectory,
+                fetchContent: { path in try await state.loadFileContent(path: path) }
+            )
+            guard !Task.isCancelled, sourceText == Self.normalizeStandaloneImageBlocks(text) else { return }
+            resolvedPreviewText = resolved
         }
     }
 }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -730,6 +730,23 @@ struct WorkspaceMarkdownImageProviderTests {
 
 struct MarkdownPreviewViewTests {
 
+    @Test func resolveImagesUsesMarkdownFileDirectoryForBareRelativePath() async {
+        let pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+XGZ0AAAAASUVORK5CYII="
+        let markdown = "![chart](execution_model_comparison.jpg)"
+
+        let resolved = await MarkdownImageResolver.resolveImages(
+            in: markdown,
+            markdownFilePath: "contexts/survey_sessions/glm51_highspeed_api.md",
+            workspaceDirectory: "/Users/test/knowledge_working",
+            fetchContent: { path in
+                #expect(path == "contexts/survey_sessions/execution_model_comparison.jpg")
+                return FileContent(type: "text", content: pngBase64)
+            }
+        )
+
+        #expect(resolved.contains("data:image/jpeg;base64,\(pngBase64)"))
+    }
+
     @Test func normalizeStandaloneImageBlocksSeparatesCaption() {
         let markdown = """
         ![雍和宫入口](https://example.com/yonghe.jpg)


### PR DESCRIPTION
## Summary
- Normalize file content paths at the AppState boundary and add a byte-path loader for safer Markdown image handoff.
- Keep remote Markdown images on the NetworkImage path while bounding base64/data URL decoding.
- Pre-resolve local Markdown preview images relative to the Markdown file path and cover the bare relative path regression.

## Verification
- `xcodebuild -project "OpenCodeClient/OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project "OpenCodeClient/OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,id=CD7FD848-491D-4110-BF1F-FF83234694D7' CODE_SIGNING_ALLOWED=NO test`