### PR TITLE
Drop the model line under user messages

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -169,11 +169,8 @@ struct MessageRowView: View {
             .clipShape(RoundedRectangle(cornerRadius: DesignCorners.large))
 
             HStack {
-                if let model = message.info.resolvedModel {
-                    Text("\(model.providerID)/\(model.modelID)")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
+                // User messages don't carry a model line — the model belongs to
+                // the assistant's reply, not to what the human said.
                 Spacer()
                 if onForkFromMessage != nil {
                     Menu {


### PR DESCRIPTION
The model belongs to the assistant's reply, not to what the human said — the assistant turn already shows "OpenCode" + the model footer. This removes the redundant `providerID/modelID` line under **user** messages; the user bubble keeps its blue left-bar and the Fork menu.

Android already only shows the model line on assistant messages, so no Android change is needed.

Verified on simulator: user message has no model line, assistant reply keeps its "OpenCode" header + model footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)