### PR TITLE
Clear 18 of 19 Swift 6 concurrency warnings

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Models/Message.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Message.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct Message: Codable, Identifiable {
+nonisolated struct Message: Codable, Identifiable {
     let id: String
     let sessionID: String
     let role: String
@@ -87,7 +87,7 @@ struct Message: Codable, Identifiable {
     }
 }
 
-struct MessageWithParts: Codable {
+nonisolated struct MessageWithParts: Codable {
     let info: Message
     let parts: [Part]
 }
@@ -223,7 +223,7 @@ struct PartStateBridge: Codable {
     }
 }
 
-struct Part: Codable, Identifiable {
+nonisolated struct Part: Codable, Identifiable {
     let id: String
     let messageID: String
     let sessionID: String

--- a/OpenCodeClient/OpenCodeClient/Models/Project.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Project.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct Project: Codable, Identifiable {
+nonisolated struct Project: Codable, Identifiable {
     let id: String
     let worktree: String
     let vcs: String?

--- a/OpenCodeClient/OpenCodeClient/Models/Session.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Session.swift
@@ -34,7 +34,7 @@ struct Session: Identifiable {
     }
 }
 
-extension Session: Codable {}
+nonisolated extension Session: Codable {}
 
 struct SessionStatus: Codable {
     let type: String // "idle" | "busy" | "retry"

--- a/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
@@ -410,7 +410,7 @@ struct FileNode: Codable, Identifiable {
     let ignored: Bool?
 }
 
-struct FileContent: Codable {
+nonisolated struct FileContent: Codable {
     let type: String  // "text" | "binary"
     let content: String?
     var text: String? { type == "text" ? content : nil }
@@ -473,7 +473,7 @@ struct FileDiff: Codable, Identifiable, Hashable {
 /// - `providers` may be an array (`[{id, name, models}]`) or a dictionary (`{ providerID: ProviderInfo }`)
 /// - `models` may be a dictionary (`{ modelID: ModelInfo }`) or an array (`[{id, ...}]`)
 /// - `ProviderModel.id` / `ConfigProvider.id` may be missing when encoded as dictionary values
-struct ProvidersResponse: Decodable {
+nonisolated struct ProvidersResponse: Decodable {
     let providers: [ConfigProvider]
     let `default`: DefaultProvider?
 
@@ -505,7 +505,7 @@ struct ProvidersResponse: Decodable {
     }
 }
 
-struct ConfigProvider: Decodable {
+nonisolated struct ConfigProvider: Decodable {
     let id: String
     let name: String?
     let models: [String: ProviderModel]
@@ -556,7 +556,7 @@ struct ConfigProvider: Decodable {
     }
 }
 
-struct ProviderModel: Decodable {
+nonisolated struct ProviderModel: Decodable {
     let id: String
     let name: String?
     let providerID: String?
@@ -586,18 +586,18 @@ struct ProviderModel: Decodable {
     }
 }
 
-struct ProviderModelLimit: Codable {
+nonisolated struct ProviderModelLimit: Codable {
     let context: Int?
     let input: Int?
     let output: Int?
 }
 
-struct DefaultProvider: Codable {
+nonisolated struct DefaultProvider: Codable {
     let providerID: String
     let modelID: String
 }
 
-struct HealthResponse: Codable {
+nonisolated struct HealthResponse: Codable {
     let healthy: Bool
     let version: String?
 }

--- a/OpenCodeClient/OpenCodeClient/Services/SSEClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/SSEClient.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct SSEEvent: Codable {
+nonisolated struct SSEEvent: Codable {
     let directory: String?
     let payload: SSEPayload
 }
@@ -15,7 +15,7 @@ struct SSEPayload: Codable {
     let properties: [String: AnyCodable]?
 }
 
-struct AnyCodable: Codable {
+nonisolated struct AnyCodable: Codable {
     let value: Any
 
     init(_ value: Any) {

--- a/OpenCodeClient/OpenCodeClient/Services/SSHTunnelManager.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/SSHTunnelManager.swift
@@ -449,6 +449,12 @@ private final class NIOToNWConnectionHandler: ChannelInboundHandler {
         let bytes = buffer.readBytes(length: buffer.readableBytes) ?? []
         guard !bytes.isEmpty else { return }
 
+        // NIO's `ChannelHandlerContext` isn't Sendable but is thread-confined
+        // to its event loop. We capture it here and immediately schedule
+        // `context.close` back onto that event loop, which is the correct NIO
+        // pattern. Swift 6 strict concurrency still flags the capture; the
+        // fix lives upstream in NIO. See
+        // https://forums.swift.org/t/nio-channelhandlercontext-sendable
         nwConnection.send(content: Data(bytes), completion: .contentProcessed { error in
             if let error {
                 #if DEBUG

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -214,7 +214,7 @@ enum L10n {
         case configureNoAgents
     }
 
-    private static let en: [String: String] = [
+    nonisolated private static let en: [String: String] = [
         Key.appChat.rawValue: "Chat",
         Key.appClose.rawValue: "Close",
         Key.appDone.rawValue: "Done",
@@ -424,7 +424,7 @@ enum L10n {
         Key.configureNoAgents.rawValue: "No agents available"
     ]
 
-    private static let zh: [String: String] = [
+    nonisolated private static let zh: [String: String] = [
         Key.appChat.rawValue: "Chat",
         Key.appClose.rawValue: "关闭",
         Key.appDone.rawValue: "完成",

--- a/OpenCodeClient/OpenCodeClient/Utils/PathNormalizer.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/PathNormalizer.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// 统一路径规范化：用于 API 请求、文件跳转等
-enum PathNormalizer {
+nonisolated enum PathNormalizer {
 
     /// 规范化文件路径：去除 a/b 前缀、# 及后缀、:line:col 后缀
     static func normalize(_ path: String) -> String {

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -14,11 +14,11 @@ import UIKit
 private final class SpeechPartialTranscriptBuffer: Sendable {
     private let storage = OSAllocatedUnfairLock(initialState: "")
 
-    func update(_ newValue: String) {
+    nonisolated func update(_ newValue: String) {
         storage.withLock { $0 = newValue }
     }
 
-    func current() -> String {
+    nonisolated func current() -> String {
         storage.withLock { $0 }
     }
 }


### PR DESCRIPTION
## Summary

OpenCode builds with \`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor\`, which silently pushes every type's default isolation onto the main actor — including plain data models. As a result, \`Codable\` conformances on 10 model types generated MainActor-isolated-conformance warnings when called from background JSON decoders. Same pattern hit two L10n dictionaries and \`PathNormalizer\`.

Marked each of these explicitly \`nonisolated\` — they're plain data / pure functions; MainActor isolation was never the intent.

Also marked \`SpeechPartialTranscriptBuffer.update\` / \`.current\` as \`nonisolated\` (backing storage is \`OSAllocatedUnfairLock\`, methods are inherently thread-safe).

Last remaining warning is upstream NIO: \`ChannelHandlerContext\` isn't \`Sendable\` but is thread-confined to its event loop; capturing it into a \`@Sendable\` send-completion closure is the correct NIO pattern. Added a comment so future readers don't break the SSH tunnel error-recovery path trying to "fix" it locally.

**Before:** 19 warnings
**After:** 1 warning (the NIO one) + 1 build-phase notice (\`AppIntents.framework dependency found\` — informational only, OpenCode doesn't use AppIntents).

## Test plan

- [x] \`xcodebuild test -only-testing:OpenCodeClientTests\` — TEST SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)