### PR TITLE
fix(speech): close realtime session after transcription

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
@@ -104,6 +104,32 @@ extension ChatTabView {
         speechRecoveryActive = false
     }
 
+    func terminateSpeechSession(_ session: VoiceFlowSession) async {
+        do {
+            if let preserved = try await session.abortPreservingAudio() {
+                state.discardPreservedAudio(preserved)
+            }
+        } catch {
+            Self.logger.error("[SpeechProfile] realtime session termination failed error=\(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func stopSpeechForBackground() async {
+        stopSpeechHeartbeat()
+        stopSpeechEventConsumer()
+        _ = try? await microphone.stop()
+
+        let session = speechSession
+        speechSession = nil
+        isRecording = false
+        isTranscribing = false
+        isStartingRecording = false
+
+        if let session {
+            await terminateSpeechSession(session)
+        }
+    }
+
     func toggleRecording() async {
         if isRecording {
             stopSpeechHeartbeat()
@@ -140,8 +166,9 @@ extension ChatTabView {
                 Self.logger.notice("[SpeechProfile] chat realtime transcribe done ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) chars=\(cleaned.count, privacy: .public)")
                 inputText = Self.mergedSpeechInput(prefix: prefix, transcript: cleaned)
                 clearPreservedSpeechAudio()
+                await terminateSpeechSession(session)
             } catch {
-                await session.cancel()
+                await terminateSpeechSession(session)
                 guard speechSession === session else { return }
                 Self.logger.error("[SpeechProfile] chat realtime transcribe failed ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) error=\(error.localizedDescription, privacy: .public)")
                 inputText = Self.speechFailureInput(prefix: prefix, lastPartialTranscript: partialTranscriptBuffer.current())
@@ -194,7 +221,7 @@ extension ChatTabView {
                 stopSpeechEventConsumer()
                 isStartingRecording = false
                 if let speechSession {
-                    await speechSession.cancel()
+                    await terminateSpeechSession(speechSession)
                 }
                 speechSession = nil
                 Self.logger.error("[SpeechProfile] realtime capture start failed error=\(error.localizedDescription, privacy: .public)")

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -72,6 +72,7 @@ struct ChatTabView: View {
     @State private var isNearBottom = true
     @Environment(\.horizontalSizeClass) private var sizeClass
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.scenePhase) private var scenePhase
 
     private var useGridCards: Bool { sizeClass == .regular }
 
@@ -651,6 +652,10 @@ struct ChatTabView: View {
             .onChange(of: inputText) { _, newValue in
                 guard !isSyncingDraft else { return }
                 state.setDraftText(newValue, for: state.currentSessionID)
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                guard newPhase == .background else { return }
+                Task { await stopSpeechForBackground() }
             }
         }
     }


### PR DESCRIPTION
## Summary
- explicitly terminates VoiceFlow realtime sessions after successful or failed transcription
- stops any active speech session when the app moves to background
- prevents completed speech sessions from lingering and auto-recovering WebSocket connections

## Tests
- xcodebuild -project \"OpenCodeClient.xcodeproj\" -scheme \"OpenCodeClient\" -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' CODE_SIGNING_ALLOWED=NO build
- xcodebuild test -project \"OpenCodeClient.xcodeproj\" -scheme \"OpenCodeClient\" -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' CODE_SIGNING_ALLOWED=NO