### PR TITLE
fix(chat): avoid markdown rendering for huge messages

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -787,7 +787,9 @@ struct ChatTabView: View {
                 Text(speechError ?? "")
             }
             .onAppear {
-                syncDraftFromState(sessionID: state.currentSessionID)
+                Task { @MainActor in
+                    syncDraftFromState(sessionID: state.currentSessionID)
+                }
             }
             .onChange(of: state.currentSessionID) { oldID, newID in
                 let draftText = inputText

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -7,6 +7,9 @@ import SwiftUI
 import MarkdownUI
 
 struct MessageRowView: View {
+    private static let markdownRenderCharacterLimit = 50_000
+    private static let largeMessagePreviewCharacterLimit = 12_000
+
     @Bindable var state: AppState
     let message: MessageWithParts
     let sessionTodos: [TodoItem]
@@ -81,7 +84,11 @@ struct MessageRowView: View {
     @ViewBuilder
     private func markdownText(_ text: String, isUser: Bool) -> some View {
         let font = isUser ? DesignTypography.bodyProminent : DesignTypography.body
-        if shouldRenderMarkdown(text) {
+        if Self.isLargeMessage(text) {
+            LargeMessagePreview(text: text, preview: Self.largeMessagePreview(text))
+                .font(font)
+                .textSelection(.enabled)
+        } else if shouldRenderMarkdown(text) {
             ResolvedMarkdownView(text: text, state: state, workspaceDirectory: workspaceDirectory)
                 .font(font)
                 .textSelection(.enabled)
@@ -124,6 +131,15 @@ struct MessageRowView: View {
         Self.hasMarkdownSyntax(text)
     }
 
+    static func isLargeMessage(_ text: String) -> Bool {
+        text.count > markdownRenderCharacterLimit
+    }
+
+    static func largeMessagePreview(_ text: String) -> String {
+        guard isLargeMessage(text) else { return text }
+        return String(text.prefix(largeMessagePreviewCharacterLimit))
+    }
+
     static func hasMarkdownSyntax(_ text: String) -> Bool {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
@@ -137,6 +153,21 @@ struct MessageRowView: View {
         }
 
         return trimmed.contains("\n\n")
+    }
+
+    private struct LargeMessagePreview: View {
+        let text: String
+        let preview: String
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: DesignSpacing.sm) {
+                Text(preview)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text("Large message: showing first \(preview.count.formatted()) of \(text.count.formatted()) characters. Markdown rendering is skipped to keep the app responsive.")
+                    .font(DesignTypography.micro)
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 
     var body: some View {

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1123,6 +1123,13 @@ struct MessageRenderingHeuristicTests {
     @Test func markdownHeuristicDetectsCodeFence() {
         #expect(MessageRowView.hasMarkdownSyntax("```swift\nprint(1)\n```") == true)
     }
+
+    @Test func largeMessageDetectionSkipsExpensiveMarkdownRendering() {
+        let text = String(repeating: "- Wells Fargo agreement\n", count: 3_000)
+
+        #expect(MessageRowView.isLargeMessage(text) == true)
+        #expect(MessageRowView.largeMessagePreview(text).count == 12_000)
+    }
 }
 
 struct ChatScrollBehaviorTests {


### PR DESCRIPTION
## Summary
- Render very large chat text as a plain truncated preview instead of sending it through MarkdownUI
- Add a small explanatory footer with full/preview character counts
- Defer initial draft sync out of the SwiftUI view update pass

## Root Cause
The Wells Fargo session contains a user message around 304k characters / 7k lines. The server returns the session successfully, but MarkdownUI rendering that oversized message can make the iOS client terminate during view construction.

## Tests
- xcodebuild test -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'platform=iOS Simulator,id=302F88CA-C2D3-4DC0-8E12-B3ED82D5A3C8'