### PR TITLE
Fix visionOS composer button hit targets

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Utils/DesignTokens.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/DesignTokens.swift
@@ -162,7 +162,8 @@ enum DesignControls {
     #if os(visionOS)
     /// Larger chat composer action buttons for gaze interaction on Apple Vision Pro.
     static let composerActionButtonSize: CGFloat = 48
-    static let composerActionButtonSpacing: CGFloat = DesignSpacing.md
+    static let composerPrimaryActionButtonSize: CGFloat = 56
+    static let composerActionButtonSpacing: CGFloat = 18
     static let composerActionIconFont: Font = .title3
     static let composerContainerHorizontalPadding: CGFloat = 32
     static let composerContainerVerticalPadding: CGFloat = 20
@@ -173,6 +174,7 @@ enum DesignControls {
     #else
     /// Compact chat composer action buttons for iPhone and iPad.
     static let composerActionButtonSize: CGFloat = 32
+    static let composerPrimaryActionButtonSize: CGFloat = 32
     static let composerActionButtonSpacing: CGFloat = DesignSpacing.sm
     static let composerActionIconFont: Font = .callout
     static let composerContainerHorizontalPadding: CGFloat = 16

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -526,6 +526,8 @@ struct ChatTabView: View {
                                         lineWidth: 1.5
                                     )
                             )
+                            .contentShape(.hoverEffect, RoundedRectangle(cornerRadius: DesignCorners.medium))
+                            .hoverEffect(.lift)
                         }
                         .disabled(isSending || isTranscribing || isStartingRecording)
                         .buttonStyle(.plain)
@@ -544,11 +546,13 @@ struct ChatTabView: View {
                                         .foregroundStyle(.white)
                                 }
                             }
-                            .frame(width: DesignControls.composerActionButtonSize, height: DesignControls.composerActionButtonSize)
+                            .frame(width: DesignControls.composerPrimaryActionButtonSize, height: DesignControls.composerPrimaryActionButtonSize)
                             .background {
                                 RoundedRectangle(cornerRadius: DesignCorners.medium)
                                     .fill(DesignColors.Brand.primary)
                             }
+                            .contentShape(.hoverEffect, RoundedRectangle(cornerRadius: DesignCorners.medium))
+                            .hoverEffect(.lift)
                         }
                         .disabled(!ChatComposerSendGate.canSend(text: inputText, isSending: isSending, hasMarkedText: hasMarkedText) || isRecording || isTranscribing)
 
@@ -571,6 +575,8 @@ struct ChatTabView: View {
                                                 lineWidth: 1.5
                                             )
                                     )
+                                    .contentShape(.hoverEffect, RoundedRectangle(cornerRadius: DesignCorners.medium))
+                                    .hoverEffect(.lift)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Increase the visionOS send button to a larger primary target while keeping the existing multi-button composer layout.
- Increase visionOS composer action spacing so mic/send/stop centers are about 70pt apart instead of sitting on the HIG minimum.
- Add explicit hover hit shapes and lift feedback to composer action buttons for more stable gaze targeting.

## Verification
- `xcodebuild build -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=visionOS Simulator,name=Apple Vision Pro,OS=26.2' CODE_SIGNING_ALLOWED=NO` — passed.
- `xcodebuild build -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' CODE_SIGNING_ALLOWED=NO` — passed.
- `xcodebuild test -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' CODE_SIGNING_ALLOWED=NO` — passed. Xcode logged one transient UI test runner launch warning, but the final result was `TEST SUCCEEDED`.
- Launched on Apple Vision Pro simulator and captured `tmp/visual_qa/opencode_visionos_composer.png`; composer controls were visible and screenshot contained no private data.