### PR TITLE
feat(models): add ollama-cloud MiniMax M3 and DeepSeek V4 Pro presets

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -388,6 +388,8 @@ final class AppState {
         ModelPreset(displayName: "DeepSeek V4 Flash", providerID: "deepseek", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),
+        ModelPreset(displayName: "Ollama DeepSeek V4 Pro", providerID: "ollama-cloud", modelID: "deepseek-v4-pro"),
+        ModelPreset(displayName: "MiniMax M3", providerID: "ollama-cloud", modelID: "minimax-m3"),
     ]
     var selectedModelIndex: Int = 2
     

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -16,6 +16,7 @@ struct ModelPreset: Codable, Identifiable {
         case "DeepSeek V4 Flash": return "DS-Flash"
         case "DeepSeek Local": return "DS-L"
         case "DeepSeek V4 Pro": return "DS-Pro"
+        case "Ollama DeepSeek V4 Pro": return "ODS-Pro"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"
         default: return displayName


### PR DESCRIPTION
## Summary

Add two ollama-cloud model presets to the iOS client's fallback model list:

- `Ollama DeepSeek V4 Pro` — provider `ollama-cloud`, model `deepseek-v4-pro`. Toolbar short name `ODS-Pro` (mirrors the existing `DS-Pro` for the official DeepSeek Pro preset, with a leading `O` to signal the ollama-cloud backend).
- `MiniMax M3` — provider `ollama-cloud`, model `minimax-m3`. Falls through to the default `shortName` mapping and renders as `MiniMax M3` in the toolbar.

Both IDs come from `GET /config/providers` against the local opencode server (`ollama-cloud` provider, exposed alongside `deepseek` and `ds4`). They are wired into `AppState.modelPresets` and follow the same select/persist flow as the existing presets; no other state or call sites change.

## Test plan

- [x] `xcodebuild build` (iOS Simulator, Debug) — passes.
- [ ] Manual: open Settings → Model in the chat toolbar, confirm both new entries appear, switch between them, send a message, and verify the new `providerID/modelID` shows up on the assistant message footer.

🤖 Generated with [opencode](https://opencode.ai)