### PR TITLE
fix: align prompt_async payload with OpenCode 1.15

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
@@ -177,11 +177,21 @@ extension AppState {
             return false
         }
 
-        let tempMessageID = appendOptimisticUserMessage(text)
+        let messageID = Self.makeServerID(prefix: "msg")
+        let partID = Self.makeServerID(prefix: "part")
+        let tempMessageID = appendOptimisticUserMessage(text, messageID: messageID, partID: partID)
         let model = selectedModel.map { Message.ModelInfo(providerID: $0.providerID, modelID: $0.modelID) }
         let agentName = selectedAgent?.name ?? "build"
         do {
-            try await apiClient.promptAsync(sessionID: sessionID, text: text, agent: agentName, model: model)
+            try await apiClient.promptAsync(
+                sessionID: sessionID,
+                messageID: messageID,
+                partID: partID,
+                text: text,
+                agent: agentName,
+                model: model,
+                directory: currentSession?.directory ?? effectiveProjectDirectory
+            )
             return true
         } catch {
             let recovered = await recoverFromMissingCurrentSessionIfNeeded(error: error, requestedSessionID: sessionID)
@@ -191,12 +201,16 @@ extension AppState {
         }
     }
 
+    nonisolated static func makeServerID(prefix: String) -> String {
+        "\(prefix)_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+    }
+
     @discardableResult
-    func appendOptimisticUserMessage(_ text: String) -> String {
+    func appendOptimisticUserMessage(_ text: String, messageID: String? = nil, partID: String? = nil) -> String {
         guard let sessionID = currentSessionID else { return "" }
         let now = Int(Date().timeIntervalSince1970 * 1000)
-        let messageID = "temp-user-\(UUID().uuidString)"
-        let partID = "temp-part-\(messageID)"
+        let messageID = messageID ?? "temp-user-\(UUID().uuidString)"
+        let partID = partID ?? "temp-part-\(messageID)"
         let message = Message(
             id: messageID,
             sessionID: sessionID,

--- a/OpenCodeClient/OpenCodeClient/AppState+Sessions.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Sessions.swift
@@ -229,7 +229,7 @@ extension AppState {
         sessionLoadingID = loadingID
 
         do {
-            let session = try await apiClient.createSession(title: nil)
+            let session = try await apiClient.createSession(title: nil, directory: effectiveProjectDirectory)
             guard sessionLoadingID == loadingID else { return }
 
             Self.logger.debug("createSession: created id=\(session.id, privacy: .public) directory=\(session.directory, privacy: .public) effectiveProjectDir=\(self.effectiveProjectDirectory ?? "nil", privacy: .public)")

--- a/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
@@ -116,10 +116,16 @@ actor APIClient {
         return try JSONDecoder().decode(Session.self, from: data)
     }
 
-    func createSession(title: String? = nil) async throws -> Session {
+    func createSession(title: String? = nil, directory: String? = nil) async throws -> Session {
         let body = title.map { ["title": $0] } ?? [:]
         let data = try JSONEncoder().encode(body)
-        let (responseData, _) = try await makeRequest(path: "/session", method: "POST", body: data)
+        let queryItems = directory.map { [URLQueryItem(name: "directory", value: $0)] }
+        let (responseData, _) = try await makeRequest(
+            path: "/session",
+            method: "POST",
+            queryItems: queryItems,
+            body: data
+        )
         return try JSONDecoder().decode(Session.self, from: responseData)
     }
 
@@ -257,12 +263,22 @@ actor APIClient {
         return try? decoder.decode(type, from: data)
     }
 
-    func promptAsync(sessionID: String, text: String, agent: String = "build", model: Message.ModelInfo?) async throws {
+    func promptAsync(
+        sessionID: String,
+        messageID: String,
+        partID: String,
+        text: String,
+        agent: String = "build",
+        model: Message.ModelInfo?,
+        directory: String?
+    ) async throws {
         struct PromptBody: Encodable {
+            let messageID: String
             let parts: [PartInput]
             let agent: String
             let model: ModelInput?
             struct PartInput: Encodable {
+                let id: String
                 let type = "text"
                 let text: String
             }
@@ -272,12 +288,19 @@ actor APIClient {
             }
         }
         let body = PromptBody(
-            parts: [.init(text: text)],
+            messageID: messageID,
+            parts: [.init(id: partID, text: text)],
             agent: agent,
             model: model.map { .init(providerID: $0.providerID, modelID: $0.modelID) }
         )
         let bodyData = try JSONEncoder().encode(body)
-        let (_, response) = try await makeRequest(path: "/session/\(sessionID)/prompt_async", method: "POST", body: bodyData)
+        let queryItems = directory.map { [URLQueryItem(name: "directory", value: $0)] }
+        let (_, response) = try await makeRequest(
+            path: "/session/\(sessionID)/prompt_async",
+            method: "POST",
+            queryItems: queryItems,
+            body: bodyData
+        )
         if let http = response as? HTTPURLResponse, http.statusCode != 204 {
             throw APIError.httpError(statusCode: http.statusCode, data: Data())
         }
@@ -637,12 +660,20 @@ protocol APIClientProtocol: Actor {
     func projects() async throws -> [Project]
     func projectCurrent() async throws -> Project?
     func sessions(directory: String?, limit: Int) async throws -> [Session]
-    func createSession(title: String?) async throws -> Session
+    func createSession(title: String?, directory: String?) async throws -> Session
     func updateSession(sessionID: String, title: String) async throws -> Session
     func updateSessionArchived(sessionID: String, archived: Int) async throws -> Session
     func deleteSession(sessionID: String) async throws
     func messages(sessionID: String, limit: Int?) async throws -> [MessageWithParts]
-    func promptAsync(sessionID: String, text: String, agent: String, model: Message.ModelInfo?) async throws
+    func promptAsync(
+        sessionID: String,
+        messageID: String,
+        partID: String,
+        text: String,
+        agent: String,
+        model: Message.ModelInfo?,
+        directory: String?
+    ) async throws
     func abort(sessionID: String) async throws
     func sessionStatus() async throws -> [String: SessionStatus]
     func pendingPermissions() async throws -> [APIClient.PermissionRequest]

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -2438,7 +2438,7 @@ actor MockAPIClient: APIClientProtocol {
         sessionLimitRequests.append(limit)
         return sessionsByLimit[limit] ?? sessionsResult
     }
-    func createSession(title: String?) async throws -> Session { createSessionResult }
+    func createSession(title: String?, directory: String?) async throws -> Session { createSessionResult }
 
     func updateSession(sessionID: String, title: String) async throws -> Session {
         updateSessionCalls.append((sessionID, title))
@@ -2483,7 +2483,15 @@ actor MockAPIClient: APIClientProtocol {
         return messagesResult
     }
 
-    func promptAsync(sessionID: String, text: String, agent: String, model: Message.ModelInfo?) async throws {
+    func promptAsync(
+        sessionID: String,
+        messageID: String,
+        partID: String,
+        text: String,
+        agent: String,
+        model: Message.ModelInfo?,
+        directory: String?
+    ) async throws {
         promptAsyncCalls.append((sessionID, text))
         if let promptError { throw promptError }
     }

--- a/OpenCodeClient/OpenCodeClientTests/ReadToolCardIntegrationTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/ReadToolCardIntegrationTests.swift
@@ -30,15 +30,19 @@ struct ReadToolCardIntegrationTests {
 
         var createdSessionID: String?
         do {
-            let session = try await client.createSession(title: "ios-tier3-read-card")
+            let directory = env.nonEmpty("OPENCODE_DIRECTORY")
+            let session = try await client.createSession(title: "ios-tier3-read-card", directory: directory)
             let sessionID = await session.id
             createdSessionID = sessionID
 
             try await client.promptAsync(
                 sessionID: sessionID,
+                messageID: AppState.makeServerID(prefix: "msg"),
+                partID: AppState.makeServerID(prefix: "part"),
                 text: "Read the file AGENTS.md and reply with only its first line. Do not create, edit, or write any file.",
                 agent: agent,
-                model: model
+                model: model,
+                directory: directory
             )
 
             let messages = try await pollForReadToolPart(client: client, sessionID: sessionID)


### PR DESCRIPTION
## Summary

Fixes new-session prompt submission against OpenCode Server 1.15.x by aligning the iOS `prompt_async` payload with the current Web client request shape.

Closes #81.

## Changes

- Include `directory` when creating sessions.
- Include `directory` when submitting `prompt_async`.
- Generate server-style `msg_...` and `part_...` ids for outbound user prompts.
- Send `messageID` and `parts[].id` in the `prompt_async` body.
- Update `APIClientProtocol`, mocks, and the opt-in integration test call site.

## Why

OpenCode 1.15 queues async prompts through `session_input`, whose `id` is `NOT NULL`. The previous iOS payload did not include `messageID`, so the server could accept the HTTP request with `204` but later fail the async prompt processing with `SQLITE_CONSTRAINT_NOTNULL`.

## Verification

- `git diff --check`

Not run:

- `xcodebuild`, because this machine is currently configured with Command Line Tools instead of full Xcode (`xcodebuild` requires Xcode).
