### PR TITLE
Update Ollama Kimi preset to K2.7 Code

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -389,7 +389,7 @@ final class AppState {
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),
         ModelPreset(displayName: "Ollama DeepSeek V4 Pro", providerID: "ollama-cloud", modelID: "deepseek-v4-pro"),
-        ModelPreset(displayName: "Ollama Kimi K2.6", providerID: "ollama-cloud", modelID: "kimi-k2.6"),
+        ModelPreset(displayName: "Ollama Kimi K2.7 Code", providerID: "ollama-cloud", modelID: "kimi-k2.7-code"),
     ]
     var selectedModelIndex: Int = 2
     

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -17,7 +17,7 @@ struct ModelPreset: Codable, Identifiable {
         case "DeepSeek Local": return "DS-L"
         case "DeepSeek V4 Pro": return "DS-Pro"
         case "Ollama DeepSeek V4 Pro": return "ODS-Pro"
-        case "Ollama Kimi K2.6": return "Kimi"
+        case "Ollama Kimi K2.7 Code": return "Kimi"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"
         default: return displayName


### PR DESCRIPTION
## Summary
- Replace the Ollama Kimi K2.6 preset with Ollama Kimi K2.7 Code.
- Use the OpenCode provider registry key `kimi-k2.7-code`, matching Ollama's `kimi-k2.7-code:cloud` model tag without the cloud suffix.

## Tests
- `xcodebuild test -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'platform=iOS Simulator,id=302F88CA-C2D3-4DC0-8E12-B3ED82D5A3C8'`