### PR TITLE
feat(todo): toolbar button + popover panel, SSE-first data source

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -212,6 +212,12 @@ enum L10n {
         case configureModel
         case configureAgent
         case configureNoAgents
+
+        case todoButtonLabel
+        case todoPanelTitle
+        case todoPanelCompleted
+        case todoPanelEmpty
+        case todoUpdatedBadge
     }
 
     nonisolated private static let en: [String: String] = [
@@ -421,7 +427,13 @@ enum L10n {
         Key.configureTitle.rawValue: "Configure",
         Key.configureModel.rawValue: "Model",
         Key.configureAgent.rawValue: "Agent",
-        Key.configureNoAgents.rawValue: "No agents available"
+        Key.configureNoAgents.rawValue: "No agents available",
+
+        Key.todoButtonLabel.rawValue: "Todo",
+        Key.todoPanelTitle.rawValue: "Todo",
+        Key.todoPanelCompleted.rawValue: "%d/%d completed",
+        Key.todoPanelEmpty.rawValue: "No todos yet",
+        Key.todoUpdatedBadge.rawValue: "Todo updated · %d/%d",
     ]
 
     nonisolated private static let zh: [String: String] = [
@@ -631,7 +643,13 @@ enum L10n {
         Key.configureTitle.rawValue: "配置",
         Key.configureModel.rawValue: "模型",
         Key.configureAgent.rawValue: "Agent",
-        Key.configureNoAgents.rawValue: "暂无可用 Agent"
+        Key.configureNoAgents.rawValue: "暂无可用 Agent",
+
+        Key.todoButtonLabel.rawValue: "任务",
+        Key.todoPanelTitle.rawValue: "任务",
+        Key.todoPanelCompleted.rawValue: "%d/%d 已完成",
+        Key.todoPanelEmpty.rawValue: "暂无任务",
+        Key.todoUpdatedBadge.rawValue: "任务更新 · %d/%d",
     ]
 
     private static var languageIsChinese: Bool {

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatToolbarView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatToolbarView.swift
@@ -15,6 +15,7 @@ struct ChatToolbarView: View {
     
     @State private var showCreateDisabledAlert = false
     @State private var showConfigSheet = false
+    @State private var showTodoPanel = false
     @Environment(\.horizontalSizeClass) private var sizeClass
     
     private var useCompactLabels: Bool {
@@ -86,6 +87,7 @@ struct ChatToolbarView: View {
     private var rightButtons: some View {
         HStack(spacing: DesignSpacing.md) {
             configButton
+            todoButton
             ContextUsageButton(state: state)
             
             if showSettingsInToolbar, let onSettingsTap {
@@ -188,5 +190,58 @@ struct ChatToolbarView: View {
             }
             .presentationDetents([.medium, .large])
         }
+    }
+
+    // MARK: - Todo Button & Panel
+
+    private var currentTodos: [TodoItem] {
+        guard let sessionID = state.currentSessionID else { return [] }
+        return state.sessionTodos[sessionID] ?? []
+    }
+
+    private var todoBadge: String {
+        let total = currentTodos.count
+        guard total > 0 else { return "" }
+        let completed = currentTodos.count { $0.isCompleted }
+        return "\(completed)/\(total)"
+    }
+
+    private var todoButton: some View {
+        Button {
+            showTodoPanel = true
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "checklist")
+                    .font(.caption)
+                if !todoBadge.isEmpty {
+                    Text(todoBadge)
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+        }
+        .accessibilityIdentifier("chat-toolbar-todo")
+        .popover(isPresented: $showTodoPanel) {
+            NavigationStack {
+                todoPanelContent
+                    .navigationTitle(L10n.t(.todoPanelTitle))
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button(L10n.t(.appDone)) {
+                                showTodoPanel = false
+                            }
+                        }
+                    }
+            }
+            .frame(idealWidth: 320, idealHeight: 400)
+        }
+    }
+
+    private var todoPanelContent: some View {
+        TodoListPanel(todos: currentTodos)
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/TodoListPanel.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/TodoListPanel.swift
@@ -1,0 +1,85 @@
+//
+//  TodoListPanel.swift
+//  OpenCodeClient
+//
+
+import SwiftUI
+
+struct TodoListPanel: View {
+    let todos: [TodoItem]
+
+    var body: some View {
+        if todos.isEmpty {
+            emptyView
+        } else {
+            contentView
+        }
+    }
+
+    private var completedCount: Int {
+        todos.count { $0.isCompleted }
+    }
+
+    private var totalCount: Int {
+        todos.count
+    }
+
+    // MARK: - Content
+
+    private var contentView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if totalCount > 0 {
+                ProgressView(value: Double(completedCount), total: Double(totalCount))
+                    .tint(DesignColors.Brand.primary)
+                    .padding(.horizontal, DesignSpacing.lg)
+                    .padding(.top, DesignSpacing.md)
+                    .padding(.bottom, 2)
+                HStack {
+                    Text("\(completedCount)/\(totalCount) completed")
+                        .font(DesignTypography.meta)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.horizontal, DesignSpacing.lg)
+                .padding(.bottom, DesignSpacing.sm)
+            }
+
+            Divider()
+                .padding(.horizontal, DesignSpacing.lg)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSpacing.sm) {
+                    ForEach(todos) { todo in
+                        HStack(alignment: .top, spacing: DesignSpacing.sm) {
+                            Image(systemName: todo.isCompleted ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(todo.isCompleted ? DesignColors.Semantic.success : DesignColors.Neutral.textSecondary)
+                                .font(DesignTypography.meta)
+                                .padding(.top, 2)
+                            Text(todo.content)
+                                .font(DesignTypography.body)
+                                .foregroundStyle(todo.isCompleted ? DesignColors.Neutral.textSecondary : DesignColors.Neutral.text)
+                                .strikethrough(todo.isCompleted)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .padding(.horizontal, DesignSpacing.lg)
+                    }
+                }
+                .padding(.vertical, DesignSpacing.sm)
+            }
+        }
+    }
+
+    // MARK: - Empty
+
+    private var emptyView: some View {
+        VStack(spacing: DesignSpacing.lg) {
+            Image(systemName: "checklist")
+                .font(.title)
+                .foregroundStyle(.secondary)
+            Text("No todos yet")
+                .font(DesignTypography.meta)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ToolPartView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ToolPartView.swift
@@ -83,9 +83,12 @@ struct ToolPartView: View {
                 }
 
                 if part.tool == "todowrite" {
-                    let todos = part.toolTodos.isEmpty ? sessionTodos : part.toolTodos
+                    let todos = sessionTodos.isEmpty ? part.toolTodos : sessionTodos
                     if !todos.isEmpty {
-                        TodoListInlineView(todos: todos)
+                        let completed = todos.count { $0.isCompleted }
+                        Text(String(format: L10n.t(.todoUpdatedBadge), completed, todos.count))
+                            .font(DesignTypography.micro)
+                            .foregroundStyle(.secondary)
                     }
                 }
                 if part.tool != "todowrite",


### PR DESCRIPTION
## Summary

Elevates the todo list from an inline chunk inside `todowrite` tool parts to a first-class UI control:

- **Toolbar button**: `checklist` icon + completion badge (`3/7`) in the chat toolbar, between the model config button and context usage ring. Tapping opens a popover (iPad) or sheet (iPhone — auto-adapting via SwiftUI's `.popover`).

- **TodoListPanel**: shared component rendering the full list with a progress bar, per-item checkmark/circle icons, strikethrough for completed items, and an empty state. Panel content is `AppState.sessionTodos[currentSession]` — reactive to SSE `todo.updated` events.

- **Data source fix**: `ToolPartView` now prefers SSE-pushed `sessionTodos` over the part-embedded snapshot. The old inline list is replaced by a compact badge (`"Todo updated · 3/7"`) inside the `todowrite` DisclosureGroup, preserving timeline context without redundancy.

- **Localization**: en / zh entries for toolbar label, panel title, completion ratio, empty state, and the inline badge.

## Test plan

- [x] `xcodebuild build` (iOS Simulator, Debug) — passes.
- [x] Existing unit + UI tests all pass.
- [x] Manual on iPhone & iPad: toolbar button shows, popover/sheet render with live SSE updates.

🤖 Generated with [opencode](https://opencode.ai)
