### PR TITLE
Fix read-only tool icon colors

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/FileCardView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/FileCardView.swift
@@ -46,6 +46,15 @@ struct FileCardView: View {
         ToolCardClassifier.parseDirectoryEntries(part.toolOutput)
     }
 
+    private var isReadOnlyFileTool: Bool {
+        guard let tool = part.tool?.lowercased() else { return false }
+        return ToolCardClassifier.readToolPrefixes.contains { tool.hasPrefix($0) }
+    }
+
+    private var fileAccent: Color {
+        isReadOnlyFileTool ? DesignColors.Neutral.textSecondary : DesignColors.Brand.primary
+    }
+
     var body: some View {
         if isDirectoryRead {
             folderCard
@@ -57,7 +66,6 @@ struct FileCardView: View {
     // MARK: - File card (unchanged behavior)
 
     private var fileCard: some View {
-        let accent = DesignColors.Brand.primary
         return Button {
             let paths = part.filePathsForNavigation
             if paths.count == 1 {
@@ -68,7 +76,7 @@ struct FileCardView: View {
                 onOpenFilesTab()
             }
         } label: {
-            cardLabel(iconName: "doc.text", accent: accent)
+            cardLabel(iconName: "doc.text", accent: fileAccent)
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("toolcard.file.\(basename)")
@@ -87,11 +95,10 @@ struct FileCardView: View {
     // MARK: - Folder card (directory read → show contents)
 
     private var folderCard: some View {
-        let accent = DesignColors.Brand.primary
         return Button {
             showFolderSheet = true
         } label: {
-            cardLabel(iconName: "folder.fill", accent: accent)
+            cardLabel(iconName: "folder.fill", accent: fileAccent)
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("toolcard.folder.\(basename)")

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ToolPartView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ToolPartView.swift
@@ -41,7 +41,13 @@ struct ToolPartView: View {
     // accent as the "you can tap this" affordance, rather than reading as inert
     // gray metadata. Blue lives on the interactive bits, not the whole card.
     private var toolAccentColor: Color {
-        DesignColors.Brand.primary
+        isReadOnlyTool ? DesignColors.Neutral.textSecondary : DesignColors.Brand.primary
+    }
+
+    private var isReadOnlyTool: Bool {
+        guard let tool = part.tool?.lowercased() else { return false }
+        return ["read_file", "read", "grep", "glob", "list", "webfetch", "task", "todoread"]
+            .contains { tool.hasPrefix($0) }
     }
 
     private var toolBackgroundColor: Color {


### PR DESCRIPTION
## Summary
- Gray out read-only tool row icons for read/search/list-style tools.
- Gray out read/read_file file and folder cards while leaving write/edit/patch blue.

## Tests
- xcodebuild build -project OpenCodeClient/OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'platform=iOS Simulator,name=iPhone 17'
- xcodebuild test -project OpenCodeClient/OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'platform=iOS Simulator,name=iPhone 17'