### PR TITLE
feat(models): update GLM preset from 5.1 to 5.2

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+Models.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Models.swift
@@ -17,8 +17,8 @@ extension AppState {
 
     func canonicalModelPresetID(for savedID: String) -> String {
         switch savedID {
-        case "zai-coding-plan/glm-5.1", "zai-coding-plan/glm-5-turbo":
-            return "zai-coding-plan/glm-5.1"
+        case "zai-coding-plan/glm-5.2", "zai-coding-plan/glm-5.1", "zai-coding-plan/glm-5-turbo":
+            return "zai-coding-plan/glm-5.2"
         case "openai/gpt-5.4":
             return "openai/gpt-5.5"
         default:

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -383,7 +383,7 @@ final class AppState {
     var streamingReasoningPart: Part? { get { messageStore.streamingReasoningPart } set { messageStore.streamingReasoningPart = newValue } }
 
     var modelPresets: [ModelPreset] = [
-        ModelPreset(displayName: "GLM-5.1", providerID: "zai-coding-plan", modelID: "glm-5.1"),
+        ModelPreset(displayName: "GLM-5.2", providerID: "zai-coding-plan", modelID: "glm-5.2"),
         ModelPreset(displayName: "GPT-5.5", providerID: "openai", modelID: "gpt-5.5"),
         ModelPreset(displayName: "DeepSeek V4 Flash", providerID: "deepseek", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1673,7 +1673,7 @@ struct ModelSelectionPersistenceTests {
         body()
     }
 
-    @Test @MainActor func legacyGLM51SelectionMapsToCurrentTurboPreset() {
+    @Test @MainActor func legacyGLM51SelectionMapsToCurrentGLM52Preset() {
         withIsolatedModelSelectionDefaults {
             let sessionID = "session-glm"
             let legacySelection = [sessionID: "zai-coding-plan/glm-5.1"]
@@ -1697,7 +1697,7 @@ struct ModelSelectionPersistenceTests {
             state.selectSession(session)
 
             #expect(state.selectedModelIndex == 0)
-            #expect(state.modelPresets[state.selectedModelIndex].displayName == "GLM-5.1")
+            #expect(state.modelPresets[state.selectedModelIndex].displayName == "GLM-5.2")
         }
     }
 


### PR DESCRIPTION
Updates the GLM model preset display name and model ID from `GLM-5.1`/`glm-5.1` to `GLM-5.2`/`glm-5.2` (`zai-coding-plan/glm-5.2`), aligning the client with the latest GLM release.

Changes:
- `AppState.swift`: preset renamed to `GLM-5.2` / `zai-coding-plan/glm-5.2`.
- `AppState+Models.swift`: `canonicalModelPresetID` now forwards legacy `glm-5.2`, `glm-5.1`, and `glm-5-turbo` saved selections to the new `glm-5.2` slot, so existing per-session model selections migrate forward instead of falling back.
- `OpenCodeClientTests.swift`: legacy-selection test updated to expect `GLM-5.2`.

Tests: `xcodebuild test` on `OpenCodeClientTests` (iPhone 17, OS 27.0) — all green.

Mirrors the equivalent change in the Android client.