### PR TITLE
Folder reads show their contents instead of a dead file card

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/FileCardView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/FileCardView.swift
@@ -9,6 +9,12 @@ import SwiftUI
 /// Quiet Tech styling: neutral surface body, single blue accent on the file icon,
 /// monospace basename, chevron to navigate. Fits the 2-up (iPhone) / 3-up (iPad)
 /// card grid alongside the merged "N tool calls" row.
+///
+/// When the part is a `read` of a *directory* (the server reports
+/// `<type>directory</type>` in its output), the card switches to a folder icon and
+/// tapping it expands the directory contents inline — opening a folder in the file
+/// preview never worked, so we render the `<entries>…</entries>` the server already
+/// returned instead of making a new API call.
 struct FileCardView: View {
     @Environment(\.colorScheme) private var colorScheme
     let part: Part
@@ -16,6 +22,7 @@ struct FileCardView: View {
     let onOpenResolvedPath: (String) -> Void
     let onOpenFilesTab: () -> Void
     @State private var showOpenFileSheet = false
+    @State private var showFolderSheet = false
 
     /// Prefer an explicit path; fall back to the first navigable path so the card
     /// always has a label even when metadata.path is absent.
@@ -30,9 +37,28 @@ struct FileCardView: View {
         return path.split(separator: "/").last.map(String.init) ?? path
     }
 
+    /// True when this read targeted a directory; flips icon + tap behavior.
+    private var isDirectoryRead: Bool {
+        ToolCardClassifier.isDirectoryRead(part)
+    }
+
+    private var folderEntries: [ToolCardClassifier.DirectoryEntry] {
+        ToolCardClassifier.parseDirectoryEntries(part.toolOutput)
+    }
+
     var body: some View {
+        if isDirectoryRead {
+            folderCard
+        } else {
+            fileCard
+        }
+    }
+
+    // MARK: - File card (unchanged behavior)
+
+    private var fileCard: some View {
         let accent = DesignColors.Brand.primary
-        Button {
+        return Button {
             let paths = part.filePathsForNavigation
             if paths.count == 1 {
                 openFile(paths[0])
@@ -42,24 +68,7 @@ struct FileCardView: View {
                 onOpenFilesTab()
             }
         } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "doc.text")
-                    .foregroundStyle(accent)
-                    .font(.caption)
-                Text(basename)
-                    .font(DesignTypography.microMono)
-                    .foregroundStyle(DesignColors.Neutral.text)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                Spacer(minLength: 4)
-                Image(systemName: "chevron.right")
-                    .font(DesignTypography.micro)
-                    .foregroundStyle(.tertiary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(DesignSpacing.cardPadding)
-            .background(DesignColors.Neutral.text.opacity(DesignColors.surfaceFill(for: colorScheme)))
-            .clipShape(RoundedRectangle(cornerRadius: DesignCorners.medium))
+            cardLabel(iconName: "doc.text", accent: accent)
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("toolcard.file.\(basename)")
@@ -75,10 +84,106 @@ struct FileCardView: View {
         }
     }
 
+    // MARK: - Folder card (directory read → show contents)
+
+    private var folderCard: some View {
+        let accent = DesignColors.Brand.primary
+        return Button {
+            showFolderSheet = true
+        } label: {
+            cardLabel(iconName: "folder.fill", accent: accent)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("toolcard.folder.\(basename)")
+        .sheet(isPresented: $showFolderSheet) {
+            FolderContentsSheet(
+                folderName: basename,
+                folderPath: displayPath,
+                entries: folderEntries
+            )
+        }
+    }
+
+    private func cardLabel(iconName: String, accent: Color) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: iconName)
+                .foregroundStyle(accent)
+                .font(.caption)
+            Text(basename)
+                .font(DesignTypography.microMono)
+                .foregroundStyle(DesignColors.Neutral.text)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 4)
+            Image(systemName: "chevron.right")
+                .font(DesignTypography.micro)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(DesignSpacing.cardPadding)
+        .background(DesignColors.Neutral.text.opacity(DesignColors.surfaceFill(for: colorScheme)))
+        .clipShape(RoundedRectangle(cornerRadius: DesignCorners.medium))
+    }
+
     private func openFile(_ path: String) {
         let raw = path.trimmingCharacters(in: .whitespacesAndNewlines)
         let p = PathNormalizer.resolveWorkspaceRelativePath(raw, workspaceDirectory: workspaceDirectory)
         guard !p.isEmpty else { return }
         onOpenResolvedPath(p)
+    }
+}
+
+/// Sheet listing the contents of a read directory. Pure presentation over the
+/// already-parsed `<entries>` — no network. Subdirectories sort above files,
+/// each name keyed by its own folder/document icon.
+private struct FolderContentsSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let folderName: String
+    let folderPath: String?
+    let entries: [ToolCardClassifier.DirectoryEntry]
+
+    private var sortedEntries: [ToolCardClassifier.DirectoryEntry] {
+        entries.sorted { lhs, rhs in
+            if lhs.isDirectory != rhs.isDirectory { return lhs.isDirectory }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if sortedEntries.isEmpty {
+                    ContentUnavailableView(
+                        "Empty folder",
+                        systemImage: "folder",
+                        description: Text("This directory has no entries.")
+                    )
+                } else {
+                    List(sortedEntries) { entry in
+                        HStack(spacing: 10) {
+                            Image(systemName: entry.isDirectory ? "folder.fill" : "doc.text")
+                                .foregroundStyle(DesignColors.Brand.primary)
+                                .font(.body)
+                                .frame(width: 22)
+                            Text(entry.name)
+                                .font(DesignTypography.microMono)
+                                .foregroundStyle(DesignColors.Neutral.text)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                        .accessibilityIdentifier("toolcard.folder.entry.\(entry.name)")
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle(folderName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.t(.commonOk)) { dismiss() }
+                }
+            }
+        }
+        .accessibilityIdentifier("toolcard.folder.sheet.\(folderName)")
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ToolCardClassifier.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ToolCardClassifier.swift
@@ -24,6 +24,57 @@ enum ToolCardClassifier {
         return fileOpToolPrefixes.contains { tool.hasPrefix($0) }
     }
 
+    /// `read` tool names (and aliases) — a directory read can only come from one of
+    /// these, never from edit/write/patch.
+    static let readToolPrefixes = ["read_file", "read"]
+
+    /// True when this part is a `read` whose tool output reports a directory.
+    /// The server embeds `<type>directory</type>` in the read output for a folder
+    /// (vs. `<type>file</type>` for a file); see Models/Message.swift toolOutput.
+    static func isDirectoryRead(_ part: Part) -> Bool {
+        guard part.isTool, let tool = part.tool?.lowercased() else { return false }
+        guard readToolPrefixes.contains(where: { tool.hasPrefix($0) }) else { return false }
+        guard let output = part.toolOutput else { return false }
+        return output.contains("<type>directory</type>")
+    }
+
+    /// One entry in a directory read: a child file or subdirectory.
+    struct DirectoryEntry: Identifiable, Equatable {
+        let name: String
+        let isDirectory: Bool
+        var id: String { name }
+    }
+
+    /// Parse the `<entries>…</entries>` block out of a directory read's output.
+    /// Each line is a child name; names ending in "/" are subdirectories. Blank
+    /// lines and trailing summary lines like "(12 entries)" are dropped. The
+    /// display name keeps the trailing "/" stripped so the UI can render it
+    /// uniformly with its own icon.
+    static func parseDirectoryEntries(_ output: String?) -> [DirectoryEntry] {
+        guard let output else { return [] }
+        guard let openRange = output.range(of: "<entries>") else { return [] }
+        let afterOpen = output[openRange.upperBound...]
+        let body: Substring
+        if let closeRange = afterOpen.range(of: "</entries>") {
+            body = afterOpen[..<closeRange.lowerBound]
+        } else {
+            body = afterOpen
+        }
+
+        var entries: [DirectoryEntry] = []
+        for rawLine in body.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty { continue }
+            // Drop summary lines such as "(12 entries)" or "(0 entries)".
+            if line.hasPrefix("(") && line.hasSuffix("entries)") { continue }
+            let isDir = line.hasSuffix("/")
+            let name = isDir ? String(line.dropLast()) : line
+            if name.isEmpty { continue }
+            entries.append(DirectoryEntry(name: name, isDirectory: isDir))
+        }
+        return entries
+    }
+
     /// Split a buffered run of tool/patch parts into the file-card group (grid) and
     /// the "other tools" group (merged into one "N tool calls" disclosure row).
     static func split(_ parts: [Part]) -> (fileParts: [Part], otherParts: [Part]) {

--- a/OpenCodeClient/OpenCodeClientTests/ToolCardClassifierTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/ToolCardClassifierTests.swift
@@ -125,4 +125,103 @@ struct ToolCardClassifierTests {
         #expect(otherParts.count == 3)
         #expect(ToolCardClassifier.toolCallsCount(parts) == 3)
     }
+
+    // MARK: - Directory read detection + entries parsing
+
+    /// Build a `read` Part whose object `state` carries `output`, mirroring the
+    /// real server shape where Part.toolOutput resolves to state.output.
+    private func makeReadPart(tool: String = "read", output: String) throws -> Part {
+        let obj: [String: Any] = [
+            "id": "d1",
+            "messageID": "m1",
+            "sessionID": "s1",
+            "type": "tool",
+            "tool": tool,
+            "state": [
+                "status": "completed",
+                "output": output,
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: obj)
+        return try JSONDecoder().decode(Part.self, from: data)
+    }
+
+    private let directoryOutput = """
+    <path>/abs/path/proj</path>
+    <type>directory</type>
+    <entries>
+    sub/
+    nested_dir/
+    file.txt
+    README.md
+    (4 entries)
+    </entries>
+    """
+
+    @Test func directoryReadIsDetected() throws {
+        let part = try makeReadPart(output: directoryOutput)
+        #expect(ToolCardClassifier.isDirectoryRead(part))
+    }
+
+    @Test func fileReadIsNotDirectoryRead() throws {
+        let fileOutput = """
+        <path>/abs/path/file.txt</path>
+        <type>file</type>
+        <content>hello</content>
+        """
+        let part = try makeReadPart(output: fileOutput)
+        #expect(!ToolCardClassifier.isDirectoryRead(part))
+    }
+
+    @Test func readFileAliasDetectsDirectory() throws {
+        let part = try makeReadPart(tool: "read_file", output: directoryOutput)
+        #expect(ToolCardClassifier.isDirectoryRead(part))
+    }
+
+    @Test func nonReadToolIsNeverDirectoryRead() throws {
+        // Even if some tool's output mentioned directory, only `read` counts.
+        let part = try makeReadPart(tool: "bash", output: directoryOutput)
+        #expect(!ToolCardClassifier.isDirectoryRead(part))
+    }
+
+    @Test func readWithoutOutputIsNotDirectoryRead() throws {
+        let part = try makePart(type: "tool", tool: "read")
+        #expect(!ToolCardClassifier.isDirectoryRead(part))
+    }
+
+    @Test func parsesEntriesWithDirAndFileFlags() throws {
+        let entries = ToolCardClassifier.parseDirectoryEntries(directoryOutput)
+        #expect(entries.count == 4)
+        #expect(entries.map(\.name) == ["sub", "nested_dir", "file.txt", "README.md"])
+        #expect(entries.map(\.isDirectory) == [true, true, false, false])
+    }
+
+    @Test func parseSkipsSummaryAndBlankLines() throws {
+        let output = """
+        <type>directory</type>
+        <entries>
+
+        a/
+
+        b.swift
+        (2 entries)
+        </entries>
+        """
+        let entries = ToolCardClassifier.parseDirectoryEntries(output)
+        #expect(entries.map(\.name) == ["a", "b.swift"])
+        #expect(entries.map(\.isDirectory) == [true, false])
+    }
+
+    @Test func parseReturnsEmptyWhenNoEntriesBlock() throws {
+        #expect(ToolCardClassifier.parseDirectoryEntries("<type>file</type>").isEmpty)
+        #expect(ToolCardClassifier.parseDirectoryEntries(nil).isEmpty)
+    }
+
+    @Test func parseHandlesMissingCloseTag() throws {
+        // Tolerate a truncated/streaming output with no </entries>.
+        let output = "<entries>\nonly/\nfile.txt\n"
+        let entries = ToolCardClassifier.parseDirectoryEntries(output)
+        #expect(entries.map(\.name) == ["only", "file.txt"])
+        #expect(entries.map(\.isDirectory) == [true, false])
+    }
 }


### PR DESCRIPTION
When a `read` tool targeted a **directory** it still rendered as a file card, and tapping it opened a file preview that could load nothing. Now a directory read renders as a **folder** and tapping it lists the directory's contents.

The server already returns the listing in the tool output (`<type>directory</type>` + `<entries>…</entries>`), so **no API call or server change** is needed — we just parse what's there.

- **ToolCardClassifier**: `isDirectoryRead(_:)` (a read-variant tool whose output contains `<type>directory</type>`) + `parseDirectoryEntries(_:)` (pulls the `<entries>` block, one entry per line, trailing `/` marks a subdirectory, drops the `(N entries)` summary line).
- **FileCardView**: directory reads use a `folder.fill` icon and, on tap, present a sheet listing the entries (subdirectories first). Plain file cards are unchanged.
- **9 unit tests** for detection + parsing.

Verified: builds; classifier/parser unit tests pass. (Folder-card sheet visual best confirmed by tapping a real folder read on device.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)