### PR TITLE
Drop the "OpenCode" speaker title

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -195,14 +195,9 @@ struct MessageRowView: View {
 
     private var assistantMessageView: some View {
         VStack(alignment: .leading, spacing: 6) {
-            // "OpenCode" header: not an avatar/icon, just a small accent title so
-            // it's obvious the AI is speaking (contrast with the user's blue left bar).
-            Text("OpenCode")
-                .font(DesignTypography.micro)
-                .fontWeight(.semibold)
-                .foregroundStyle(DesignColors.Brand.primary)
-                .accessibilityIdentifier("assistant.header")
-
+            // No "OpenCode" speaker title — the user's blue left-bar vs the
+            // assistant's container-less reply already make it clear who's
+            // speaking, so an extra blue label is redundant.
             ForEach(assistantBlocks) { block in
                 switch block {
                 case .text(let part):


### PR DESCRIPTION
The user's blue left-bar vs the assistant's container-less reply already make it clear who's speaking, so the extra blue "OpenCode" label on each assistant turn was redundant. Removed it; the model footer stays.

Verified on simulator: assistant reply has no "OpenCode" header, content + model footer intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)