### PR TITLE
fix: recover realtime speech streams from cached PCM

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Services/AIBuildersAudioClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/AIBuildersAudioClient.swift
@@ -48,6 +48,7 @@ enum AIBuildersAudioError: Error, Equatable {
     case httpError(statusCode: Int, body: Data)
     case audioConversionFailed
     case websocketError(String)
+    case connectionLost(String)
 }
 
 struct RealtimeSessionPayload: Equatable {
@@ -72,6 +73,145 @@ struct RealtimeSessionPayload: Equatable {
             payload["terms"] = terms
         }
         return payload
+    }
+}
+
+final class RealtimeSpeechAudioCache: @unchecked Sendable {
+    nonisolated private let queue = DispatchQueue(label: "com.grapeot.OpenCodeClient.realtimeSpeechAudioCache")
+    nonisolated let fileURL: URL
+    nonisolated(unsafe) private var byteCountValue = 0
+
+    init(directory: URL = FileManager.default.temporaryDirectory) throws {
+        fileURL = directory.appendingPathComponent("opencode-realtime-speech-\(UUID().uuidString).pcm")
+        FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+    }
+
+    nonisolated var byteCount: Int {
+        queue.sync { byteCountValue }
+    }
+
+    nonisolated func append(_ data: Data) throws {
+        guard !data.isEmpty else { return }
+        try queue.sync {
+            let handle = try FileHandle(forWritingTo: fileURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+            byteCountValue += data.count
+        }
+    }
+
+    nonisolated func readChunk(offset: Int, maxBytes: Int) throws -> Data {
+        try queue.sync {
+            guard offset < byteCountValue else { return Data() }
+            let handle = try FileHandle(forReadingFrom: fileURL)
+            defer { try? handle.close() }
+            try handle.seek(toOffset: UInt64(offset))
+            return try handle.read(upToCount: min(maxBytes, byteCountValue - offset)) ?? Data()
+        }
+    }
+
+    nonisolated func remove() {
+        queue.sync {
+            try? FileManager.default.removeItem(at: fileURL)
+            byteCountValue = 0
+        }
+    }
+}
+
+actor RealtimeSpeechStreamer {
+    private let cache: RealtimeSpeechAudioCache
+    private let makeSession: @MainActor @Sendable () async throws -> AIBuildersRealtimeSession
+    private let logger: Logger
+    private var session: AIBuildersRealtimeSession
+    private var isRecovering = false
+
+    init(
+        session: AIBuildersRealtimeSession,
+        cache: RealtimeSpeechAudioCache,
+        logger: Logger,
+        makeSession: @escaping @MainActor @Sendable () async throws -> AIBuildersRealtimeSession
+    ) {
+        self.session = session
+        self.cache = cache
+        self.logger = logger
+        self.makeSession = makeSession
+    }
+
+    func appendAudioChunk(_ chunk: Data) async {
+        do {
+            try cache.append(chunk)
+            guard !isRecovering else { return }
+            try await session.sendAudioChunk(chunk)
+        } catch {
+            await recover(reason: error)
+        }
+    }
+
+    func heartbeat() async {
+        guard !isRecovering else { return }
+        do {
+            try await session.ping()
+        } catch {
+            await recover(reason: error)
+        }
+    }
+
+    func commitAndStop(onPartialTranscript: (@Sendable (String) -> Void)? = nil) async throws -> String {
+        while isRecovering {
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        do {
+            return try await session.commitAndStop(onPartialTranscript: onPartialTranscript)
+        } catch {
+            await recover(reason: error)
+            while isRecovering {
+                try await Task.sleep(for: .milliseconds(100))
+            }
+            return try await session.commitAndStop(onPartialTranscript: onPartialTranscript)
+        }
+    }
+
+    func cancel() async {
+        await session.cancel()
+        cache.remove()
+    }
+
+    func cleanupCache() {
+        cache.remove()
+    }
+
+    private func recover(reason: Error) async {
+        guard !isRecovering else { return }
+        isRecovering = true
+        let cachedBytes = cache.byteCount
+        logger.error("[SpeechProfile] realtime recovery begin bytes=\(cachedBytes, privacy: .public) error=\(String(describing: reason), privacy: .public)")
+        await session.cancel()
+        do {
+            let replacement = try await makeSession()
+            try await replayCache(to: replacement)
+            session = replacement
+            let cachedBytes = cache.byteCount
+            logger.notice("[SpeechProfile] realtime recovery done bytes=\(cachedBytes, privacy: .public)")
+        } catch {
+            let cachedBytes = cache.byteCount
+            logger.error("[SpeechProfile] realtime recovery failed bytes=\(cachedBytes, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        }
+        isRecovering = false
+    }
+
+    private func replayCache(to targetSession: AIBuildersRealtimeSession) async throws {
+        var offset = 0
+        while true {
+            let chunk = try cache.readChunk(offset: offset, maxBytes: AIBuildersAudioClient.realtimeReplayChunkSize)
+            if chunk.isEmpty {
+                if offset >= cache.byteCount { return }
+                try await Task.sleep(for: .milliseconds(20))
+                continue
+            }
+            try await targetSession.sendAudioChunk(chunk)
+            offset += chunk.count
+        }
     }
 }
 
@@ -130,6 +270,19 @@ actor AIBuildersRealtimeSession {
         try await sender.send(.data(chunk))
     }
 
+    func ping() async throws {
+        guard !isClosed else { throw AIBuildersAudioError.connectionLost("Realtime speech connection is closed") }
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            webSocketTask.sendPing { error in
+                if let error {
+                    continuation.resume(throwing: AIBuildersAudioError.connectionLost(error.localizedDescription))
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
     func commitAndStop(onPartialTranscript: (@Sendable (String) -> Void)? = nil) async throws -> String {
         guard !isClosed else { return "" }
         isCommitted = true
@@ -186,8 +339,10 @@ enum AIBuildersAudioClient {
     private static let targetSampleRate: Double = 24_000
     private static let targetChannels: AVAudioChannelCount = 1
     private static let sendChunkSize = 240_000
+    nonisolated static let realtimeReplayChunkSize = 240_000
     static let realtimeCommitMessage = "{\"type\":\"commit\"}"
     static let realtimeStopMessage = "{\"type\":\"stop\"}"
+    nonisolated static let realtimeHeartbeatIntervalSeconds: UInt64 = 12
 
     private final class TaskMetricsCollector: NSObject, URLSessionTaskDelegate {
         private(set) var metrics: URLSessionTaskMetrics?

--- a/OpenCodeClient/OpenCodeClient/Services/AIBuildersAudioClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/AIBuildersAudioClient.swift
@@ -118,16 +118,15 @@ final class RealtimeSpeechAudioCache: @unchecked Sendable {
         }
     }
 }
-
 actor RealtimeSpeechStreamer {
     private let cache: RealtimeSpeechAudioCache
     private let makeSession: @MainActor @Sendable () async throws -> AIBuildersRealtimeSession
     private let logger: Logger
-    private var session: AIBuildersRealtimeSession
+    private var session: AIBuildersRealtimeSession?
     private var isRecovering = false
 
     init(
-        session: AIBuildersRealtimeSession,
+        session: AIBuildersRealtimeSession? = nil,
         cache: RealtimeSpeechAudioCache,
         logger: Logger,
         makeSession: @escaping @MainActor @Sendable () async throws -> AIBuildersRealtimeSession
@@ -141,15 +140,33 @@ actor RealtimeSpeechStreamer {
     func appendAudioChunk(_ chunk: Data) async {
         do {
             try cache.append(chunk)
-            guard !isRecovering else { return }
+            guard !isRecovering, let session else { return }
             try await session.sendAudioChunk(chunk)
         } catch {
             await recover(reason: error)
         }
     }
 
+    func attachSession(_ newSession: AIBuildersRealtimeSession) async {
+        guard session == nil, !isRecovering else {
+            await newSession.cancel()
+            return
+        }
+        isRecovering = true
+        do {
+            try await replayCache(to: newSession)
+            session = newSession
+            let cachedBytes = cache.byteCount
+            logger.notice("[SpeechProfile] realtime startup replay done bytes=\(cachedBytes, privacy: .public)")
+        } catch {
+            logger.error("[SpeechProfile] realtime startup replay failed error=\(String(describing: error), privacy: .public)")
+            await newSession.cancel()
+        }
+        isRecovering = false
+    }
+
     func heartbeat() async {
-        guard !isRecovering else { return }
+        guard !isRecovering, let session else { return }
         do {
             try await session.ping()
         } catch {
@@ -161,6 +178,15 @@ actor RealtimeSpeechStreamer {
         while isRecovering {
             try await Task.sleep(for: .milliseconds(100))
         }
+        if session == nil {
+            await recover(reason: AIBuildersAudioError.connectionLost("Realtime speech session was not ready before stop"))
+        }
+        while isRecovering {
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        guard let session else {
+            throw AIBuildersAudioError.connectionLost("Realtime speech session is unavailable")
+        }
         do {
             return try await session.commitAndStop(onPartialTranscript: onPartialTranscript)
         } catch {
@@ -168,12 +194,15 @@ actor RealtimeSpeechStreamer {
             while isRecovering {
                 try await Task.sleep(for: .milliseconds(100))
             }
-            return try await session.commitAndStop(onPartialTranscript: onPartialTranscript)
+            guard let recoveredSession = self.session else { throw error }
+            return try await recoveredSession.commitAndStop(onPartialTranscript: onPartialTranscript)
         }
     }
 
     func cancel() async {
-        await session.cancel()
+        if let session {
+            await session.cancel()
+        }
         cache.remove()
     }
 
@@ -186,7 +215,10 @@ actor RealtimeSpeechStreamer {
         isRecovering = true
         let cachedBytes = cache.byteCount
         logger.error("[SpeechProfile] realtime recovery begin bytes=\(cachedBytes, privacy: .public) error=\(String(describing: reason), privacy: .public)")
-        await session.cancel()
+        if let session {
+            await session.cancel()
+        }
+        session = nil
         do {
             let replacement = try await makeSession()
             try await replayCache(to: replacement)

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -24,33 +24,6 @@ private final class SpeechPartialTranscriptBuffer: @unchecked Sendable {
     }
 }
 
-private final class SpeechAudioChunkDispatcher: @unchecked Sendable {
-    private let queue = DispatchQueue(label: "com.grapeot.OpenCodeClient.speechChunkDispatcher")
-    private let session: AIBuildersRealtimeSession
-    private var pendingSend: Task<Void, Error>?
-
-    init(session: AIBuildersRealtimeSession) {
-        self.session = session
-    }
-
-    func enqueue(_ chunk: Data) {
-        queue.sync {
-            let previous = pendingSend
-            pendingSend = Task {
-                if let previous {
-                    try await previous.value
-                }
-                try await session.sendAudioChunk(chunk)
-            }
-        }
-    }
-
-    func flush() async throws {
-        let task = queue.sync { pendingSend }
-        try await task?.value
-    }
-}
-
 private enum MessageGroupItem: Identifiable {
     case user(MessageWithParts)
     case assistantMerged([MessageWithParts])
@@ -130,8 +103,8 @@ struct ChatTabView: View {
     @State private var showRenameAlert = false
     @State private var renameText = ""
     @State private var recorder = AudioRecorder()
-    @State private var realtimeSpeechSession: AIBuildersRealtimeSession?
-    @State private var speechChunkDispatcher: SpeechAudioChunkDispatcher?
+    @State private var speechStreamer: RealtimeSpeechStreamer?
+    @State private var speechHeartbeatTask: Task<Void, Never>?
     @State private var recordingInputPrefix = ""
     @State private var isRecording = false
     @State private var isStartingRecording = false
@@ -758,20 +731,37 @@ struct ChatTabView: View {
         }
     }
 
+    private func startSpeechHeartbeat(for streamer: RealtimeSpeechStreamer) {
+        speechHeartbeatTask?.cancel()
+        speechHeartbeatTask = Task {
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(AIBuildersAudioClient.realtimeHeartbeatIntervalSeconds))
+                } catch {
+                    return
+                }
+                await streamer.heartbeat()
+            }
+        }
+    }
+
+    private func stopSpeechHeartbeat() {
+        speechHeartbeatTask?.cancel()
+        speechHeartbeatTask = nil
+    }
     private func toggleRecording() async {
         if isRecording {
+            stopSpeechHeartbeat()
             let stopStart = ProcessInfo.processInfo.systemUptime
             recorder.stop()
             isRecording = false
             Self.logger.notice("[SpeechProfile] realtime capture stopped ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - stopStart) * 1000)), privacy: .public)")
 
-            guard let session = realtimeSpeechSession else {
-                Self.logger.error("[SpeechProfile] realtime stop failed: missing session")
+            guard let streamer = speechStreamer else {
+                Self.logger.error("[SpeechProfile] realtime stop failed: missing streamer")
                 return
             }
-            let dispatcher = speechChunkDispatcher
-            realtimeSpeechSession = nil
-            speechChunkDispatcher = nil
+            speechStreamer = nil
 
             isTranscribing = true
             defer { isTranscribing = false }
@@ -779,18 +769,18 @@ struct ChatTabView: View {
             let partialTranscriptBuffer = SpeechPartialTranscriptBuffer()
             let transcribeStart = ProcessInfo.processInfo.systemUptime
             do {
-                try await dispatcher?.flush()
-                let transcript = try await session.commitAndStop { partial in
+                let transcript = try await streamer.commitAndStop { partial in
                     partialTranscriptBuffer.update(partial)
                     Task { @MainActor in
                         inputText = Self.mergedSpeechInput(prefix: prefix, transcript: partial)
                     }
                 }
+                await streamer.cleanupCache()
                 let cleaned = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
                 Self.logger.notice("[SpeechProfile] chat realtime transcribe done ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) chars=\(cleaned.count, privacy: .public)")
                 inputText = Self.mergedSpeechInput(prefix: prefix, transcript: cleaned)
             } catch {
-                await session.cancel()
+                await streamer.cancel()
                 Self.logger.error("[SpeechProfile] chat realtime transcribe failed ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) error=\(error.localizedDescription, privacy: .public)")
                 inputText = Self.speechFailureInput(prefix: prefix, lastPartialTranscript: partialTranscriptBuffer.current())
                 speechError = error.localizedDescription
@@ -823,25 +813,35 @@ struct ChatTabView: View {
             let startSessionStart = ProcessInfo.processInfo.systemUptime
             do {
                 let session = try await state.startRealtimeSpeechSession()
-                let dispatcher = SpeechAudioChunkDispatcher(session: session)
+                let cache = try RealtimeSpeechAudioCache()
+                let streamer = RealtimeSpeechStreamer(
+                    session: session,
+                    cache: cache,
+                    logger: Self.logger,
+                    makeSession: { @MainActor in
+                        try await state.startRealtimeSpeechSession()
+                    }
+                )
                 recordingInputPrefix = inputText
-                realtimeSpeechSession = session
-                speechChunkDispatcher = dispatcher
+                speechStreamer = streamer
                 Self.logger.notice("[SpeechProfile] realtime session started ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startSessionStart) * 1000)), privacy: .public)")
 
                 let startRecordingStart = ProcessInfo.processInfo.systemUptime
                 try recorder.start { chunk in
-                    dispatcher.enqueue(chunk)
+                    Task {
+                        await streamer.appendAudioChunk(chunk)
+                    }
                 }
                 isRecording = true
+                startSpeechHeartbeat(for: streamer)
                 Self.logger.notice("[SpeechProfile] realtime capture started ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startRecordingStart) * 1000)), privacy: .public)")
             } catch {
                 recorder.stop()
-                if let realtimeSpeechSession {
-                    await realtimeSpeechSession.cancel()
+                stopSpeechHeartbeat()
+                if let speechStreamer {
+                    await speechStreamer.cancel()
                 }
-                realtimeSpeechSession = nil
-                speechChunkDispatcher = nil
+                speechStreamer = nil
                 Self.logger.error("[SpeechProfile] realtime start failed error=\(error.localizedDescription, privacy: .public)")
                 speechError = error.localizedDescription
             }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -809,13 +809,10 @@ struct ChatTabView: View {
                 return
             }
             isStartingRecording = true
-            defer { isStartingRecording = false }
-            let startSessionStart = ProcessInfo.processInfo.systemUptime
+            let startRecordingStart = ProcessInfo.processInfo.systemUptime
             do {
-                let session = try await state.startRealtimeSpeechSession()
                 let cache = try RealtimeSpeechAudioCache()
                 let streamer = RealtimeSpeechStreamer(
-                    session: session,
                     cache: cache,
                     logger: Self.logger,
                     makeSession: { @MainActor in
@@ -824,25 +821,36 @@ struct ChatTabView: View {
                 )
                 recordingInputPrefix = inputText
                 speechStreamer = streamer
-                Self.logger.notice("[SpeechProfile] realtime session started ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startSessionStart) * 1000)), privacy: .public)")
 
-                let startRecordingStart = ProcessInfo.processInfo.systemUptime
                 try recorder.start { chunk in
                     Task {
                         await streamer.appendAudioChunk(chunk)
                     }
                 }
                 isRecording = true
+                isStartingRecording = false
                 startSpeechHeartbeat(for: streamer)
                 Self.logger.notice("[SpeechProfile] realtime capture started ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startRecordingStart) * 1000)), privacy: .public)")
+
+                let startSessionStart = ProcessInfo.processInfo.systemUptime
+                Task { @MainActor in
+                    do {
+                        let session = try await state.startRealtimeSpeechSession()
+                        await streamer.attachSession(session)
+                        Self.logger.notice("[SpeechProfile] realtime session attached ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startSessionStart) * 1000)), privacy: .public)")
+                    } catch {
+                        Self.logger.error("[SpeechProfile] realtime deferred session start failed error=\(error.localizedDescription, privacy: .public)")
+                    }
+                }
             } catch {
                 recorder.stop()
                 stopSpeechHeartbeat()
+                isStartingRecording = false
                 if let speechStreamer {
                     await speechStreamer.cancel()
                 }
                 speechStreamer = nil
-                Self.logger.error("[SpeechProfile] realtime start failed error=\(error.localizedDescription, privacy: .public)")
+                Self.logger.error("[SpeechProfile] realtime capture start failed error=\(error.localizedDescription, privacy: .public)")
                 speechError = error.localizedDescription
             }
         }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1121,6 +1121,40 @@ struct AIBuildersAudioClientTests {
         #expect(AIBuildersAudioClient.realtimeStopMessage == "{\"type\":\"stop\"}")
     }
 
+    @Test func realtimeSpeechAudioCacheAppendsAndReadsChunks() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-cache-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cache = try RealtimeSpeechAudioCache(directory: directory)
+        defer { cache.remove() }
+
+        try cache.append(Data([1, 2, 3]))
+        try cache.append(Data([4, 5]))
+
+        #expect(cache.byteCount == 5)
+        #expect(try cache.readChunk(offset: 0, maxBytes: 4) == Data([1, 2, 3, 4]))
+        #expect(try cache.readChunk(offset: 4, maxBytes: 4) == Data([5]))
+        #expect(try cache.readChunk(offset: 5, maxBytes: 4).isEmpty)
+    }
+
+    @Test func realtimeSpeechAudioCacheRemoveDeletesBackingFile() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-cache-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cache = try RealtimeSpeechAudioCache(directory: directory)
+        try cache.append(Data([1, 2, 3]))
+        #expect(FileManager.default.fileExists(atPath: cache.fileURL.path))
+
+        cache.remove()
+
+        #expect(cache.byteCount == 0)
+        #expect(FileManager.default.fileExists(atPath: cache.fileURL.path) == false)
+    }
+
     @Test func realtimeSocketEventParsesTranscriptDelta() throws {
         let data = #"{"type":"transcript_delta","text":"hello","code":"c","message":"m"}"#.data(using: .utf8)!
         let event = try RealtimeSocketEvent(data: data)

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1155,6 +1155,22 @@ struct AIBuildersAudioClientTests {
         #expect(FileManager.default.fileExists(atPath: cache.fileURL.path) == false)
     }
 
+    @Test func realtimeSpeechAudioCacheSupportsPreSessionBuffering() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-cache-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cache = try RealtimeSpeechAudioCache(directory: directory)
+        defer { cache.remove() }
+
+        try cache.append(Data([10, 11]))
+        try cache.append(Data([12, 13, 14]))
+
+        #expect(cache.byteCount == 5)
+        #expect(try cache.readChunk(offset: 0, maxBytes: 10) == Data([10, 11, 12, 13, 14]))
+    }
+
     @Test func realtimeSocketEventParsesTranscriptDelta() throws {
         let data = #"{"type":"transcript_delta","text":"hello","code":"c","message":"m"}"#.data(using: .utf8)!
         let event = try RealtimeSocketEvent(data: data)

--- a/docs/OpenCode_iOS_Client_PRD.md
+++ b/docs/OpenCode_iOS_Client_PRD.md
@@ -226,7 +226,7 @@ OpenCode 绝大多数情况下不会请求 permission，若出现 `permission.as
 
 **草稿持久化（Draft Persistence）**：未发送的输入内容按 sessionID 保存（本地持久化），切换到其他 session 再切回时仍可恢复；发送成功后清空草稿。
 
-**语音输入（Speech Recognition）**：输入框右侧麦克风按钮。点击开始录音，再次点击停止并调用 AI Builder `/v1/audio/transcriptions` 转写，将文本追加到输入框。Token 和 Base URL 在 Settings → Speech Recognition 配置，存 Keychain，不提交到 git。
+**语音输入（Speech Recognition）**：输入框右侧麦克风按钮。点击开始录音时创建 AI Builder realtime WebSocket session，并用 `AVAudioEngine` 采集 PCM16 mono 24kHz 音频。客户端一边发送 live PCM，一边把同一份 PCM 追加写入本地临时 `.pcm` 文件。若 heartbeat 或 live send 发现 WebSocket 断开，客户端不中断录音，而是新建 session 并从本地缓存重放完整 PCM，追上当前录音后继续 live 发送；停止录音时等待恢复完成后发送 `commit` / `stop`，将 transcript 追加到输入框。Token 和 Base URL 在 Settings → Speech Recognition 配置，存 Keychain，不提交到 git。
 
 **消息队列**：当 session 处于 busy 状态时，用户发送的消息进入队列。OpenCode Server 的 `POST /session/:id/prompt_async` 在服务端已支持队列——busy 时会将消息入队，当前运行结束后自动处理。iOS 端调用 `prompt_async` 即可，无需本地维护队列。若未来 API 变更，可退化为本地队列维护。
 

--- a/docs/OpenCode_iOS_Client_RFC.md
+++ b/docs/OpenCode_iOS_Client_RFC.md
@@ -400,7 +400,7 @@ var customProjectPath: String = ""        // "Custom path" 时用户输入的路
 - **草稿**：按 sessionID 持久化未发送输入；切换 session 可恢复；发送成功后清空
 - **模型选择**：按 sessionID 记忆当前选择的模型；切换 Session 自动恢复（避免全局 model 覆盖）
 - **Agent 选择**：按 sessionID 记忆当前选择的 agent（与 model 同理）；发送消息时在 body 中携带 `agent: string` 字段
-- **语音输入**：输入框右侧麦克风按钮；录音后调用 AI Builder `POST /v1/audio/transcriptions` 转写，结果追加到输入框；Base URL 与 token 在 Settings → Speech Recognition 配置并存 Keychain
+- **语音输入**：输入框右侧麦克风按钮；开始录音时创建 AI Builder realtime WebSocket session，`AVAudioEngine` 输出 PCM16 mono 24kHz chunk；每个 chunk 同时写入本地临时 `.pcm` cache 并发送到当前 WebSocket。heartbeat / send failure 触发恢复状态机：取消坏 session，创建新 session，从 cache 文件 offset 0 顺序 replay 到当前文件末尾，之后继续 live 发送。停止录音时等待恢复完成，发送 `commit` / `stop`，将 transcript 追加到输入框；Base URL 与 token 在 Settings → Speech Recognition 配置并存 Keychain
 - **Abort**：提供按钮调用 `POST /session/:id/abort`
 - **历史加载交互**：Chat 顶部显示“下拉加载更多历史消息”提示；加载中显示“正在加载更多历史消息...”，支持中英文本地化
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -72,6 +72,7 @@ OPENCODE_SERVER_PASSWORD="restart_Web@" \
   - [x] 产品语义：长录音期间 WebSocket 断开时不中断录音，客户端用本地 PCM cache 恢复，而不是等 Stop 后才失败
   - [x] 技术方案：每个 PCM chunk 同时写入临时 `.pcm` 文件和 live WebSocket；heartbeat / send failure 触发新 session，从 cache offset 0 replay 到当前文件末尾，追上后继续 live 发送；Stop 时等待恢复完成再 commit/stop
   - [x] 约束：第一版接受每次断线都从头 replay，十分钟 PCM16 mono 24kHz 约 30MB，优先保证可靠性，性能问题后续再优化 checkpoint
+  - [x] 启动体验优化：点击麦克风后立即开始 `AVAudioEngine` 录音并写入本地 PCM cache；AI Builder session POST 在后台完成，session ready 后 replay 启动期间缓存的 PCM，避免首包网络等待导致录音按钮半透明但未采集。
 
 - [x] **Voiceflow-style 单 app target 迁移起步（2026-05-02）**：
   - [x] 对照 `adhoc_jobs/brainwave_mobile/brainwave_ios` 的 Voiceflow 配置，确认它不是独立 visionOS app target，而是主 app target 同时支持 `iphoneos iphonesimulator xros xrsimulator`，`TARGETED_DEVICE_FAMILY = "1,2,7"`，并保持同一个 bundle id

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -68,6 +68,11 @@ OPENCODE_SERVER_PASSWORD="restart_Web@" \
 
 ## 已完成（近期）
 
+- [x] **Realtime speech WebSocket recovery V2（2026-05-25）**：
+  - [x] 产品语义：长录音期间 WebSocket 断开时不中断录音，客户端用本地 PCM cache 恢复，而不是等 Stop 后才失败
+  - [x] 技术方案：每个 PCM chunk 同时写入临时 `.pcm` 文件和 live WebSocket；heartbeat / send failure 触发新 session，从 cache offset 0 replay 到当前文件末尾，追上后继续 live 发送；Stop 时等待恢复完成再 commit/stop
+  - [x] 约束：第一版接受每次断线都从头 replay，十分钟 PCM16 mono 24kHz 约 30MB，优先保证可靠性，性能问题后续再优化 checkpoint
+
 - [x] **Voiceflow-style 单 app target 迁移起步（2026-05-02）**：
   - [x] 对照 `adhoc_jobs/brainwave_mobile/brainwave_ios` 的 Voiceflow 配置，确认它不是独立 visionOS app target，而是主 app target 同时支持 `iphoneos iphonesimulator xros xrsimulator`，`TARGETED_DEVICE_FAMILY = "1,2,7"`，并保持同一个 bundle id
   - [x] 将 `OpenCodeClient` 主 target 改为支持 iPhone / iPad / Apple Vision：新增 `SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator"`、`TARGETED_DEVICE_FAMILY = "1,2,7"`、`XROS_DEPLOYMENT_TARGET = 26.0`、`SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO`


### PR DESCRIPTION
## Summary

- Add a disk-backed PCM cache for realtime speech recording so every captured chunk is preserved locally while live streaming continues.
- Add a `RealtimeSpeechStreamer` recovery state machine: heartbeat/send failure creates a fresh session, replays cached PCM from offset 0, then resumes live sending.
- Update PRD/RFC/WORKING docs and add cache coverage tests.

## Verification

- `xcodebuild -project "OpenCodeClient/OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project "OpenCodeClient/OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,id=3EB51FEF-C951-4485-AD0F-33463C66DBEB' CODE_SIGNING_ALLOWED=NO test`
- `xcodebuild -project "OpenCodeClient/OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=visionOS Simulator,name=Apple Vision Pro' CODE_SIGNING_ALLOWED=NO build`