### PR TITLE
fix(files): open external host paths via directory query

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+FileTree.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+FileTree.swift
@@ -10,7 +10,7 @@ extension AppState {
         let previousChildrenCache = fileChildrenCache
         let previouslyExpandedPaths = expandedPaths
         do {
-            fileTreeRoot = try await apiClient.fileList(path: "")
+            fileTreeRoot = try await apiClient.fileList(path: "", directory: nil)
             fileChildrenCache = previousChildrenCache.filter { previouslyExpandedPaths.contains($0.key) }
         } catch {
             fileTreeRoot = []
@@ -33,7 +33,7 @@ extension AppState {
 
     func loadFileChildren(path: String) async -> [FileNode] {
         do {
-            let children = try await apiClient.fileList(path: path)
+            let children = try await apiClient.fileList(path: path, directory: nil)
             fileChildrenCache[path] = children
             return children
         } catch {
@@ -57,7 +57,11 @@ extension AppState {
 
     func loadFileContent(path: String) async throws -> FileContent {
         let resolved = PathNormalizer.resolveWorkspaceRelativePath(path, workspaceDirectory: currentSession?.directory)
-        return try await apiClient.fileContent(path: resolved)
+        if resolved.hasPrefix("/") {
+            let url = URL(fileURLWithPath: resolved)
+            return try await apiClient.fileContent(path: url.lastPathComponent, directory: url.deletingLastPathComponent().path)
+        }
+        return try await apiClient.fileContent(path: resolved, directory: nil)
     }
 
     func loadFileContent(pathBytes: [UInt8]) async throws -> FileContent {

--- a/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
@@ -384,13 +384,21 @@ actor APIClient {
         return try JSONDecoder().decode([TodoItem].self, from: data)
     }
 
-    func fileList(path: String = "") async throws -> [FileNode] {
-        let (data, _) = try await makeRequest(path: "/file", queryItems: [URLQueryItem(name: "path", value: path)])
+    func fileList(path: String = "", directory: String? = nil) async throws -> [FileNode] {
+        var queryItems = [URLQueryItem(name: "path", value: path)]
+        if let directory, !directory.isEmpty {
+            queryItems.append(URLQueryItem(name: "directory", value: directory))
+        }
+        let (data, _) = try await makeRequest(path: "/file", queryItems: queryItems)
         return try JSONDecoder().decode([FileNode].self, from: data)
     }
 
-    func fileContent(path: String) async throws -> FileContent {
-        let (data, _) = try await makeRequest(path: "/file/content", queryItems: [URLQueryItem(name: "path", value: path)])
+    func fileContent(path: String, directory: String? = nil) async throws -> FileContent {
+        var queryItems = [URLQueryItem(name: "path", value: path)]
+        if let directory, !directory.isEmpty {
+            queryItems.append(URLQueryItem(name: "directory", value: directory))
+        }
+        let (data, _) = try await makeRequest(path: "/file/content", queryItems: queryItems)
         return try JSONDecoder().decode(FileContent.self, from: data)
     }
 
@@ -654,8 +662,8 @@ protocol APIClientProtocol: Actor {
     func agents() async throws -> [AgentInfo]
     func sessionDiff(sessionID: String) async throws -> [FileDiff]
     func sessionTodos(sessionID: String) async throws -> [TodoItem]
-    func fileList(path: String) async throws -> [FileNode]
-    func fileContent(path: String) async throws -> FileContent
+    func fileList(path: String, directory: String?) async throws -> [FileNode]
+    func fileContent(path: String, directory: String?) async throws -> FileContent
     func findFile(query: String, limit: Int) async throws -> [String]
     func fileStatus() async throws -> [FileStatusEntry]
     func forkSession(sessionID: String, messageID: String?) async throws -> Session

--- a/OpenCodeClient/OpenCodeClient/Utils/PathNormalizer.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/PathNormalizer.swift
@@ -101,9 +101,10 @@ nonisolated enum PathNormalizer {
     /// Tool payloads sometimes carry absolute paths (e.g. "/Users/.../repo/file.swift").
     /// OpenCode server APIs generally expect workspace-relative paths.
     static func resolveWorkspaceRelativePath(_ path: String, workspaceDirectory: String?) -> String {
+        let absoluteInput = absoluteHostPath(path)
         let p = normalize(path)
         guard let workspaceDirectory, !workspaceDirectory.isEmpty else {
-            return p
+            return absoluteInput ?? p
         }
         let dir = normalize(workspaceDirectory)
         if p == dir {
@@ -113,6 +114,16 @@ nonisolated enum PathNormalizer {
             let resolved = String(p.dropFirst(dir.count + 1))
             return resolved
         }
+        if let absoluteInput {
+            return absoluteInput
+        }
         return p
+    }
+
+    private static func absoluteHostPath(_ path: String) -> String? {
+        let trimmed = trimPathWhitespace(path)
+        if trimmed.hasPrefix("/") { return trimmed }
+        if trimmed.hasPrefix("Users/") { return "/" + trimmed }
+        return nil
     }
 }

--- a/OpenCodeClient/OpenCodeClientTests/MarkdownWebPreviewPathTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/MarkdownWebPreviewPathTests.swift
@@ -64,12 +64,12 @@ struct MarkdownWebPreviewPathTests {
     }
 
     @Test func absoluteOutsideWorkspaceIsNormalizedButNotRelativized() {
-        // Outside the workspace: normalize() strips the leading slash but cannot
-        // make it workspace-relative (no shared prefix).
+        // Outside the workspace: preserve the host absolute path so the file API
+        // can read it via the explicit `directory` query parameter.
         let resolved = MarkdownImageResolver.resolveRelativeReference(
             "/etc/hosts", markdownFilePath: mdPath, workspaceDirectory: workspace
         )
-        #expect(resolved == "etc/hosts")
+        #expect(resolved == "/etc/hosts")
     }
 
     @Test func nilMarkdownPathKeepsReferenceWorkspaceRelative() {

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -690,6 +690,15 @@ struct PathNormalizerTests {
         let abs = "/Users/test/workspace/src%2Fapp.swift"
         #expect(PathNormalizer.resolveWorkspaceRelativePath(abs, workspaceDirectory: dir) == "src/app.swift")
     }
+
+    @Test func resolvesWorkspaceRelativePreservesExternalHostPath() {
+        let dir = "/Users/grapeot/co/knowledge_working"
+        let absWithoutSlash = "Users/grapeot/co/vatic/agentic_trading/docs/slides_260617/outline.md"
+        #expect(
+            PathNormalizer.resolveWorkspaceRelativePath(absWithoutSlash, workspaceDirectory: dir)
+                == "/Users/grapeot/co/vatic/agentic_trading/docs/slides_260617/outline.md"
+        )
+    }
 }
 
 struct WorkspaceMarkdownImageProviderTests {
@@ -2382,7 +2391,8 @@ actor MockAPIClient: APIClientProtocol {
     var sessionDiffResult: [FileDiff] = []
     var sessionDiffCallCount = 0
     var fileListResults: [String: [FileNode]] = [:]
-    var fileListRequests: [String] = []
+    var fileListRequests: [(path: String, directory: String?)] = []
+    var fileContentRequests: [(path: String, directory: String?)] = []
 
     func setHealthError(_ error: Error?) {
         healthError = error
@@ -2511,11 +2521,14 @@ actor MockAPIClient: APIClientProtocol {
         return sessionDiffResult
     }
     func sessionTodos(sessionID: String) async throws -> [TodoItem] { [] }
-    func fileList(path: String) async throws -> [FileNode] {
-        fileListRequests.append(path)
+    func fileList(path: String, directory: String?) async throws -> [FileNode] {
+        fileListRequests.append((path, directory))
         return fileListResults[path] ?? []
     }
-    func fileContent(path: String) async throws -> FileContent { FileContent(type: "text", content: "") }
+    func fileContent(path: String, directory: String?) async throws -> FileContent {
+        fileContentRequests.append((path, directory))
+        return FileContent(type: "text", content: "")
+    }
     func findFile(query: String, limit: Int) async throws -> [String] { [] }
     func fileStatus() async throws -> [FileStatusEntry] { [] }
     func forkSession(sessionID: String, messageID: String?) async throws -> Session {
@@ -2577,6 +2590,24 @@ struct AppStateFlowTests {
 
         #expect(state.isConnected == false)
         #expect(state.connectionError?.isEmpty == false)
+    }
+
+    @Test @MainActor func loadFileContentUsesDirectoryQueryForExternalHostPath() async throws {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.sessions = [
+            Self.makeSession(id: "s1", updated: 1, directory: "/Users/grapeot/co/knowledge_working")
+        ]
+        state.currentSessionID = "s1"
+
+        _ = try await state.loadFileContent(
+            path: "Users/grapeot/co/vatic/agentic_trading/docs/slides_260617/outline.md"
+        )
+
+        #expect(await apiClient.fileContentRequests.map { $0.path } == ["outline.md"])
+        #expect(await apiClient.fileContentRequests.map { $0.directory } == [
+            "/Users/grapeot/co/vatic/agentic_trading/docs/slides_260617"
+        ])
     }
 
     @Test @MainActor func loadSessionsSelectsFirstSessionWhenNeeded() async {


### PR DESCRIPTION
## Summary
- preserve external host absolute paths instead of forcing them workspace-relative
- pass explicit directory query params for external host file opens
- update API client protocol and tests for directory-aware file APIs

## Validation
- xcodebuild build -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4'
- xcodebuild test -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' -only-testing:OpenCodeClientTests

Note: full test suite was blocked by an iOS Simulator UI runner launch flake: RequestDenied launching OpenCodeClientUITests.xctrunner.