### PR TITLE
Subscribe to session.events for mid-recording phase changes; modernize partial-transcript buffer

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -101,6 +101,7 @@ enum L10n {
         case chatSpeechTokenMissing
         case chatSpeechTesting
         case chatSpeechNotPassed
+        case chatSpeechStreamDisconnected
         case chatMicrophoneDenied
         case chatSessionStatusBusy
         case chatSessionStatusRetrying
@@ -309,6 +310,7 @@ enum L10n {
         Key.chatSpeechTokenMissing.rawValue: "Speech recognition is not configured. Set AI Builder Token in Settings → Speech Recognition and tap Test Connection.",
         Key.chatSpeechTesting.rawValue: "AI Builder connection is being tested, please wait.",
         Key.chatSpeechNotPassed.rawValue: "AI Builder connection test failed. Go to Settings → Speech Recognition, tap Test Connection, and confirm it's OK before recording.",
+        Key.chatSpeechStreamDisconnected.rawValue: "The speech connection was lost and couldn't recover. Tap stop and try again.",
         Key.chatMicrophoneDenied.rawValue: "Microphone permission denied",
         Key.chatSessionStatusBusy.rawValue: "Running",
         Key.chatSessionStatusRetrying.rawValue: "Retrying",
@@ -521,6 +523,7 @@ enum L10n {
         Key.chatSpeechTokenMissing.rawValue: "语音识别未配置：请先到 Settings -> Speech Recognition 设置 AI Builder Token，并点击 Test Connection。",
         Key.chatSpeechTesting.rawValue: "AI Builder 正在测试连接，请稍候。",
         Key.chatSpeechNotPassed.rawValue: "AI Builder 连接未通过测试：请先到 Settings -> Speech Recognition 点击 Test Connection，确认 OK 后再录音。",
+        Key.chatSpeechStreamDisconnected.rawValue: "语音连接断开且无法恢复，请按停止后重试。",
         Key.chatMicrophoneDenied.rawValue: "未授权麦克风权限",
         Key.chatSessionStatusBusy.rawValue: "运行中",
         Key.chatSessionStatusRetrying.rawValue: "重试中",

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -5,23 +5,21 @@
 
 import SwiftUI
 import os
+import os.lock
 import VoiceFlowKit
 #if canImport(UIKit)
 import UIKit
 #endif
 
-private final class SpeechPartialTranscriptBuffer: @unchecked Sendable {
-    private let queue = DispatchQueue(label: "com.grapeot.OpenCodeClient.speechPartialTranscript")
-    nonisolated(unsafe) private var transcript = ""
+private final class SpeechPartialTranscriptBuffer: Sendable {
+    private let storage = OSAllocatedUnfairLock(initialState: "")
 
-    nonisolated func update(_ newValue: String) {
-        queue.sync {
-            transcript = newValue
-        }
+    func update(_ newValue: String) {
+        storage.withLock { $0 = newValue }
     }
 
-    nonisolated func current() -> String {
-        queue.sync { transcript }
+    func current() -> String {
+        storage.withLock { $0 }
     }
 }
 
@@ -106,11 +104,13 @@ struct ChatTabView: View {
     @State private var microphone = VoiceFlowMicrophone()
     @State private var speechSession: VoiceFlowSession?
     @State private var speechHeartbeatTask: Task<Void, Never>?
+    @State private var speechEventTask: Task<Void, Never>?
     @State private var recordingInputPrefix = ""
     @State private var isRecording = false
     @State private var isStartingRecording = false
     @State private var isTranscribing = false
     @State private var speechError: String?
+    @State private var speechRecoveryActive = false
     @State private var pendingScrollTask: Task<Void, Never>?
     @State private var pendingBottomVisibilityTask: Task<Void, Never>?
     @State private var isNearBottom = true
@@ -753,9 +753,49 @@ struct ChatTabView: View {
         speechHeartbeatTask = nil
     }
 
+    /// Drain `session.events` so the UI sees phase transitions and recovery
+    /// state mid-recording. Otherwise a stream blip is invisible until the
+    /// user hits stop and `commitAndStop` either succeeds late or fails.
+    private func startSpeechEventConsumer(for session: VoiceFlowSession) {
+        speechEventTask?.cancel()
+        speechEventTask = Task {
+            let events = await session.events
+            for await event in events {
+                guard !Task.isCancelled else { return }
+                switch event {
+                case .recoveryStarted:
+                    await MainActor.run { speechRecoveryActive = true }
+                case .recoveryFailed(let message):
+                    Self.logger.error("[SpeechProfile] realtime recovery failed message=\(message, privacy: .public)")
+                    await MainActor.run {
+                        speechRecoveryActive = false
+                        speechError = L10n.t(.chatSpeechStreamDisconnected)
+                    }
+                case .phaseChanged(let phase):
+                    if phase == .connected, speechRecoveryActive {
+                        await MainActor.run { speechRecoveryActive = false }
+                    }
+                case .partialTranscript:
+                    // Mid-recording partial transcripts are intentionally
+                    // suppressed in OpenCode's chat composer — the user only
+                    // sees text after stop. (See VoiceFlow's recording flow
+                    // for the opposite UX.)
+                    continue
+                }
+            }
+        }
+    }
+
+    private func stopSpeechEventConsumer() {
+        speechEventTask?.cancel()
+        speechEventTask = nil
+        speechRecoveryActive = false
+    }
+
     private func toggleRecording() async {
         if isRecording {
             stopSpeechHeartbeat()
+            stopSpeechEventConsumer()
             let stopStart = ProcessInfo.processInfo.systemUptime
             _ = try? await microphone.stop()
             isRecording = false
@@ -817,6 +857,7 @@ struct ChatTabView: View {
                 let session = try await state.startRealtimeSpeechSession()
                 recordingInputPrefix = inputText
                 speechSession = session
+                startSpeechEventConsumer(for: session)
 
                 try await microphone.start { chunk in
                     Task {
@@ -830,6 +871,7 @@ struct ChatTabView: View {
             } catch {
                 _ = try? await microphone.stop()
                 stopSpeechHeartbeat()
+                stopSpeechEventConsumer()
                 isStartingRecording = false
                 if let speechSession {
                     await speechSession.cancel()


### PR DESCRIPTION
## Summary

Two improvements to the chat composer's VoiceFlowKit integration, based on the latest VoiceFlowKit best-practices audit.

**1. Subscribe to `session.events`.** OpenCode previously only awaited `commitAndStop` at the end. Anything that happened mid-recording — connection blip, recovery start, recovery failure — was invisible. The user would record 30 s, lose connection halfway, and only discover the truncation on stop.

Now `startSpeechEventConsumer(for:)` runs a concurrent Task draining `session.events`. We intentionally still suppress `.partialTranscript` (OpenCode's UX shows text only after stop, unlike VoiceFlow's live recorder), but `.recoveryStarted` / `.recoveryFailed` / `.phaseChanged` now drive UI state. A `recoveryFailed` event surfaces a typed error string (`chatSpeechStreamDisconnected`) instead of silently rotting the session.

**2. Modernize `SpeechPartialTranscriptBuffer`.** Drop `@unchecked Sendable` + `DispatchQueue` in favor of `OSAllocatedUnfairLock<String>`. Same semantics, no manual locking risk.

## Test plan

- [x] `xcodebuild build` passes
- [x] `xcodebuild test -only-testing:OpenCodeClientTests` — **TEST SUCCEEDED**
- [ ] Manual: record in a chat composer, simulate a network blip (toggle airplane mode), verify the typed error surfaces if recovery fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)