### PR TITLE
Split VoiceFlowKit speech integration into AppState+VoiceFlowKit.swift

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+VoiceFlowKit.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+VoiceFlowKit.swift
@@ -1,0 +1,112 @@
+import Foundation
+import os
+import VoiceFlowKit
+
+/// VoiceFlowKit speech recognition integration. Wraps the kit's
+/// `VoiceFlowClient` for OpenCode's three speech entry points:
+/// one-shot transcription of an audio file, real-time WS sessions for
+/// the chat composer's mic button, and the Settings-side connection
+/// test against the AI Builder Space token.
+///
+/// All four methods are facade-only — host (`ChatTabView` /
+/// `SettingsView`) never touches kit Internal types.
+extension AppState {
+    private func makeVoiceFlowClient() throws -> VoiceFlowClient {
+        let token = aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { throw VoiceFlowError.missingToken }
+        let base = aiBuilderBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let endpointString = base.isEmpty ? VoiceFlowConfig.defaultEndpoint.absoluteString : base
+        let normalized = endpointString.hasPrefix("http://") || endpointString.hasPrefix("https://")
+            ? endpointString
+            : "https://\(endpointString)"
+        guard let endpoint = URL(string: normalized) else {
+            throw VoiceFlowError.invalidEndpoint
+        }
+        let promptText = aiBuilderCustomPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let terms = aiBuilderTerminology
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let config = VoiceFlowConfig(
+            endpoint: endpoint,
+            tokenProvider: { token },
+            prompt: promptText.isEmpty ? nil : promptText,
+            terms: terms
+        )
+        return VoiceFlowClient(config: config)
+    }
+
+    func transcribeAudio(audioFileURL: URL, onPartialTranscript: (@Sendable (String) -> Void)? = nil) async throws -> String {
+        let start = ProcessInfo.processInfo.systemUptime
+        let fileName = audioFileURL.lastPathComponent.isEmpty ? "audio.m4a" : audioFileURL.lastPathComponent
+        Self.logger.notice("[SpeechProfile] appState.transcribe begin file=\(fileName, privacy: .public)")
+        do {
+            let client = try makeVoiceFlowClient()
+            let result = try await client.transcribe(audioFile: audioFileURL, onPartialTranscript: onPartialTranscript)
+            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
+            Self.logger.notice("[SpeechProfile] appState.transcribe done ms=\(elapsedMs, privacy: .public) textChars=\(result.text.count, privacy: .public) requestID=\(result.requestID, privacy: .public)")
+            return result.text
+        } catch {
+            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
+            Self.logger.error("[SpeechProfile] appState.transcribe failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+
+    func startRealtimeSpeechSession() async throws -> VoiceFlowSession {
+        let start = ProcessInfo.processInfo.systemUptime
+        Self.logger.notice("[SpeechProfile] appState.realtime start begin")
+        do {
+            let client = try makeVoiceFlowClient()
+            let session = try await client.startSession()
+            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
+            Self.logger.notice("[SpeechProfile] appState.realtime start done ms=\(elapsedMs, privacy: .public)")
+            return session
+        } catch {
+            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
+            Self.logger.error("[SpeechProfile] appState.realtime start failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+
+    func testAIBuilderConnection() async {
+        guard !isTestingAIBuilderConnection else { return }
+        isTestingAIBuilderConnection = true
+        defer { isTestingAIBuilderConnection = false }
+
+        aiBuilderConnectionError = nil
+        aiBuilderConnectionOK = false
+        let token = aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            aiBuilderConnectionError = L10n.t(.errorAiBuilderTokenEmpty)
+            aiBuilderLastTestedAt = Date()
+            return
+        }
+        let base = aiBuilderBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            let client = try makeVoiceFlowClient()
+            try await client.testConnection()
+            aiBuilderConnectionOK = true
+            aiBuilderLastTestedAt = Date()
+
+            let sig = Self.aiBuilderSignature(baseURL: base, token: token)
+            UserDefaults.standard.set(sig, forKey: Self.aiBuilderLastOKSignatureKey)
+            UserDefaults.standard.set(aiBuilderLastTestedAt?.timeIntervalSince1970, forKey: Self.aiBuilderLastOKTestedAtKey)
+        } catch {
+            aiBuilderLastTestedAt = Date()
+            aiBuilderConnectionOK = false
+            UserDefaults.standard.removeObject(forKey: Self.aiBuilderLastOKSignatureKey)
+            UserDefaults.standard.removeObject(forKey: Self.aiBuilderLastOKTestedAtKey)
+            switch error {
+            case VoiceFlowError.missingToken:
+                aiBuilderConnectionError = L10n.t(.errorAiBuilderTokenEmpty)
+            case VoiceFlowError.invalidEndpoint:
+                aiBuilderConnectionError = L10n.t(.errorInvalidBaseURL)
+            case VoiceFlowError.httpError(let statusCode):
+                aiBuilderConnectionError = L10n.errorMessage(.errorServerError, String(statusCode))
+            default:
+                aiBuilderConnectionError = error.localizedDescription
+            }
+        }
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -18,7 +18,7 @@ struct SessionNode: Identifiable {
 @Observable
 @MainActor
 final class AppState {
-    private static let logger = Logger(
+    static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "OpenCodeClient",
         category: "AppState"
     )
@@ -163,8 +163,8 @@ final class AppState {
     private static let aiBuilderTokenKeychainKey = "aiBuilderToken"
     private static let aiBuilderCustomPromptKey = "aiBuilderCustomPrompt"
     private static let aiBuilderTerminologyKey = "aiBuilderTerminology"
-    private static let aiBuilderLastOKSignatureKey = "aiBuilderLastOKSignature"
-    private static let aiBuilderLastOKTestedAtKey = "aiBuilderLastOKTestedAt"
+    static let aiBuilderLastOKSignatureKey = "aiBuilderLastOKSignature"
+    static let aiBuilderLastOKTestedAtKey = "aiBuilderLastOKTestedAt"
     private static let draftInputsBySessionKey = "draftInputsBySession"
     private static let selectedModelBySessionKey = "selectedModelBySession"
     private static let showArchivedSessionsKey = "showArchivedSessions"
@@ -260,7 +260,7 @@ final class AppState {
         }
     }
 
-    private static func aiBuilderSignature(baseURL: String, token: String) -> String {
+    static func aiBuilderSignature(baseURL: String, token: String) -> String {
         let base = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let tok = token.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !base.isEmpty, !tok.isEmpty else { return "" }
@@ -1187,105 +1187,6 @@ final class AppState {
     func loadFileContent(pathBytes: [UInt8]) async throws -> FileContent {
         let path = String(decoding: pathBytes, as: UTF8.self)
         return try await loadFileContent(path: path)
-    }
-
-    private func makeVoiceFlowClient() throws -> VoiceFlowClient {
-        let token = aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !token.isEmpty else { throw VoiceFlowError.missingToken }
-        let base = aiBuilderBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        let endpointString = base.isEmpty ? VoiceFlowConfig.defaultEndpoint.absoluteString : base
-        let normalized = endpointString.hasPrefix("http://") || endpointString.hasPrefix("https://")
-            ? endpointString
-            : "https://\(endpointString)"
-        guard let endpoint = URL(string: normalized) else {
-            throw VoiceFlowError.invalidEndpoint
-        }
-        let promptText = aiBuilderCustomPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        let terms = aiBuilderTerminology
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        let config = VoiceFlowConfig(
-            endpoint: endpoint,
-            tokenProvider: { token },
-            prompt: promptText.isEmpty ? nil : promptText,
-            terms: terms
-        )
-        return VoiceFlowClient(config: config)
-    }
-
-    func transcribeAudio(audioFileURL: URL, onPartialTranscript: (@Sendable (String) -> Void)? = nil) async throws -> String {
-        let start = ProcessInfo.processInfo.systemUptime
-        let fileName = audioFileURL.lastPathComponent.isEmpty ? "audio.m4a" : audioFileURL.lastPathComponent
-        Self.logger.notice("[SpeechProfile] appState.transcribe begin file=\(fileName, privacy: .public)")
-        do {
-            let client = try makeVoiceFlowClient()
-            let result = try await client.transcribe(audioFile: audioFileURL, onPartialTranscript: onPartialTranscript)
-            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
-            Self.logger.notice("[SpeechProfile] appState.transcribe done ms=\(elapsedMs, privacy: .public) textChars=\(result.text.count, privacy: .public) requestID=\(result.requestID, privacy: .public)")
-            return result.text
-        } catch {
-            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
-            Self.logger.error("[SpeechProfile] appState.transcribe failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-            throw error
-        }
-    }
-
-    func startRealtimeSpeechSession() async throws -> VoiceFlowSession {
-        let start = ProcessInfo.processInfo.systemUptime
-        Self.logger.notice("[SpeechProfile] appState.realtime start begin")
-        do {
-            let client = try makeVoiceFlowClient()
-            let session = try await client.startSession()
-            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
-            Self.logger.notice("[SpeechProfile] appState.realtime start done ms=\(elapsedMs, privacy: .public)")
-            return session
-        } catch {
-            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
-            Self.logger.error("[SpeechProfile] appState.realtime start failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-            throw error
-        }
-    }
-
-    func testAIBuilderConnection() async {
-        guard !isTestingAIBuilderConnection else { return }
-        isTestingAIBuilderConnection = true
-        defer { isTestingAIBuilderConnection = false }
-
-        aiBuilderConnectionError = nil
-        aiBuilderConnectionOK = false
-        let token = aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !token.isEmpty else {
-            aiBuilderConnectionError = L10n.t(.errorAiBuilderTokenEmpty)
-            aiBuilderLastTestedAt = Date()
-            return
-        }
-        let base = aiBuilderBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        do {
-            let client = try makeVoiceFlowClient()
-            try await client.testConnection()
-            aiBuilderConnectionOK = true
-            aiBuilderLastTestedAt = Date()
-
-            let sig = Self.aiBuilderSignature(baseURL: base, token: token)
-            UserDefaults.standard.set(sig, forKey: Self.aiBuilderLastOKSignatureKey)
-            UserDefaults.standard.set(aiBuilderLastTestedAt?.timeIntervalSince1970, forKey: Self.aiBuilderLastOKTestedAtKey)
-        } catch {
-            aiBuilderLastTestedAt = Date()
-            aiBuilderConnectionOK = false
-            UserDefaults.standard.removeObject(forKey: Self.aiBuilderLastOKSignatureKey)
-            UserDefaults.standard.removeObject(forKey: Self.aiBuilderLastOKTestedAtKey)
-            switch error {
-            case VoiceFlowError.missingToken:
-                aiBuilderConnectionError = L10n.t(.errorAiBuilderTokenEmpty)
-            case VoiceFlowError.invalidEndpoint:
-                aiBuilderConnectionError = L10n.t(.errorInvalidBaseURL)
-            case VoiceFlowError.httpError(let statusCode):
-                aiBuilderConnectionError = L10n.errorMessage(.errorServerError, String(statusCode))
-            default:
-                aiBuilderConnectionError = error.localizedDescription
-            }
-        }
     }
 
     func toggleFileExpanded(_ path: String) {


### PR DESCRIPTION
## Summary

First slice of the OpenCode AppState split, modeled on the pattern that worked well in `grapeot/voiceflow#40`. AppState.swift drops by 97 lines; the speech integration code (`makeVoiceFlowClient` / `transcribeAudio` / `startRealtimeSpeechSession` / `testAIBuilderConnection`) moves to `AppState+VoiceFlowKit.swift`.

Demoted three `private static` AppState members to internal (default) so the extension can reach them: `logger`, `aiBuilderLastOKSignatureKey`, `aiBuilderLastOKTestedAtKey`, and `aiBuilderSignature(baseURL:token:)`. Still module-internal, no API surface change.

This is the first of several planned splits — SSE / Sessions / FileTree are larger and more interdependent, will be done in follow-ups.

## Test plan

- [x] `xcodebuild test -only-testing:OpenCodeClientTests` — TEST SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)