### PR TITLE
feat: realtime AI Builder speech streaming

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -1218,6 +1218,33 @@ final class AppState {
         }
     }
 
+    func startRealtimeSpeechSession(language: String? = nil) async throws -> AIBuildersRealtimeSession {
+        let token = aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { throw AIBuildersAudioError.missingToken }
+
+        let base = aiBuilderBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prompt = aiBuilderCustomPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let terms = aiBuilderTerminology.trimmingCharacters(in: .whitespacesAndNewlines)
+        let start = ProcessInfo.processInfo.systemUptime
+        Self.logger.notice("[SpeechProfile] appState.realtime start begin")
+        do {
+            let session = try await AIBuildersAudioClient.startRealtimeSession(
+                baseURL: base,
+                token: token,
+                language: language,
+                prompt: prompt.isEmpty ? nil : prompt,
+                terms: terms.isEmpty ? nil : terms
+            )
+            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
+            Self.logger.notice("[SpeechProfile] appState.realtime start done ms=\(elapsedMs, privacy: .public)")
+            return session
+        } catch {
+            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
+            Self.logger.error("[SpeechProfile] appState.realtime start failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+
     func testAIBuilderConnection() async {
         guard !isTestingAIBuilderConnection else { return }
         isTestingAIBuilderConnection = true

--- a/OpenCodeClient/OpenCodeClient/Models/Session.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Session.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct Session: Codable, Identifiable {
+struct Session: Identifiable {
     let id: String
     let slug: String
     let projectID: String
@@ -33,6 +33,8 @@ struct Session: Codable, Identifiable {
         let files: Int
     }
 }
+
+extension Session: Codable {}
 
 struct SessionStatus: Codable {
     let type: String // "idle" | "busy" | "retry"

--- a/OpenCodeClient/OpenCodeClient/Services/AIBuildersAudioClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/AIBuildersAudioClient.swift
@@ -13,7 +13,7 @@ struct TranscriptionResponse: Codable {
     }
 }
 
-private struct RealtimeSessionResponse: Decodable {
+struct RealtimeSessionResponse: Decodable {
     let sessionID: String
     let wsURL: String
 
@@ -23,7 +23,7 @@ private struct RealtimeSessionResponse: Decodable {
     }
 }
 
-private struct RealtimeSocketEvent {
+struct RealtimeSocketEvent {
     let type: String
     let text: String?
     let code: String?
@@ -41,7 +41,7 @@ private struct RealtimeSocketEvent {
     }
 }
 
-enum AIBuildersAudioError: Error {
+enum AIBuildersAudioError: Error, Equatable {
     case invalidBaseURL
     case missingToken
     case invalidResponse
@@ -50,10 +50,144 @@ enum AIBuildersAudioError: Error {
     case websocketError(String)
 }
 
+struct RealtimeSessionPayload: Equatable {
+    let language: String?
+    let prompt: String?
+    let terms: [String]
+    let vad: Bool
+    let silenceDurationMs: Int
+
+    var jsonObject: [String: Any] {
+        var payload: [String: Any] = [
+            "vad": vad,
+            "silence_duration_ms": silenceDurationMs,
+        ]
+        if let language, !language.isEmpty {
+            payload["language"] = language
+        }
+        if let prompt, !prompt.isEmpty {
+            payload["prompt"] = prompt
+        }
+        if !terms.isEmpty {
+            payload["terms"] = terms
+        }
+        return payload
+    }
+}
+
+actor RealtimeWebSocketSender {
+    private let task: URLSessionWebSocketTask
+    private var pendingSend: Task<Void, Error>?
+
+    init(task: URLSessionWebSocketTask) {
+        self.task = task
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        let previous = pendingSend
+        let current = Task {
+            if let previous {
+                try await previous.value
+            }
+            try await task.send(message)
+        }
+        pendingSend = current
+        try await current.value
+    }
+
+    func flush() async throws {
+        try await pendingSend?.value
+    }
+}
+
+actor AIBuildersRealtimeSession {
+    let sessionID: String
+
+    private let webSocketTask: URLSessionWebSocketTask
+    private let urlSession: URLSession
+    private let sender: RealtimeWebSocketSender
+    private let logger: Logger
+    private var isCommitted = false
+    private var isClosed = false
+    private var enqueuedAudioBytes = 0
+
+    init(
+        sessionID: String,
+        webSocketTask: URLSessionWebSocketTask,
+        urlSession: URLSession,
+        logger: Logger
+    ) {
+        self.sessionID = sessionID
+        self.webSocketTask = webSocketTask
+        self.urlSession = urlSession
+        self.sender = RealtimeWebSocketSender(task: webSocketTask)
+        self.logger = logger
+    }
+
+    func sendAudioChunk(_ chunk: Data) async throws {
+        guard !chunk.isEmpty, !isCommitted, !isClosed else { return }
+        enqueuedAudioBytes += chunk.count
+        try await sender.send(.data(chunk))
+    }
+
+    func commitAndStop(onPartialTranscript: (@Sendable (String) -> Void)? = nil) async throws -> String {
+        guard !isClosed else { return "" }
+        isCommitted = true
+        try await sender.flush()
+        try await sender.send(.string(AIBuildersAudioClient.realtimeCommitMessage))
+        logger.notice("[SpeechProfile] realtime live commit sent bytes=\(self.enqueuedAudioBytes, privacy: .public)")
+
+        var finalTranscript: String?
+        var partialAccumulator = ""
+        do {
+            while true {
+                let event = try await AIBuildersAudioClient.receiveSocketEvent(task: webSocketTask)
+                switch event.type {
+                case "transcript_delta":
+                    if let delta = event.text, !delta.isEmpty {
+                        partialAccumulator += delta
+                        onPartialTranscript?(partialAccumulator)
+                    }
+                case "speech_started", "speech_stopped", "usage":
+                    continue
+                case "transcript_completed":
+                    finalTranscript = event.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+                    try await sender.send(.string(AIBuildersAudioClient.realtimeStopMessage))
+                case "session_stopped":
+                    close()
+                    return finalTranscript ?? ""
+                case "error":
+                    let message = event.message ?? event.code ?? "Unknown websocket error"
+                    throw AIBuildersAudioError.websocketError(message)
+                default:
+                    continue
+                }
+            }
+        } catch {
+            logger.error("[SpeechProfile] realtime websocket error=\(String(describing: error), privacy: .public)")
+            close()
+            throw error
+        }
+    }
+
+    func cancel() {
+        close()
+    }
+
+    private func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        webSocketTask.cancel(with: .goingAway, reason: nil)
+        urlSession.invalidateAndCancel()
+    }
+}
+
 enum AIBuildersAudioClient {
     private static let targetSampleRate: Double = 24_000
     private static let targetChannels: AVAudioChannelCount = 1
     private static let sendChunkSize = 240_000
+    static let realtimeCommitMessage = "{\"type\":\"commit\"}"
+    static let realtimeStopMessage = "{\"type\":\"stop\"}"
 
     private final class TaskMetricsCollector: NSObject, URLSessionTaskDelegate {
         private(set) var metrics: URLSessionTaskMetrics?
@@ -138,9 +272,10 @@ enum AIBuildersAudioClient {
         )
 
         let websocketURL = try realtimeWebSocketURL(baseURL: normalizedBase, relativePath: sessionResponse.wsURL)
-        logger.notice("[SpeechProfile] realtime ws_url=\(sessionResponse.wsURL, privacy: .public) resolved=\(websocketURL.absoluteString, privacy: .public)")
+        logger.notice("[SpeechProfile] realtime ws_url=\(redactedRealtimeWebSocketLogURL(websocketURL), privacy: .public)")
         let transcript = try await streamPCMOverRealtimeWebSocket(
             websocketURL: websocketURL,
+            sessionID: sessionResponse.sessionID,
             pcmAudio: pcmAudio,
             onPartialTranscript: onPartialTranscript
         )
@@ -181,6 +316,36 @@ enum AIBuildersAudioClient {
         return URL(string: normalizedBase) ?? URL(string: "https://invalid.example")!
     }
 
+    static func isLocalDevelopmentHost(_ host: String?) -> Bool {
+        guard let host else { return false }
+        if host == "localhost" || host.hasSuffix(".local") { return true }
+        let parts = host.split(separator: ".")
+        guard parts.count == 4,
+              let first = Int(parts[0]),
+              let second = Int(parts[1]) else { return false }
+        if first == 10 || first == 127 { return true }
+        if first == 192 && second == 168 { return true }
+        if first == 172 && (16...31).contains(second) { return true }
+        if first == 169 && second == 254 { return true }
+        return false
+    }
+
+    static func validateSecureRealtimeBaseURL(_ baseURL: URL) throws {
+        if baseURL.scheme == "https" { return }
+        if baseURL.scheme == "http", isLocalDevelopmentHost(baseURL.host) { return }
+        throw AIBuildersAudioError.invalidBaseURL
+    }
+
+    static func redactedRealtimeWebSocketLogURL(_ url: URL) -> String {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+            return "<invalid-websocket-url>"
+        }
+        if components.query != nil {
+            components.query = "ticket=redacted"
+        }
+        return components.url?.absoluteString ?? "<invalid-websocket-url>"
+    }
+
     /// Builds API URL by appending path to base (preserves mount path like /backend).
     /// Ensures base path ends with / so relative path appends instead of replacing (RFC 3986).
     static func buildAPIURL(base: URL, path: String) -> URL? {
@@ -196,7 +361,18 @@ enum AIBuildersAudioClient {
     }
 
     static func realtimeWebSocketURL(baseURL: URL, relativePath: String) throws -> URL {
-        guard let httpURL = URL(string: relativePath, relativeTo: baseURL)?.absoluteURL else {
+        let websocketPath: String
+        if relativePath.hasPrefix("/"),
+           let basePath = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)?.path,
+           !basePath.isEmpty,
+           basePath != "/",
+           !relativePath.hasPrefix(basePath + "/") {
+            websocketPath = basePath + relativePath
+        } else {
+            websocketPath = relativePath
+        }
+
+        guard let httpURL = URL(string: websocketPath, relativeTo: baseURL)?.absoluteURL else {
             throw AIBuildersAudioError.invalidBaseURL
         }
         var components = URLComponents(url: httpURL, resolvingAgainstBaseURL: true)
@@ -208,7 +384,79 @@ enum AIBuildersAudioClient {
         guard let websocketURL = components?.url else {
             throw AIBuildersAudioError.invalidBaseURL
         }
+        if websocketURL.scheme == "wss" { return websocketURL }
+        if websocketURL.scheme == "ws", isLocalDevelopmentHost(websocketURL.host) { return websocketURL }
+        if websocketURL.scheme == "ws" {
+            throw AIBuildersAudioError.invalidBaseURL
+        }
         return websocketURL
+    }
+
+    static func realtimeSessionPayload(
+        language: String?,
+        prompt: String?,
+        terms: String?
+    ) -> RealtimeSessionPayload {
+        let termsArray = terms?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+
+        return RealtimeSessionPayload(
+            language: language?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+            prompt: prompt?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+            terms: termsArray,
+            vad: false,
+            silenceDurationMs: 1200
+        )
+    }
+
+    static func startRealtimeSession(
+        baseURL: String,
+        token: String,
+        language: String? = nil,
+        prompt: String? = nil,
+        terms: String? = nil
+    ) async throws -> AIBuildersRealtimeSession {
+        let trimmedBase = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBase.isEmpty else { throw AIBuildersAudioError.invalidBaseURL }
+        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { throw AIBuildersAudioError.missingToken }
+
+        let normalizedBase = normalizedBaseURL(from: trimmedBase)
+        try validateSecureRealtimeBaseURL(normalizedBase)
+        let sessionResponse = try await createRealtimeSession(
+            baseURL: normalizedBase,
+            token: token,
+            language: language,
+            prompt: prompt,
+            terms: terms
+        )
+        let websocketURL = try realtimeWebSocketURL(baseURL: normalizedBase, relativePath: sessionResponse.wsURL)
+        logger.notice("[SpeechProfile] realtime live ws_url=\(redactedRealtimeWebSocketLogURL(websocketURL), privacy: .public)")
+
+        let urlSession = URLSession(configuration: .default)
+        let webSocketTask = urlSession.webSocketTask(with: websocketURL)
+        webSocketTask.resume()
+        do {
+            let readyEvent = try await receiveSocketEvent(task: webSocketTask)
+            guard readyEvent.type == "session_ready" else {
+                webSocketTask.cancel(with: .goingAway, reason: nil)
+                urlSession.invalidateAndCancel()
+                throw AIBuildersAudioError.websocketError("Expected session_ready, got \(readyEvent.type)")
+            }
+        } catch {
+            webSocketTask.cancel(with: .goingAway, reason: nil)
+            urlSession.invalidateAndCancel()
+            throw error
+        }
+
+        logger.notice("[SpeechProfile] realtime live session ready requestID=\(sessionResponse.sessionID, privacy: .public)")
+        return AIBuildersRealtimeSession(
+            sessionID: sessionResponse.sessionID,
+            webSocketTask: webSocketTask,
+            urlSession: urlSession,
+            logger: logger
+        )
     }
 
     private static func createRealtimeSession(
@@ -218,35 +466,25 @@ enum AIBuildersAudioClient {
         prompt: String?,
         terms: String?
     ) async throws -> RealtimeSessionResponse {
+        try validateSecureRealtimeBaseURL(baseURL)
         guard let url = buildAPIURL(base: baseURL, path: "/v1/audio/realtime/sessions") else {
             throw AIBuildersAudioError.invalidBaseURL
         }
         logger.notice("[SpeechProfile] realtime session POST url=\(url.absoluteString, privacy: .public)")
 
-        var payload: [String: Any] = [:]
-        if let language, !language.isEmpty {
-            payload["language"] = language
-        }
-        if let prompt, !prompt.isEmpty {
-            payload["prompt"] = prompt
+        let payload = realtimeSessionPayload(language: language, prompt: prompt, terms: terms)
+        if let prompt = payload.prompt {
             logger.notice("[SpeechProfile] realtime session payload includes prompt len=\(prompt.count, privacy: .public)")
         }
-        if let terms, !terms.isEmpty {
-            let termsArray = terms
-                .split(separator: ",")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }
-            payload["terms"] = termsArray
-            logger.notice("[SpeechProfile] realtime session payload includes terms count=\(termsArray.count, privacy: .public)")
+        if !payload.terms.isEmpty {
+            logger.notice("[SpeechProfile] realtime session payload includes terms count=\(payload.terms.count, privacy: .public)")
         }
-        payload["vad"] = false
-        payload["silence_duration_ms"] = 1200
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload.jsonObject)
 
         let metricsCollector = TaskMetricsCollector()
         let networkStart = ProcessInfo.processInfo.systemUptime
@@ -279,10 +517,11 @@ enum AIBuildersAudioClient {
 
     private static func streamPCMOverRealtimeWebSocket(
         websocketURL: URL,
+        sessionID: String,
         pcmAudio: Data,
         onPartialTranscript: (@Sendable (String) -> Void)? = nil
     ) async throws -> String {
-        logger.notice("[SpeechProfile] realtime websocket connect url=\(websocketURL.absoluteString, privacy: .public)")
+        logger.notice("[SpeechProfile] realtime websocket connect url=\(redactedRealtimeWebSocketLogURL(websocketURL), privacy: .public)")
         let session = URLSession(configuration: .default)
         let webSocketTask = session.webSocketTask(with: websocketURL)
         webSocketTask.resume()
@@ -293,37 +532,19 @@ enum AIBuildersAudioClient {
                 throw AIBuildersAudioError.websocketError("Expected session_ready, got \(readyEvent.type)")
             }
 
+            let handle = AIBuildersRealtimeSession(
+                sessionID: sessionID,
+                webSocketTask: webSocketTask,
+                urlSession: session,
+                logger: logger
+            )
+
             for start in stride(from: 0, to: pcmAudio.count, by: sendChunkSize) {
                 let end = min(start + sendChunkSize, pcmAudio.count)
                 let chunk = pcmAudio.subdata(in: start..<end)
-                try await webSocketTask.send(.data(chunk))
+                try await handle.sendAudioChunk(chunk)
             }
-            try await webSocketTask.send(.string("{\"type\":\"commit\"}"))
-
-            var finalTranscript: String?
-            var partialAccumulator = ""
-            while true {
-                let event = try await receiveSocketEvent(task: webSocketTask)
-                switch event.type {
-                case "transcript_delta":
-                    if let delta = event.text, !delta.isEmpty {
-                        partialAccumulator += delta
-                        onPartialTranscript?(partialAccumulator)
-                    }
-                case "speech_started", "speech_stopped", "usage":
-                    continue
-                case "transcript_completed":
-                    finalTranscript = event.text?.trimmingCharacters(in: .whitespacesAndNewlines)
-                    try await webSocketTask.send(.string("{\"type\":\"stop\"}"))
-                case "session_stopped":
-                    return finalTranscript ?? ""
-                case "error":
-                    let message = event.message ?? event.code ?? "Unknown websocket error"
-                    throw AIBuildersAudioError.websocketError(message)
-                default:
-                    continue
-                }
-            }
+            return try await handle.commitAndStop(onPartialTranscript: onPartialTranscript)
         } catch {
             logger.error("[SpeechProfile] realtime websocket error=\(String(describing: error), privacy: .public)")
             webSocketTask.cancel(with: .goingAway, reason: nil)
@@ -332,7 +553,7 @@ enum AIBuildersAudioClient {
         }
     }
 
-    private static func receiveSocketEvent(task: URLSessionWebSocketTask) async throws -> RealtimeSocketEvent {
+    static func receiveSocketEvent(task: URLSessionWebSocketTask) async throws -> RealtimeSocketEvent {
         let message = try await task.receive()
         switch message {
         case .data(let data):
@@ -406,5 +627,11 @@ enum AIBuildersAudioClient {
             throw AIBuildersAudioError.audioConversionFailed
         }
         return pcmData
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Services/AudioRecorder.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/AudioRecorder.swift
@@ -5,12 +5,27 @@
 
 import AVFoundation
 import Foundation
+import os
 
-final class AudioRecorder: NSObject, AVAudioRecorderDelegate {
-    private var recorder: AVAudioRecorder?
-    private(set) var currentFileURL: URL?
+final class AudioRecorder {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "OpenCodeClient",
+        category: "SpeechProfile"
+    )
 
-    var isRecording: Bool { recorder?.isRecording == true }
+    private let engine = AVAudioEngine()
+    private var converter: AVAudioConverter?
+    private var inputFormat: AVAudioFormat?
+    private let audioProcessingQueue = DispatchQueue(label: "com.grapeot.OpenCodeClient.liveAudioProcessing")
+    private let outputFormat = AVAudioFormat(
+        commonFormat: .pcmFormatInt16,
+        sampleRate: 24_000,
+        channels: 1,
+        interleaved: true
+    )!
+    private var chunkHandler: (@Sendable (Data) -> Void)?
+
+    var isRecording: Bool { engine.isRunning }
 
     func requestPermission() async -> Bool {
         #if os(iOS) || os(visionOS)
@@ -28,35 +43,91 @@ final class AudioRecorder: NSObject, AVAudioRecorderDelegate {
         #endif
     }
 
-    func start() throws {
+    func start(onPCMChunk: @escaping @Sendable (Data) -> Void) throws {
         #if os(iOS) || os(visionOS)
         let session = AVAudioSession.sharedInstance()
         try session.setCategory(.playAndRecord, mode: .measurement, options: [.defaultToSpeaker, .allowBluetooth])
         try session.setActive(true, options: [])
         #endif
 
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("opencode-recording-\(UUID().uuidString).m4a")
+        let inputNode = engine.inputNode
+        let sourceFormat = inputNode.outputFormat(forBus: 0)
+        guard sourceFormat.channelCount > 0 else {
+            throw AIBuildersAudioError.audioConversionFailed
+        }
+        guard let converter = AVAudioConverter(from: sourceFormat, to: outputFormat) else {
+            throw AIBuildersAudioError.audioConversionFailed
+        }
 
-        let settings: [String: Any] = [
-            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
-            AVSampleRateKey: 44_100,
-            AVNumberOfChannelsKey: 1,
-            AVEncoderBitRateKey: 64_000,
-        ]
+        self.inputFormat = sourceFormat
+        self.converter = converter
+        self.chunkHandler = onPCMChunk
 
-        let r = try AVAudioRecorder(url: url, settings: settings)
-        r.delegate = self
-        r.isMeteringEnabled = false
-        r.record()
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: sourceFormat) { [weak self] buffer, _ in
+            self?.audioProcessingQueue.sync {
+                self?.handleInputBuffer(buffer)
+            }
+        }
 
-        recorder = r
-        currentFileURL = url
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            self.inputFormat = nil
+            self.converter = nil
+            self.chunkHandler = nil
+            throw error
+        }
     }
 
-    func stop() -> URL? {
-        recorder?.stop()
-        recorder = nil
-        return currentFileURL
+    func stop() {
+        if inputFormat != nil {
+            engine.inputNode.removeTap(onBus: 0)
+        }
+        engine.stop()
+        audioProcessingQueue.sync {}
+        inputFormat = nil
+        converter = nil
+        chunkHandler = nil
+        #if os(iOS) || os(visionOS)
+        try? AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        #endif
+    }
+
+    private func handleInputBuffer(_ buffer: AVAudioPCMBuffer) {
+        guard let data = convertToPCM16Mono24k(buffer), !data.isEmpty else { return }
+        chunkHandler?(data)
+    }
+
+    private func convertToPCM16Mono24k(_ inputBuffer: AVAudioPCMBuffer) -> Data? {
+        guard let converter else { return nil }
+        let ratio = outputFormat.sampleRate / inputBuffer.format.sampleRate
+        let outputCapacity = max(1, AVAudioFrameCount(Double(inputBuffer.frameLength) * ratio) + 8)
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outputCapacity) else {
+            return nil
+        }
+
+        var didProvideInput = false
+        var conversionError: NSError?
+        let status = converter.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
+            if didProvideInput {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            didProvideInput = true
+            outStatus.pointee = .haveData
+            return inputBuffer
+        }
+
+        if status == .error {
+            Self.logger.error("[SpeechProfile] live audio convert failed error=\(String(describing: conversionError), privacy: .public)")
+            return nil
+        }
+        guard outputBuffer.frameLength > 0 else { return nil }
+
+        let audioBuffer = outputBuffer.audioBufferList.pointee.mBuffers
+        guard let bytes = audioBuffer.mData, audioBuffer.mDataByteSize > 0 else { return nil }
+        return Data(bytes: bytes, count: Int(audioBuffer.mDataByteSize))
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Services/AudioRecorder.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/AudioRecorder.swift
@@ -46,7 +46,7 @@ final class AudioRecorder {
     func start(onPCMChunk: @escaping @Sendable (Data) -> Void) throws {
         #if os(iOS) || os(visionOS)
         let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playAndRecord, mode: .measurement, options: [.defaultToSpeaker, .allowBluetooth])
+        try session.setCategory(.playAndRecord, mode: .measurement, options: [.defaultToSpeaker, .allowBluetoothHFP])
         try session.setActive(true, options: [])
         #endif
 

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatComposerTextView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatComposerTextView.swift
@@ -91,7 +91,7 @@ struct ChatComposerTextView: UIViewRepresentable {
         func textView(
             _ textView: UITextView,
             shouldChangeTextIn range: NSRange,
-            replacementText replacementText: String
+            replacementText: String
         ) -> Bool {
             let action = ChatComposerKeyAction.action(
                 for: replacementText,

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -10,16 +10,16 @@ import UIKit
 #endif
 
 private final class SpeechPartialTranscriptBuffer: @unchecked Sendable {
-    nonisolated(unsafe) private let queue = DispatchQueue(label: "com.grapeot.OpenCodeClient.speechPartialTranscript")
+    private let queue = DispatchQueue(label: "com.grapeot.OpenCodeClient.speechPartialTranscript")
     nonisolated(unsafe) private var transcript = ""
 
-    nonisolated(unsafe) func update(_ newValue: String) {
+    nonisolated func update(_ newValue: String) {
         queue.sync {
             transcript = newValue
         }
     }
 
-    nonisolated(unsafe) func current() -> String {
+    nonisolated func current() -> String {
         queue.sync { transcript }
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -10,19 +10,44 @@ import UIKit
 #endif
 
 private final class SpeechPartialTranscriptBuffer: @unchecked Sendable {
-    private let lock = NSLock()
-    private var transcript = ""
+    nonisolated(unsafe) private let queue = DispatchQueue(label: "com.grapeot.OpenCodeClient.speechPartialTranscript")
+    nonisolated(unsafe) private var transcript = ""
 
-    func update(_ newValue: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        transcript = newValue
+    nonisolated(unsafe) func update(_ newValue: String) {
+        queue.sync {
+            transcript = newValue
+        }
     }
 
-    func current() -> String {
-        lock.lock()
-        defer { lock.unlock() }
-        return transcript
+    nonisolated(unsafe) func current() -> String {
+        queue.sync { transcript }
+    }
+}
+
+private final class SpeechAudioChunkDispatcher: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "com.grapeot.OpenCodeClient.speechChunkDispatcher")
+    private let session: AIBuildersRealtimeSession
+    private var pendingSend: Task<Void, Error>?
+
+    init(session: AIBuildersRealtimeSession) {
+        self.session = session
+    }
+
+    func enqueue(_ chunk: Data) {
+        queue.sync {
+            let previous = pendingSend
+            pendingSend = Task {
+                if let previous {
+                    try await previous.value
+                }
+                try await session.sendAudioChunk(chunk)
+            }
+        }
+    }
+
+    func flush() async throws {
+        let task = queue.sync { pendingSend }
+        try await task?.value
     }
 }
 
@@ -105,7 +130,11 @@ struct ChatTabView: View {
     @State private var showRenameAlert = false
     @State private var renameText = ""
     @State private var recorder = AudioRecorder()
+    @State private var realtimeSpeechSession: AIBuildersRealtimeSession?
+    @State private var speechChunkDispatcher: SpeechAudioChunkDispatcher?
+    @State private var recordingInputPrefix = ""
     @State private var isRecording = false
+    @State private var isStartingRecording = false
     @State private var isTranscribing = false
     @State private var speechError: String?
     @State private var pendingScrollTask: Task<Void, Never>?
@@ -571,7 +600,7 @@ struct ChatTabView: View {
                                     )
                             )
                         }
-                        .disabled(isSending || isTranscribing)
+                        .disabled(isSending || isTranscribing || isStartingRecording)
                         .buttonStyle(.plain)
 
                         Button {
@@ -732,36 +761,42 @@ struct ChatTabView: View {
     private func toggleRecording() async {
         if isRecording {
             let stopStart = ProcessInfo.processInfo.systemUptime
-            guard let url = recorder.stop() else {
-                isRecording = false
-                Self.logger.error("[SpeechProfile] recorder stop failed: missing file URL")
+            recorder.stop()
+            isRecording = false
+            Self.logger.notice("[SpeechProfile] realtime capture stopped ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - stopStart) * 1000)), privacy: .public)")
+
+            guard let session = realtimeSpeechSession else {
+                Self.logger.error("[SpeechProfile] realtime stop failed: missing session")
                 return
             }
-            isRecording = false
-            let fileBytes = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -1
-            Self.logger.notice("[SpeechProfile] recorder stopped ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - stopStart) * 1000)), privacy: .public) file=\(url.lastPathComponent, privacy: .public) bytes=\(fileBytes, privacy: .public)")
+            let dispatcher = speechChunkDispatcher
+            realtimeSpeechSession = nil
+            speechChunkDispatcher = nil
 
             isTranscribing = true
             defer { isTranscribing = false }
-            let prefix = inputText
+            let prefix = recordingInputPrefix
             let partialTranscriptBuffer = SpeechPartialTranscriptBuffer()
             let transcribeStart = ProcessInfo.processInfo.systemUptime
             do {
-                let transcript = try await state.transcribeAudio(audioFileURL: url) { partial in
+                try await dispatcher?.flush()
+                let transcript = try await session.commitAndStop { partial in
                     partialTranscriptBuffer.update(partial)
                     Task { @MainActor in
                         inputText = Self.mergedSpeechInput(prefix: prefix, transcript: partial)
                     }
                 }
                 let cleaned = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-                Self.logger.notice("[SpeechProfile] chat transcribe done ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) chars=\(cleaned.count, privacy: .public)")
+                Self.logger.notice("[SpeechProfile] chat realtime transcribe done ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) chars=\(cleaned.count, privacy: .public)")
                 inputText = Self.mergedSpeechInput(prefix: prefix, transcript: cleaned)
             } catch {
-                Self.logger.error("[SpeechProfile] chat transcribe failed ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+                await session.cancel()
+                Self.logger.error("[SpeechProfile] chat realtime transcribe failed ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) error=\(error.localizedDescription, privacy: .public)")
                 inputText = Self.speechFailureInput(prefix: prefix, lastPartialTranscript: partialTranscriptBuffer.current())
                 speechError = error.localizedDescription
             }
         } else {
+            guard !isStartingRecording else { return }
             let token = state.aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines)
             if token.isEmpty {
                 speechError = L10n.t(.chatSpeechTokenMissing)
@@ -783,13 +818,31 @@ struct ChatTabView: View {
                 speechError = L10n.t(.chatMicrophoneDenied)
                 return
             }
-            let startRecordingStart = ProcessInfo.processInfo.systemUptime
+            isStartingRecording = true
+            defer { isStartingRecording = false }
+            let startSessionStart = ProcessInfo.processInfo.systemUptime
             do {
-                try recorder.start()
+                let session = try await state.startRealtimeSpeechSession()
+                let dispatcher = SpeechAudioChunkDispatcher(session: session)
+                recordingInputPrefix = inputText
+                realtimeSpeechSession = session
+                speechChunkDispatcher = dispatcher
+                Self.logger.notice("[SpeechProfile] realtime session started ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startSessionStart) * 1000)), privacy: .public)")
+
+                let startRecordingStart = ProcessInfo.processInfo.systemUptime
+                try recorder.start { chunk in
+                    dispatcher.enqueue(chunk)
+                }
                 isRecording = true
-                Self.logger.notice("[SpeechProfile] recorder started ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startRecordingStart) * 1000)), privacy: .public)")
+                Self.logger.notice("[SpeechProfile] realtime capture started ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startRecordingStart) * 1000)), privacy: .public)")
             } catch {
-                Self.logger.error("[SpeechProfile] recorder start failed error=\(error.localizedDescription, privacy: .public)")
+                recorder.stop()
+                if let realtimeSpeechSession {
+                    await realtimeSpeechSession.cancel()
+                }
+                realtimeSpeechSession = nil
+                speechChunkDispatcher = nil
+                Self.logger.error("[SpeechProfile] realtime start failed error=\(error.localizedDescription, privacy: .public)")
                 speechError = error.localizedDescription
             }
         }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1032,7 +1032,7 @@ struct AIBuildersAudioClientTests {
             baseURL: baseURL,
             relativePath: "/v1/audio/realtime/ws?ticket=abc123"
         )
-        #expect(websocketURL.absoluteString == "wss://space.ai-builders.com/v1/audio/realtime/ws?ticket=abc123")
+        #expect(websocketURL.absoluteString == "wss://space.ai-builders.com/backend/v1/audio/realtime/ws?ticket=abc123")
     }
 
     @Test func realtimeWebSocketURLWithMountPath() throws {
@@ -1042,6 +1042,30 @@ struct AIBuildersAudioClientTests {
             relativePath: "/backend/v1/audio/realtime/ws?ticket=abc123"
         )
         #expect(websocketURL.absoluteString == "wss://space.ai-builders.com/backend/v1/audio/realtime/ws?ticket=abc123")
+    }
+
+    @Test func realtimeWebSocketURLRejectsPlaintextRemoteHost() throws {
+        let baseURL = URL(string: "http://space.ai-builders.com/backend")!
+        #expect(throws: AIBuildersAudioError.invalidBaseURL) {
+            try AIBuildersAudioClient.realtimeWebSocketURL(
+                baseURL: baseURL,
+                relativePath: "/v1/audio/realtime/ws?ticket=abc123"
+            )
+        }
+    }
+
+    @Test func realtimeWebSocketURLAllowsPlaintextLocalHost() throws {
+        let baseURL = URL(string: "http://127.0.0.1:8016/backend")!
+        let websocketURL = try AIBuildersAudioClient.realtimeWebSocketURL(
+            baseURL: baseURL,
+            relativePath: "/v1/audio/realtime/ws?ticket=abc123"
+        )
+        #expect(websocketURL.absoluteString == "ws://127.0.0.1:8016/backend/v1/audio/realtime/ws?ticket=abc123")
+    }
+
+    @Test func redactedRealtimeWebSocketLogURLRemovesTicketValue() throws {
+        let url = URL(string: "wss://space.ai-builders.com/backend/v1/audio/realtime/ws?ticket=abc123")!
+        #expect(AIBuildersAudioClient.redactedRealtimeWebSocketLogURL(url) == "wss://space.ai-builders.com/backend/v1/audio/realtime/ws?ticket=redacted")
     }
 
     @Test func buildAPIURLPreservesMountPath() throws {
@@ -1054,6 +1078,64 @@ struct AIBuildersAudioClientTests {
         let baseNoMount = URL(string: "https://space.ai-builders.com")!
         let url = AIBuildersAudioClient.buildAPIURL(base: baseNoMount, path: "/v1/audio/realtime/sessions")
         #expect(url?.absoluteString == "https://space.ai-builders.com/v1/audio/realtime/sessions")
+    }
+
+    @Test func realtimeSessionPayloadTrimsTermsAndKeepsManualCommitMode() throws {
+        let payload = AIBuildersAudioClient.realtimeSessionPayload(
+            language: " en ",
+            prompt: " Use snake_case ",
+            terms: " adhoc_jobs, , survey_sessions "
+        )
+
+        #expect(payload.language == "en")
+        #expect(payload.prompt == "Use snake_case")
+        #expect(payload.terms == ["adhoc_jobs", "survey_sessions"])
+        #expect(payload.vad == false)
+        #expect(payload.silenceDurationMs == 1200)
+
+        let json = payload.jsonObject
+        #expect(json["language"] as? String == "en")
+        #expect(json["prompt"] as? String == "Use snake_case")
+        #expect(json["terms"] as? [String] == ["adhoc_jobs", "survey_sessions"])
+        #expect(json["vad"] as? Bool == false)
+        #expect(json["silence_duration_ms"] as? Int == 1200)
+    }
+
+    @Test func realtimeSessionPayloadOmitsEmptyOptionalFields() throws {
+        let payload = AIBuildersAudioClient.realtimeSessionPayload(
+            language: "   ",
+            prompt: "",
+            terms: " , "
+        )
+
+        #expect(payload.language == nil)
+        #expect(payload.prompt == nil)
+        #expect(payload.terms.isEmpty)
+        #expect(payload.jsonObject.keys.contains("language") == false)
+        #expect(payload.jsonObject.keys.contains("prompt") == false)
+        #expect(payload.jsonObject.keys.contains("terms") == false)
+    }
+
+    @Test func realtimeControlMessagesMatchBackendProtocol() {
+        #expect(AIBuildersAudioClient.realtimeCommitMessage == "{\"type\":\"commit\"}")
+        #expect(AIBuildersAudioClient.realtimeStopMessage == "{\"type\":\"stop\"}")
+    }
+
+    @Test func realtimeSocketEventParsesTranscriptDelta() throws {
+        let data = #"{"type":"transcript_delta","text":"hello","code":"c","message":"m"}"#.data(using: .utf8)!
+        let event = try RealtimeSocketEvent(data: data)
+
+        #expect(event.type == "transcript_delta")
+        #expect(event.text == "hello")
+        #expect(event.code == "c")
+        #expect(event.message == "m")
+    }
+
+    @Test func realtimeSocketEventRejectsMissingType() throws {
+        let data = #"{"text":"hello"}"#.data(using: .utf8)!
+        #expect(throws: AIBuildersAudioError.invalidResponse) {
+            try RealtimeSocketEvent(data: data)
+        }
     }
 
     @Test func mergedSpeechInputOmitsLeadingSpaceForEmptyPrefix() {


### PR DESCRIPTION
## Summary

Replace the old batch recording workflow (`AVAudioRecorder` → local `.m4a` file → `POST /v1/audio/realtime/sessions` + WebSocket upload after recording stops) with true realtime streaming:

- **AudioRecorder**: Rewritten from `AVAudioRecorder` to `AVAudioEngine` input tap + `AVAudioConverter`, outputting PCM16 mono 24kHz chunks as they arrive
- **AIBuildersAudioClient**: New actor-based `AIBuildersRealtimeSession` for live WebSocket session lifecycle (chunk send, commit, transcript events, stop). Introduced `RealtimeWebSocketSender` for serialized ordered chunk delivery
- **ChatTabView**: Recording start → creates realtime session → dispatches PCM chunks via `SpeechAudioChunkDispatcher` → stop → flushes + commitAndStop
- **Security**: Plaintext `http/ws` restricted to local/private IP only; remote requires `https/wss`. Ticket values redacted from logs
- **Tests**: New tests for realtime URL construction, mount path preservation, security validation, payload building, socket event parsing, control message protocol
- **Housekeeping**: Fixed deprecation warning (`allowBluetooth` → `allowBluetoothHFP`), unnecessary `nonisolated(unsafe)` annotations, duplicate parameter name warning