### PR TITLE
Add iPhone file preview refresh button

### DIFF
--- a/OpenCodeClient/OpenCodeClient/ContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var showSettingsSheet = false
     @State private var showTabletSettings = false
+    @State private var filePreviewRefreshTrigger = 0
 
     init() {
         _state = State(initialValue: Self.makeInitialState())
@@ -316,13 +317,28 @@ struct ContentView: View {
         }
         .sheet(item: filePreviewSheetItem) { wrapper in
             NavigationStack {
-                FileContentView(state: state, filePath: wrapper.path)
+                FileContentView(
+                    state: state,
+                    filePath: wrapper.path,
+                    refreshTrigger: filePreviewRefreshTrigger
+                )
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
-                            Button(L10n.t(.appClose)) {
+                            Button {
                                 state.fileToOpenInFilesTab = nil
                                 if !useSplitLayout { state.selectedTab = 0 }
+                            } label: {
+                                Image(systemName: "xmark")
                             }
+                            .accessibilityLabel(L10n.t(.appClose))
+                        }
+                        ToolbarItem(placement: .primaryAction) {
+                            Button {
+                                filePreviewRefreshTrigger += 1
+                            } label: {
+                                Image(systemName: "arrow.clockwise")
+                            }
+                            .accessibilityLabel(L10n.t(.contentRefreshHelp))
                         }
                     }
             }

--- a/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
@@ -20,6 +20,7 @@ enum ImageFileUtils {
 struct FileContentView: View {
     @Bindable var state: AppState
     let filePath: String
+    var refreshTrigger: Int = 0
     @State private var content: String?
     @State private var imageData: Data?
     @State private var isLoading = false
@@ -88,6 +89,9 @@ struct FileContentView: View {
             loadContent()
         }
         .refreshable {
+            loadContent()
+        }
+        .onChange(of: refreshTrigger) { _, _ in
             loadContent()
         }
     }


### PR DESCRIPTION
## Summary
- Replace the iPhone file preview sheet Close text button with a compact xmark button.
- Add a refresh toolbar button that reloads the currently previewed file.
- Leave iPad inline preview behavior unchanged.

## Tests
- xcodebuild build -project OpenCodeClient/OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'platform=iOS Simulator,name=iPhone 17'
- xcodebuild test -project OpenCodeClient/OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'platform=iOS Simulator,name=iPhone 17'