### PR TITLE
fix(files): show refresh button in file previews

### DIFF
--- a/OpenCodeClient/OpenCodeClient/ContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/ContentView.swift
@@ -13,7 +13,6 @@ struct ContentView: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var showSettingsSheet = false
     @State private var showTabletSettings = false
-    @State private var filePreviewRefreshTrigger = 0
 
     init() {
         _state = State(initialValue: Self.makeInitialState())
@@ -374,11 +373,7 @@ struct ContentView: View {
         }
         .sheet(item: filePreviewSheetItem) { wrapper in
             NavigationStack {
-                FileContentView(
-                    state: state,
-                    filePath: wrapper.path,
-                    refreshTrigger: filePreviewRefreshTrigger
-                )
+                FileContentView(state: state, filePath: wrapper.path)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button {
@@ -388,14 +383,6 @@ struct ContentView: View {
                                 Image(systemName: "xmark")
                             }
                             .accessibilityLabel(L10n.t(.appClose))
-                        }
-                        ToolbarItem(placement: .primaryAction) {
-                            Button {
-                                filePreviewRefreshTrigger += 1
-                            } label: {
-                                Image(systemName: "arrow.clockwise")
-                            }
-                            .accessibilityLabel(L10n.t(.contentRefreshHelp))
                         }
                     }
             }
@@ -474,14 +461,12 @@ private struct FilePathWrapper: Identifiable {
 
 private struct TabletFilesColumn: View {
     @Bindable var state: AppState
-    @State private var reloadToken = UUID()
 
     var body: some View {
         NavigationStack {
             Group {
                 if let path = state.previewFilePath, !path.isEmpty {
                     FileContentView(state: state, filePath: path)
-                        .id("\(path)|\(reloadToken.uuidString)")
                 } else {
                     FileTreeView(state: state, forceSplitPreview: true)
                         .searchable(text: $state.fileSearchQuery, prompt: L10n.t(.appSearchFiles))
@@ -506,22 +491,13 @@ private struct TabletFilesColumn: View {
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     if let path = state.previewFilePath, !path.isEmpty {
-                        HStack(spacing: 12) {
-                            Button {
-                                reloadToken = UUID()
-                            } label: {
-                                Image(systemName: "arrow.clockwise")
-                            }
-                            .help(L10n.t(.contentRefreshHelp))
-
-                            Button {
-                                state.previewFilePath = nil
-                                state.fileToOpenInFilesTab = nil
-                            } label: {
-                                Image(systemName: "xmark")
-                            }
-                            .help(L10n.t(.appClose))
+                        Button {
+                            state.previewFilePath = nil
+                            state.fileToOpenInFilesTab = nil
+                        } label: {
+                            Image(systemName: "xmark")
                         }
+                        .help(L10n.t(.appClose))
                     }
                 }
             }

--- a/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
@@ -20,7 +20,6 @@ enum ImageFileUtils {
 struct FileContentView: View {
     @Bindable var state: AppState
     let filePath: String
-    var refreshTrigger: Int = 0
     @State private var content: String?
     @State private var imageData: Data?
     @State private var isLoading = false
@@ -41,6 +40,16 @@ struct FileContentView: View {
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .primaryAction) {
+            Button {
+                loadContent()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .disabled(isLoading)
+            .accessibilityLabel(L10n.t(.contentRefreshHelp))
+            .help(L10n.t(.contentRefreshHelp))
+        }
         if let content {
             ToolbarItem(placement: .primaryAction) {
                 ShareLink(item: content, subject: Text(fileName)) {
@@ -89,9 +98,6 @@ struct FileContentView: View {
             loadContent()
         }
         .refreshable {
-            loadContent()
-        }
-        .onChange(of: refreshTrigger) { _, _ in
             loadContent()
         }
     }


### PR DESCRIPTION
## Summary
- Move the file preview refresh action into `FileContentView` so chat-opened previews and Files tab previews share the same refresh affordance.
- Remove parent-level refresh triggers from chat sheets and iPad preview columns, leaving the shared content view responsible for reloading itself.

## Testing
- `xcodebuild build -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'generic/platform=iOS Simulator'`