### PR TITLE
Pin VoiceFlowKit to the 0.1.0 tag

### DIFF
--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
@@ -644,8 +644,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/grapeot/voiceflow.git";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grapeot/voiceflow.git",
       "state" : {
-        "branch" : "master",
-        "revision" : "265fa13c4aaad8edad41db2863a7506c4b970c6a"
+        "revision" : "1e22166d535bee9d8e028a9c1bdda9ccd23e7285",
+        "version" : "0.1.0"
       }
     }
   ],


### PR DESCRIPTION
## What

VoiceFlow has entered a release cycle and now publishes SemVer tags. This moves
the VoiceFlowKit SPM dependency from `branch: master` to
`upToNextMinorVersion(0.1.0)`, so the app builds against a stable tagged release
instead of whatever is on `master`.

- `project.pbxproj`: requirement `branch master` → `upToNextMinorVersion 0.1.0`.
- `Package.resolved`: pinned to version `0.1.0` (revision `1e22166`).

Reverting to master tracking later (if rapid iteration resumes) is a one-line
requirement change — the flexibility is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)