### PR TITLE
feat(chat): add edit from message revert

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
@@ -8,6 +8,13 @@ import os
 ///
 /// State lives on `MessageStore`; this extension only orchestrates.
 extension AppState {
+    nonisolated static func visibleMessages(_ messages: [MessageWithParts], revertMessageID: String?) -> [MessageWithParts] {
+        guard let revertMessageID else { return messages }
+        return messages.filter { message in
+            message.info.id.hasPrefix("temp-") || message.info.id < revertMessageID
+        }
+    }
+
     func loadMessages() async {
         guard let sessionID = currentSessionID else { return }
         do {
@@ -189,6 +196,37 @@ extension AppState {
             removeMessage(id: tempMessageID)
             return false
         }
+    }
+
+    func editFromMessage(messageID: String) async -> String? {
+        guard isConnected else { return nil }
+        guard let sessionID = currentSessionID else { return nil }
+        guard let message = messages.first(where: { $0.info.id == messageID && $0.info.isUser }) else { return nil }
+
+        let draft = Self.editDraftText(for: message)
+        guard !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+
+        do {
+            let updatedSession = try await apiClient.revertSession(sessionID: sessionID, messageID: messageID, partID: nil)
+            guard Self.shouldApplySessionScopedResult(requestedSessionID: sessionID, currentSessionID: currentSessionID) else { return nil }
+            upsertSession(updatedSession)
+            setDraftText(draft, for: sessionID)
+            await loadMessages()
+            await loadSessionDiff()
+            await loadFileStatus()
+            return draft
+        } catch {
+            guard Self.shouldApplySessionScopedResult(requestedSessionID: sessionID, currentSessionID: currentSessionID) else { return nil }
+            sendError = error.localizedDescription
+            return nil
+        }
+    }
+
+    nonisolated static func editDraftText(for message: MessageWithParts) -> String {
+        message.parts
+            .filter { $0.isText }
+            .compactMap { $0.text }
+            .joined(separator: "\n\n")
     }
 
     @discardableResult

--- a/OpenCodeClient/OpenCodeClient/Models/Session.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Session.swift
@@ -16,6 +16,7 @@ struct Session: Identifiable, Equatable {
     let time: TimeInfo
     let share: ShareInfo?
     let summary: SummaryInfo?
+    var revert: RevertInfo? = nil
 
     var isArchived: Bool {
         guard let archived = time.archived else { return false }
@@ -36,6 +37,13 @@ struct Session: Identifiable, Equatable {
         let additions: Int
         let deletions: Int
         let files: Int
+    }
+
+    struct RevertInfo: Codable, Equatable {
+        let messageID: String
+        let partID: String?
+        let snapshot: String?
+        let diff: String?
     }
 }
 

--- a/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
@@ -431,6 +431,21 @@ actor APIClient {
         )
         return try JSONDecoder().decode(Session.self, from: responseData)
     }
+
+    func revertSession(sessionID: String, messageID: String, partID: String? = nil) async throws -> Session {
+        struct RevertBody: Encodable {
+            let messageID: String
+            let partID: String?
+        }
+
+        let data = try JSONEncoder().encode(RevertBody(messageID: messageID, partID: partID))
+        let (responseData, _) = try await makeRequest(
+            path: "/session/\(sessionID)/revert",
+            method: "POST",
+            body: data
+        )
+        return try JSONDecoder().decode(Session.self, from: responseData)
+    }
 }
 
 struct FileNode: Codable, Identifiable {
@@ -667,6 +682,7 @@ protocol APIClientProtocol: Actor {
     func findFile(query: String, limit: Int) async throws -> [String]
     func fileStatus() async throws -> [FileStatusEntry]
     func forkSession(sessionID: String, messageID: String?) async throws -> Session
+    func revertSession(sessionID: String, messageID: String, partID: String?) async throws -> Session
 }
 
 extension APIClient: APIClientProtocol {}

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -297,18 +297,22 @@ struct ChatTabView: View {
 
     /// 合并同一 assistant turn 的连续 step-only 消息，使 tool 卡片在一个 grid 内连续显示
     private var messageGroups: [MessageGroupItem] {
+        let visibleMessages = AppState.visibleMessages(
+            state.messages,
+            revertMessageID: state.currentSession?.revert?.messageID
+        )
         var result: [MessageGroupItem] = []
         var i = 0
-        while i < state.messages.count {
-            let msg = state.messages[i]
+        while i < visibleMessages.count {
+            let msg = visibleMessages[i]
             if msg.info.isUser {
                 result.append(.user(msg))
                 i += 1
                 continue
             }
             var assistantBatch: [MessageWithParts] = []
-            while i < state.messages.count {
-                let m = state.messages[i]
+            while i < visibleMessages.count {
+                let m = visibleMessages[i]
                 if m.info.isUser { break }
                 assistantBatch.append(m)
                 i += 1
@@ -558,13 +562,19 @@ struct ChatTabView: View {
                                                         state: state,
                                                         message: msg,
                                                         sessionTodos: state.sessionTodos[msg.info.sessionID] ?? [],
-                                                        workspaceDirectory: state.currentSession?.directory,
-                                                        onOpenResolvedPath: openFileInChat,
-                                                        onOpenFilesTab: openFilesTab,
-                                                        onForkFromMessage: { messageID in
-                                                            Task { await state.forkSession(messageID: messageID) }
-                                                        }
-                                                    )
+                                                         workspaceDirectory: state.currentSession?.directory,
+                                                         onOpenResolvedPath: openFileInChat,
+                                                         onOpenFilesTab: openFilesTab,
+                                                         onForkFromMessage: { messageID in
+                                                             Task { await state.forkSession(messageID: messageID) }
+                                                         },
+                                                         onEditFromMessage: { messageID in
+                                                             Task {
+                                                                 guard let draft = await state.editFromMessage(messageID: messageID) else { return }
+                                                                 inputText = draft
+                                                             }
+                                                         }
+                                                     )
                                                 case .assistantMerged(let msgs):
                                                     if let first = msgs.first {
                                                         let merged = MessageWithParts(info: first.info, parts: msgs.flatMap(\.parts))
@@ -572,13 +582,19 @@ struct ChatTabView: View {
                                                             state: state,
                                                             message: merged,
                                                             sessionTodos: state.sessionTodos[merged.info.sessionID] ?? [],
-                                                            workspaceDirectory: state.currentSession?.directory,
-                                                            onOpenResolvedPath: openFileInChat,
-                                                            onOpenFilesTab: openFilesTab,
-                                                            onForkFromMessage: { messageID in
-                                                                Task { await state.forkSession(messageID: messageID) }
-                                                            }
-                                                        )
+                                                             workspaceDirectory: state.currentSession?.directory,
+                                                             onOpenResolvedPath: openFileInChat,
+                                                             onOpenFilesTab: openFilesTab,
+                                                             onForkFromMessage: { messageID in
+                                                                 Task { await state.forkSession(messageID: messageID) }
+                                                             },
+                                                             onEditFromMessage: { messageID in
+                                                                 Task {
+                                                                     guard let draft = await state.editFromMessage(messageID: messageID) else { return }
+                                                                     inputText = draft
+                                                                 }
+                                                             }
+                                                         )
                                                     }
                                                 }
                                             case .activity(let a):

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -17,6 +17,7 @@ struct MessageRowView: View {
     let onOpenResolvedPath: (String) -> Void
     let onOpenFilesTab: () -> Void
     let onForkFromMessage: ((String) -> Void)?
+    let onEditFromMessage: ((String) -> Void)?
     @Environment(\.horizontalSizeClass) private var sizeClass
     @Environment(\.colorScheme) private var colorScheme
 
@@ -205,6 +206,15 @@ struct MessageRowView: View {
                 Spacer()
                 if onForkFromMessage != nil {
                     Menu {
+                        if onEditFromMessage != nil {
+                            Button {
+                                onEditFromMessage?(message.info.id)
+                            } label: {
+                                Label("Edit from here", systemImage: "pencil")
+                            }
+                            .disabled(state.isBusy)
+                        }
+
                         Button {
                             onForkFromMessage?(message.info.id)
                         } label: {

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -62,6 +62,17 @@ struct OpenCodeClientTests {
         #expect(session.title == "Test")
     }
 
+    @Test func sessionDecodingWithRevert() throws {
+        let json = """
+        {"id":"s1","slug":"s1","projectID":"p1","directory":"/tmp","parentID":null,"title":"Test","version":"1","time":{"created":0,"updated":0},"share":null,"summary":null,"revert":{"messageID":"msg-2","partID":null,"snapshot":"abc","diff":"def"}}
+        """
+        let data = json.data(using: .utf8)!
+        let session = try JSONDecoder().decode(Session.self, from: data)
+        #expect(session.revert?.messageID == "msg-2")
+        #expect(session.revert?.snapshot == "abc")
+        #expect(session.revert?.diff == "def")
+    }
+
     @Test func messageDecoding() throws {
         let json = """
         {"id":"m1","sessionID":"s1","role":"user","parentID":null,"model":{"providerID":"anthropic","modelID":"claude-3"},"time":{"created":0,"completed":null},"finish":null}
@@ -2379,6 +2390,20 @@ actor MockAPIClient: APIClientProtocol {
     )
     var forkSessionError: Error?
     var forkSessionCalls: [(String, String?)] = []
+    var revertSessionResult = Session(
+        id: "s1",
+        slug: "s1",
+        projectID: "p1",
+        directory: "/tmp",
+        parentID: nil,
+        title: "Session",
+        version: "1",
+        time: .init(created: 2, updated: 3, archived: nil),
+        share: nil,
+        summary: nil
+    )
+    var revertSessionError: Error?
+    var revertSessionCalls: [(String, String, String?)] = []
     var messagesResult: [MessageWithParts] = []
     var messagesByLimit: [Int: [MessageWithParts]] = [:]
     var messageLimitRequests: [Int?] = []
@@ -2436,6 +2461,14 @@ actor MockAPIClient: APIClientProtocol {
 
     func setForkSessionError(_ error: Error?) {
         forkSessionError = error
+    }
+
+    func setRevertSessionResult(_ session: Session) {
+        revertSessionResult = session
+    }
+
+    func setRevertSessionError(_ error: Error?) {
+        revertSessionError = error
     }
 
     func configure(baseURL: String, username: String?, password: String?) {
@@ -2535,6 +2568,12 @@ actor MockAPIClient: APIClientProtocol {
         forkSessionCalls.append((sessionID, messageID))
         if let forkSessionError { throw forkSessionError }
         return forkSessionResult
+    }
+
+    func revertSession(sessionID: String, messageID: String, partID: String?) async throws -> Session {
+        revertSessionCalls.append((sessionID, messageID, partID))
+        if let revertSessionError { throw revertSessionError }
+        return revertSessionResult
     }
 }
 
@@ -2759,6 +2798,70 @@ struct AppStateFlowTests {
         #expect(state.messages.count == 1)
         #expect(state.partsByMessage["m1"]?.count == 1)
         #expect(state.partsByMessage["m1"]?.first?.text == "hi")
+    }
+
+    @Test func visibleMessagesHidesRowsAtAndAfterRevertMessageID() {
+        let rows = [
+            Self.makeMessageRow(messageID: "msg-1", sessionID: "s1", role: "user", text: "first"),
+            Self.makeMessageRow(messageID: "msg-2", sessionID: "s1", role: "assistant", text: "reply"),
+            Self.makeMessageRow(messageID: "msg-3", sessionID: "s1", role: "user", text: "edit me"),
+            Self.makeMessageRow(messageID: "msg-4", sessionID: "s1", role: "assistant", text: "old reply"),
+        ]
+
+        let visible = AppState.visibleMessages(rows, revertMessageID: "msg-3")
+
+        #expect(visible.map(\.info.id) == ["msg-1", "msg-2"])
+    }
+
+    @Test @MainActor func editFromMessageCallsRevertAndStoresDraft() async {
+        let apiClient = MockAPIClient()
+        var reverted = Self.makeSession(id: "s1", updated: 20)
+        reverted.revert = .init(messageID: "msg-3", partID: nil, snapshot: nil, diff: nil)
+        await apiClient.setRevertSessionResult(reverted)
+        await apiClient.setMessagesResult([
+            Self.makeMessageRow(messageID: "msg-1", sessionID: "s1", role: "user", text: "first"),
+            Self.makeMessageRow(messageID: "msg-2", sessionID: "s1", role: "assistant", text: "reply"),
+        ])
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.isConnected = true
+        state.sessions = [Self.makeSession(id: "s1", updated: 10)]
+        state.currentSessionID = "s1"
+        state.messages = [
+            Self.makeMessageRow(messageID: "msg-1", sessionID: "s1", role: "user", text: "first"),
+            Self.makeMessageRow(messageID: "msg-2", sessionID: "s1", role: "assistant", text: "reply"),
+            Self.makeMessageRow(messageID: "msg-3", sessionID: "s1", role: "user", text: "edit me"),
+        ]
+
+        let draft = await state.editFromMessage(messageID: "msg-3")
+
+        #expect(draft == "edit me")
+        #expect(state.draftText(for: "s1") == "edit me")
+        #expect(state.currentSession?.revert?.messageID == "msg-3")
+        #expect(state.messages.map(\.info.id) == ["msg-1", "msg-2"])
+        #expect(await apiClient.revertSessionCalls.count == 1)
+        #expect(await apiClient.revertSessionCalls.first?.0 == "s1")
+        #expect(await apiClient.revertSessionCalls.first?.1 == "msg-3")
+        #expect(await apiClient.messagesCallCount == 1)
+    }
+
+    @Test @MainActor func editFromMessageKeepsDraftUnchangedOnFailure() async {
+        let apiClient = MockAPIClient()
+        await apiClient.setRevertSessionError(APIError.invalidURL)
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.isConnected = true
+        state.sessions = [Self.makeSession(id: "s1", updated: 10)]
+        state.currentSessionID = "s1"
+        state.setDraftText("existing draft", for: "s1")
+        state.messages = [
+            Self.makeMessageRow(messageID: "msg-3", sessionID: "s1", role: "user", text: "edit me"),
+        ]
+
+        let draft = await state.editFromMessage(messageID: "msg-3")
+
+        #expect(draft == nil)
+        #expect(state.draftText(for: "s1") == "existing draft")
+        #expect(state.currentSession?.revert == nil)
+        #expect(state.sendError != nil)
     }
 
     @Test @MainActor func loadOlderMessagesIncreasesLimitAndAppliesLargerWindow() async {

--- a/docs/OpenCode_Web_API.md
+++ b/docs/OpenCode_Web_API.md
@@ -134,8 +134,8 @@ OPENCODE_SERVER_USERNAME=admin OPENCODE_SERVER_PASSWORD=secret opencode web
 | DELETE | `/session/:id/share` | 取消分享 | `Session` |
 | GET | `/session/:id/diff` | 会话 diff | `FileDiff[]` |
 | POST | `/session/:id/summarize` | 会话摘要 | `boolean` |
-| POST | `/session/:id/revert` | 回滚某条消息 | `boolean` |
-| POST | `/session/:id/unrevert` | 恢复所有回滚 | `boolean` |
+| POST | `/session/:id/revert` | 回滚某条消息（body: `{ messageID, partID? }`） | `Session` |
+| POST | `/session/:id/unrevert` | 恢复所有回滚 | `Session` |
 | POST | `/session/:id/permissions/:permissionID` | 响应权限请求 | `boolean` |
 
 ### 4.8 Messages（消息与 AI 交互）

--- a/docs/OpenCode_iOS_Client_RFC.md
+++ b/docs/OpenCode_iOS_Client_RFC.md
@@ -140,6 +140,17 @@ let channel = try await client.createDirectTCPIPChannel(
 - 目标是把弱网首屏时延从“全量历史”收敛到“最近可操作上下文”
 - 注意：`limit` 统计单位是 **message**，不是 tool 调用次数。一个 assistant message 可包含多个 tool/text/reasoning parts
 
+#### 3.1.2 Edit from here / message revert（已实现 MVP）
+
+iOS 客户端支持 Web 端同源的 message revert MVP，用于从某条 user message 回到历史位置、把原消息放回 composer，并让用户修改后重新发送。
+
+- 数据模型：`Session` 解码 server 返回的 `revert` 字段，最小字段为 `messageID`、`partID`、`snapshot`、`diff`
+- API：`APIClient.revertSession(sessionID:messageID:partID:)` 调用 `POST /session/:id/revert`，body 为 `{ messageID, partID? }`，返回更新后的 `Session`
+- UI 入口：`MessageRowView` 的 user message 菜单新增 `Edit from here`；busy session 下禁用，避免和 server 的 `assertNotBusy` 冲突
+- 状态编排：`AppState.editFromMessage(messageID:)` 只接受 user message，拼接 text parts 写回 per-session draft，upsert 返回的 session，并刷新 messages / diff / file status
+- 消息可见性：`AppState.visibleMessages(_:revertMessageID:)` 按 OpenCode Web 语义隐藏 `message.id >= revert.messageID` 的已回滚消息；临时 optimistic message 保留
+- 非目标：MVP 不提供 `unrevert` / restore dock / part-level revert；这些行为留给后续需要时再补
+
 #### 3.2 SSE 连接
 
 - 连接 `GET /global/event`

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,11 +4,20 @@
 
 ## 当前状态
 
-- **最后更新**：2026-06-08
-- **分支**：`design/f3-voice-steer`（PR #84）
-- **编译**：✅ iPhone 16 Simulator build 通过
-- **测试**：✅ F3 deterministic composer UI tests 通过
-- **Phase**：F3 voice rail composer ready to merge
+- **最后更新**：2026-06-18
+- **分支**：`feature/revert-message-edit`
+- **编译/测试**：✅ `xcodebuild test` on iPhone 16 Simulator OS 18.4 通过
+- **Phase**：Message revert MVP ready to merge
+
+### 2026-06-18 — Message revert / Edit from here MVP
+
+- 目标收敛为最小可用版：只做 user message 的 `Edit from here`，不做 restore dock、`unrevert` UI 或 part-level revert。
+- 数据协议：`Session` 增加 `revert` 解码；`APIClient` 新增 `POST /session/:id/revert`，按当前 server 返回 `Session` 处理。
+- UI：user message 的 `⋯` 菜单新增 `Edit from here`；busy session 下禁用，避免 server busy 状态下 revert 失败。
+- 状态流：点击后调用 `AppState.editFromMessage`，成功后把原 user text parts 写回 composer draft，upsert returned session，并刷新 messages / diff / file status。
+- 渲染语义：`ChatTabView` 使用 `AppState.visibleMessages`，当 `currentSession.revert.messageID` 存在时隐藏 `message.id >= revert.messageID` 的历史行，与 Web 的 rewind 视图保持一致。
+- 测试：新增 `sessionDecodingWithRevert`、`visibleMessagesHidesRowsAtAndAfterRevertMessageID`、`editFromMessageCallsRevertAndStoresDraft`、`editFromMessageKeepsDraftUnchangedOnFailure`。
+- 验证：`xcodebuild test -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4'` 通过。
 
 ### 2026-06-14 — Markdown Web Preview 真机验收与收口
 


### PR DESCRIPTION
## Summary
- add Session.revert decoding and POST /session/:id/revert client support
- add user-message Edit from here action that reverts server state and restores the prompt into the composer
- filter reverted history in chat and document the MVP behavior

## Tests
- xcodebuild test -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4'