### PR TITLE
feat(chat): support image attachments

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
@@ -169,7 +169,7 @@ extension AppState {
         }
     }
 
-    func sendMessage(_ text: String) async -> Bool {
+    func sendMessage(_ text: String, attachments: [ComposerImageAttachment] = []) async -> Bool {
         sendError = nil
         guard let sessionID = currentSessionID else {
             sendError = L10n.t(.chatSelectSessionFirst)
@@ -184,11 +184,11 @@ extension AppState {
             return false
         }
 
-        let tempMessageID = appendOptimisticUserMessage(text)
+        let tempMessageID = appendOptimisticUserMessage(text, attachments: attachments)
         let model = selectedModel.map { Message.ModelInfo(providerID: $0.providerID, modelID: $0.modelID) }
         let agentName = selectedAgent?.name ?? "build"
         do {
-            try await apiClient.promptAsync(sessionID: sessionID, text: text, agent: agentName, model: model)
+            try await apiClient.promptAsync(sessionID: sessionID, text: text, attachments: attachments, agent: agentName, model: model)
             return true
         } catch {
             let recovered = await recoverFromMissingCurrentSessionIfNeeded(error: error, requestedSessionID: sessionID)
@@ -230,11 +230,10 @@ extension AppState {
     }
 
     @discardableResult
-    func appendOptimisticUserMessage(_ text: String) -> String {
+    func appendOptimisticUserMessage(_ text: String, attachments: [ComposerImageAttachment] = []) -> String {
         guard let sessionID = currentSessionID else { return "" }
         let now = Int(Date().timeIntervalSince1970 * 1000)
         let messageID = "temp-user-\(UUID().uuidString)"
-        let partID = "temp-part-\(messageID)"
         let message = Message(
             id: messageID,
             sessionID: sessionID,
@@ -249,21 +248,41 @@ extension AppState {
             tokens: nil,
             cost: nil
         )
-        let part = Part(
-            id: partID,
-            messageID: messageID,
-            sessionID: sessionID,
-            type: "text",
-            text: text,
-            tool: nil,
-            callID: nil,
-            state: nil,
-            metadata: nil,
-            files: nil
-        )
-        let row = MessageWithParts(info: message, parts: [part])
+        var parts: [Part] = []
+        if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            parts.append(Part(
+                id: "temp-part-\(messageID)",
+                messageID: messageID,
+                sessionID: sessionID,
+                type: "text",
+                text: text,
+                tool: nil,
+                callID: nil,
+                state: nil,
+                metadata: nil,
+                files: nil
+            ))
+        }
+        for attachment in attachments {
+            parts.append(Part(
+                id: "temp-file-\(attachment.id.uuidString)",
+                messageID: messageID,
+                sessionID: sessionID,
+                type: "file",
+                text: nil,
+                tool: nil,
+                callID: nil,
+                state: nil,
+                metadata: nil,
+                files: nil,
+                mime: attachment.mime,
+                filename: attachment.filename,
+                url: attachment.dataURL
+            ))
+        }
+        let row = MessageWithParts(info: message, parts: parts)
         messages.append(row)
-        partsByMessage[messageID] = [part]
+        partsByMessage[messageID] = parts
         return messageID
     }
 

--- a/OpenCodeClient/OpenCodeClient/Models/Message.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Message.swift
@@ -92,6 +92,15 @@ nonisolated struct MessageWithParts: Codable {
     let parts: [Part]
 }
 
+struct ComposerImageAttachment: Identifiable, Equatable {
+    let id: UUID
+    let filename: String
+    let mime: String
+    let dataURL: String
+    let thumbnailData: Data
+    let byteSize: Int
+}
+
 /// Part.state can be String (simple) or object (ToolState with status/title/input/output)
 struct PartStateBridge: Codable {
     let displayString: String
@@ -234,6 +243,10 @@ nonisolated struct Part: Codable, Identifiable {
     let state: PartStateBridge?
     let metadata: PartMetadata?
     let files: [FileChange]?
+    var mime: String? = nil
+    var filename: String? = nil
+    var url: String? = nil
+    var source: String? = nil
 
     /// For UI display; handles both string and object state
     var stateDisplay: String? { state?.displayString }
@@ -347,6 +360,8 @@ nonisolated struct Part: Codable, Identifiable {
     var isReasoning: Bool { type == "reasoning" }
     var isTool: Bool { type == "tool" }
     var isPatch: Bool { type == "patch" }
+    var isFile: Bool { type == "file" }
+    var isImageAttachment: Bool { isFile && (mime?.hasPrefix("image/") ?? false) }
 
     /// 可跳转的文件路径列表：来自 files 数组、metadata.path、或 state.input 中的 path/patchText 解析
     var filePathsForNavigation: [String] {

--- a/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
@@ -257,22 +257,39 @@ actor APIClient {
         return try? decoder.decode(type, from: data)
     }
 
-    func promptAsync(sessionID: String, text: String, agent: String = "build", model: Message.ModelInfo?) async throws {
+    func promptAsync(sessionID: String, text: String, attachments: [ComposerImageAttachment] = [], agent: String = "build", model: Message.ModelInfo?) async throws {
         struct PromptBody: Encodable {
             let parts: [PartInput]
             let agent: String
             let model: ModelInput?
             struct PartInput: Encodable {
-                let type = "text"
-                let text: String
+                let type: String
+                let text: String?
+                let mime: String?
+                let filename: String?
+                let url: String?
+
+                static func text(_ text: String) -> PartInput {
+                    PartInput(type: "text", text: text, mime: nil, filename: nil, url: nil)
+                }
+
+                static func file(_ attachment: ComposerImageAttachment) -> PartInput {
+                    PartInput(type: "file", text: nil, mime: attachment.mime, filename: attachment.filename, url: attachment.dataURL)
+                }
             }
             struct ModelInput: Encodable {
                 let providerID: String
                 let modelID: String
             }
         }
+        var parts: [PromptBody.PartInput] = []
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            parts.append(.text(text))
+        }
+        parts.append(contentsOf: attachments.map { .file($0) })
         let body = PromptBody(
-            parts: [.init(text: text)],
+            parts: parts,
             agent: agent,
             model: model.map { .init(providerID: $0.providerID, modelID: $0.modelID) }
         )
@@ -665,7 +682,7 @@ protocol APIClientProtocol: Actor {
     func updateSessionArchived(sessionID: String, archived: Int) async throws -> Session
     func deleteSession(sessionID: String) async throws
     func messages(sessionID: String, limit: Int?) async throws -> [MessageWithParts]
-    func promptAsync(sessionID: String, text: String, agent: String, model: Message.ModelInfo?) async throws
+    func promptAsync(sessionID: String, text: String, attachments: [ComposerImageAttachment], agent: String, model: Message.ModelInfo?) async throws
     func abort(sessionID: String) async throws
     func sessionStatus() async throws -> [String: SessionStatus]
     func pendingPermissions() async throws -> [APIClient.PermissionRequest]

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import os
 import os.lock
+import PhotosUI
 import VoiceFlowKit
 #if canImport(UIKit)
 import UIKit
@@ -75,6 +76,10 @@ struct ChatTabView: View {
     @State var speechRecoveryActive = false
     @State var speechAudioLevel: Float = 0
     @State var speechAudioLevelTask: Task<Void, Never>?
+    @State private var selectedPhotoItems: [PhotosPickerItem] = []
+    @State private var imageAttachments: [ComposerImageAttachment] = []
+    @State private var attachmentError: String?
+    @State private var isLoadingAttachment = false
     @State private var pendingScrollTask: Task<Void, Never>?
     @State private var pendingBottomVisibilityTask: Task<Void, Never>?
     @State private var isNearBottom = true
@@ -108,7 +113,7 @@ struct ChatTabView: View {
     }
 
     private var canSendNow: Bool {
-        ChatComposerSendGate.canSend(text: inputText, isSending: isSending, hasMarkedText: hasMarkedText)
+        (ChatComposerSendGate.canSend(text: inputText, isSending: isSending, hasMarkedText: hasMarkedText) || (!imageAttachments.isEmpty && !isSending && !hasMarkedText))
             && !isRecording && !isShowingTranscribingUI && !isRetryingSpeech
     }
 
@@ -707,7 +712,33 @@ struct ChatTabView: View {
 
                     voiceRail
 
+                    if !imageAttachments.isEmpty || isLoadingAttachment || attachmentError != nil {
+                        attachmentStrip
+                    }
+
                     HStack(alignment: .bottom, spacing: DesignSpacing.sm) {
+                        PhotosPicker(
+                            selection: $selectedPhotoItems,
+                            maxSelectionCount: 4,
+                            matching: .images
+                        ) {
+                            ZStack {
+                                if isLoadingAttachment {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                } else {
+                                    Image(systemName: "photo")
+                                        .font(DesignControls.composerActionIconFont)
+                                }
+                            }
+                            .frame(width: DesignControls.composerPrimaryActionButtonSize, height: DesignControls.composerPrimaryActionButtonSize)
+                            .foregroundStyle(DesignColors.Brand.primary)
+                            .background(DesignColors.Brand.primary.opacity(0.10))
+                            .clipShape(RoundedRectangle(cornerRadius: DesignCorners.medium))
+                        }
+                        .disabled(isLoadingAttachment || isSending)
+                        .accessibilityIdentifier("chat-attach-image")
+
                         ZStack(alignment: .topLeading) {
                             ChatComposerTextView(
                                 text: $inputText,
@@ -821,6 +852,9 @@ struct ChatTabView: View {
                 guard !isSyncingDraft else { return }
                 state.setDraftText(newValue, for: state.currentSessionID)
             }
+            .onChange(of: selectedPhotoItems) { _, newItems in
+                Task { await loadSelectedPhotos(newItems) }
+            }
             .onChange(of: scenePhase) { _, newPhase in
                 guard newPhase == .background else { return }
                 Task { await stopSpeechForBackground() }
@@ -865,17 +899,65 @@ struct ChatTabView: View {
     }
 
     private func sendCurrentInput() {
-        guard ChatComposerSendGate.canSend(text: inputText, isSending: isSending, hasMarkedText: hasMarkedText) else { return }
+        guard canSendNow else { return }
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let attachments = imageAttachments
 
         inputText = ""
+        imageAttachments = []
+        selectedPhotoItems = []
         hasMarkedText = false
         isSending = true
         Task {
-            let success = await state.sendMessage(text)
+            let success = await state.sendMessage(text, attachments: attachments)
             isSending = false
             if !success {
                 inputText = text
+                imageAttachments = attachments
+            }
+        }
+    }
+
+    private var attachmentStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: DesignSpacing.sm) {
+                ForEach(imageAttachments) { attachment in
+                    ComposerAttachmentThumbnail(attachment: attachment) {
+                        imageAttachments.removeAll { $0.id == attachment.id }
+                    }
+                }
+                if isLoadingAttachment {
+                    ProgressView()
+                        .frame(width: 54, height: 54)
+                }
+                if let attachmentError {
+                    Text(attachmentError)
+                        .font(DesignTypography.micro)
+                        .foregroundStyle(DesignColors.Semantic.error)
+                        .lineLimit(2)
+                }
+            }
+            .padding(.vertical, 6)
+        }
+        .accessibilityIdentifier("chat-attachment-strip")
+    }
+
+    private func loadSelectedPhotos(_ items: [PhotosPickerItem]) async {
+        guard !items.isEmpty else { return }
+        attachmentError = nil
+        isLoadingAttachment = true
+        defer {
+            isLoadingAttachment = false
+            selectedPhotoItems = []
+        }
+
+        for item in items {
+            do {
+                guard let data = try await item.loadTransferable(type: Data.self) else { continue }
+                let attachment = try ComposerImageTranscoder.makeAttachment(from: data)
+                imageAttachments.append(attachment)
+            } catch {
+                attachmentError = error.localizedDescription
             }
         }
     }
@@ -986,6 +1068,88 @@ struct ChatTabView: View {
                 ) else { return }
                 showSessionList = true
             }
+    }
+}
+
+private struct ComposerAttachmentThumbnail: View {
+    let attachment: ComposerImageAttachment
+    let onRemove: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            if let image = UIImage(data: attachment.thumbnailData) {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 54, height: 54)
+                    .clipShape(RoundedRectangle(cornerRadius: DesignCorners.medium))
+            } else {
+                RoundedRectangle(cornerRadius: DesignCorners.medium)
+                    .fill(DesignColors.Neutral.text.opacity(0.08))
+                    .frame(width: 54, height: 54)
+                    .overlay(Image(systemName: "photo"))
+            }
+
+            Button(action: onRemove) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.caption)
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, DesignColors.Neutral.textSecondary)
+            }
+            .offset(x: 6, y: -6)
+            .accessibilityLabel("Remove image")
+        }
+        .accessibilityIdentifier("chat-attachment-thumbnail")
+    }
+}
+
+private enum ComposerImageTranscoder {
+    static let maxDimension: CGFloat = 2048
+    static let jpegQuality: CGFloat = 0.82
+    static let maxByteSize = 5 * 1024 * 1024
+
+    enum TranscodeError: LocalizedError {
+        case invalidImage
+        case tooLarge(Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidImage:
+                return "Could not read the selected image."
+            case .tooLarge(let bytes):
+                return "Image is too large after compression (\(ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)))."
+            }
+        }
+    }
+
+    static func makeAttachment(from data: Data) throws -> ComposerImageAttachment {
+        guard let image = UIImage(data: data) else { throw TranscodeError.invalidImage }
+        let resized = resize(image, maxDimension: maxDimension)
+        guard let jpeg = resized.jpegData(compressionQuality: jpegQuality) else { throw TranscodeError.invalidImage }
+        guard jpeg.count <= maxByteSize else { throw TranscodeError.tooLarge(jpeg.count) }
+        let thumb = resize(resized, maxDimension: 240).jpegData(compressionQuality: 0.75) ?? jpeg
+        let base64 = jpeg.base64EncodedString()
+        let id = UUID()
+        return ComposerImageAttachment(
+            id: id,
+            filename: "image-\(id.uuidString.prefix(8)).jpg",
+            mime: "image/jpeg",
+            dataURL: "data:image/jpeg;base64,\(base64)",
+            thumbnailData: thumb,
+            byteSize: jpeg.count
+        )
+    }
+
+    private static func resize(_ image: UIImage, maxDimension: CGFloat) -> UIImage {
+        let size = image.size
+        let longest = max(size.width, size.height)
+        guard longest > maxDimension, longest > 0 else { return image }
+        let scale = maxDimension / longest
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: newSize))
+        }
     }
 }
 

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -31,6 +31,7 @@ struct MessageRowView: View {
     private enum AssistantBlock: Identifiable {
         case text(Part)
         case cards([Part])
+        case attachment(Part)
 
         var id: String {
             switch self {
@@ -40,6 +41,8 @@ struct MessageRowView: View {
                 let first = parts.first?.id ?? "nil"
                 let last = parts.last?.id ?? "nil"
                 return "cards-\(first)-\(last)"
+            case .attachment(let part):
+                return "attachment-\(part.id)"
             }
         }
     }
@@ -73,6 +76,9 @@ struct MessageRowView: View {
             if part.isText {
                 flushBuffer()
                 blocks.append(.text(part))
+            } else if part.isFile {
+                flushBuffer()
+                blocks.append(.attachment(part))
             } else {
                 flushBuffer()
             }
@@ -194,6 +200,12 @@ struct MessageRowView: View {
                             .padding(.horizontal, 14)
                             .padding(.vertical, 10)
                     }
+                    let attachments = message.parts.filter { $0.isFile }
+                    if !attachments.isEmpty {
+                        MessageAttachmentsGrid(parts: attachments)
+                            .padding(.horizontal, 14)
+                            .padding(.bottom, 10)
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -246,6 +258,8 @@ struct MessageRowView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 case .cards(let parts):
                     cardsBlock(parts)
+                case .attachment(let part):
+                    MessageAttachmentView(part: part)
                 }
             }
 
@@ -328,5 +342,102 @@ struct MessageRowView: View {
         .background(DesignColors.Neutral.text.opacity(DesignColors.surfaceFill(for: colorScheme)))
         .clipShape(RoundedRectangle(cornerRadius: DesignCorners.medium))
         .accessibilityIdentifier("toolcard.toolcalls")
+    }
+}
+
+private struct MessageAttachmentsGrid: View {
+    let parts: [Part]
+
+    private var columns: [GridItem] {
+        [GridItem(.adaptive(minimum: 120, maximum: 180), spacing: DesignSpacing.sm)]
+    }
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: DesignSpacing.sm) {
+            ForEach(parts, id: \.id) { part in
+                MessageAttachmentView(part: part)
+            }
+        }
+    }
+}
+
+private struct MessageAttachmentView: View {
+    let part: Part
+    @State private var showImage = false
+
+    private var imageData: Data? {
+        guard part.isImageAttachment, let url = part.url else { return nil }
+        return Self.decodeDataURL(url)
+    }
+
+    var body: some View {
+        Group {
+            if let imageData, let image = UIImage(data: imageData) {
+                Button {
+                    showImage = true
+                } label: {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 140, height: 100)
+                        .clipShape(RoundedRectangle(cornerRadius: DesignCorners.medium))
+                        .overlay(alignment: .bottomLeading) {
+                            Text(part.filename ?? "Image")
+                                .font(DesignTypography.micro)
+                                .lineLimit(1)
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 4)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(.black.opacity(0.45))
+                        }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("message-attachment-image")
+                .sheet(isPresented: $showImage) {
+                    NavigationStack {
+                        ImageView(uiImage: image)
+                            .navigationTitle(part.filename ?? "Image")
+                            .navigationBarTitleDisplayMode(.inline)
+                            .toolbar {
+                                ToolbarItem(placement: .cancellationAction) {
+                                    Button("Done") { showImage = false }
+                                }
+                            }
+                    }
+                }
+            } else {
+                HStack(spacing: DesignSpacing.sm) {
+                    Image(systemName: "paperclip")
+                        .foregroundStyle(DesignColors.Brand.primary)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(part.filename ?? "Attachment")
+                            .font(DesignTypography.meta)
+                            .lineLimit(1)
+                        if let mime = part.mime {
+                            Text(mime)
+                                .font(DesignTypography.micro)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+                .padding(DesignSpacing.cardPadding)
+                .background(DesignColors.Neutral.text.opacity(0.06))
+                .clipShape(RoundedRectangle(cornerRadius: DesignCorners.medium))
+                .accessibilityIdentifier("message-attachment-file")
+            }
+        }
+    }
+
+    private static func decodeDataURL(_ url: String) -> Data? {
+        guard let comma = url.firstIndex(of: ",") else { return nil }
+        let metadata = url[..<comma]
+        guard metadata.contains(";base64") else { return nil }
+        let raw = url[url.index(after: comma)...]
+            .replacingOccurrences(of: "\n", with: "")
+            .replacingOccurrences(of: "\r", with: "")
+            .replacingOccurrences(of: " ", with: "")
+        return Data(base64Encoded: raw)
     }
 }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -83,6 +83,18 @@ struct OpenCodeClientTests {
         #expect(message.isUser == true)
     }
 
+    @Test func filePartDecoding() throws {
+        let json = """
+        {"id":"p-file","messageID":"m1","sessionID":"s1","type":"file","text":null,"tool":null,"callID":null,"state":null,"metadata":null,"files":null,"mime":"image/jpeg","filename":"photo.jpg","url":"data:image/jpeg;base64,AAA","source":null}
+        """
+        let part = try JSONDecoder().decode(Part.self, from: Data(json.utf8))
+        #expect(part.isFile)
+        #expect(part.isImageAttachment)
+        #expect(part.mime == "image/jpeg")
+        #expect(part.filename == "photo.jpg")
+        #expect(part.url == "data:image/jpeg;base64,AAA")
+    }
+
     @Test func messageDecodingWithoutTokenTotal() throws {
         let json = """
         {"id":"m2","sessionID":"s1","role":"assistant","parentID":"m1","providerID":"openai","modelID":"gpt-5.2","time":{"created":0,"completed":1},"finish":"stop","tokens":{"input":10,"output":2,"reasoning":3,"cache":{"read":0,"write":0}}}
@@ -2409,7 +2421,7 @@ actor MockAPIClient: APIClientProtocol {
     var messageLimitRequests: [Int?] = []
     var messagesCallCount = 0
     var promptError: Error?
-    var promptAsyncCalls: [(String, String)] = []
+    var promptAsyncCalls: [(String, String, [ComposerImageAttachment])] = []
     var deletedSessionIDs: [String] = []
     var updateSessionCalls: [(String, String)] = []
     var updateSessionArchivedCalls: [(String, Int)] = []
@@ -2533,8 +2545,8 @@ actor MockAPIClient: APIClientProtocol {
         return messagesResult
     }
 
-    func promptAsync(sessionID: String, text: String, agent: String, model: Message.ModelInfo?) async throws {
-        promptAsyncCalls.append((sessionID, text))
+    func promptAsync(sessionID: String, text: String, attachments: [ComposerImageAttachment], agent: String, model: Message.ModelInfo?) async throws {
+        promptAsyncCalls.append((sessionID, text, attachments))
         if let promptError { throw promptError }
     }
 
@@ -2798,6 +2810,36 @@ struct AppStateFlowTests {
         #expect(state.messages.count == 1)
         #expect(state.partsByMessage["m1"]?.count == 1)
         #expect(state.partsByMessage["m1"]?.first?.text == "hi")
+    }
+
+    @Test @MainActor func appendOptimisticUserMessageIncludesImageAttachmentPart() {
+        let state = AppState(apiClient: MockAPIClient(), sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.currentSessionID = "s1"
+        let attachment = Self.makeAttachment(filename: "photo.jpg")
+
+        let tempMessageID = state.appendOptimisticUserMessage("look", attachments: [attachment])
+
+        let parts = state.partsByMessage[tempMessageID] ?? []
+        #expect(parts.map(\.type) == ["text", "file"])
+        #expect(parts.last?.mime == "image/jpeg")
+        #expect(parts.last?.filename == "photo.jpg")
+        #expect(parts.last?.url == attachment.dataURL)
+    }
+
+    @Test @MainActor func sendMessagePassesImageAttachmentsToAPI() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.currentSessionID = "s1"
+        let attachment = Self.makeAttachment(filename: "photo.jpg")
+
+        let success = await state.sendMessage("look", attachments: [attachment])
+
+        #expect(success)
+        let calls = await apiClient.promptAsyncCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].0 == "s1")
+        #expect(calls[0].1 == "look")
+        #expect(calls[0].2 == [attachment])
     }
 
     @Test func visibleMessagesHidesRowsAtAndAfterRevertMessageID() {
@@ -3255,6 +3297,17 @@ struct AppStateFlowTests {
             files: nil
         )
         return MessageWithParts(info: message, parts: [part])
+    }
+
+    private static func makeAttachment(filename: String) -> ComposerImageAttachment {
+        ComposerImageAttachment(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            filename: filename,
+            mime: "image/jpeg",
+            dataURL: "data:image/jpeg;base64,AAA",
+            thumbnailData: Data([0x01, 0x02]),
+            byteSize: 3
+        )
     }
 }
 

--- a/docs/OpenCode_Web_API.md
+++ b/docs/OpenCode_Web_API.md
@@ -145,7 +145,7 @@ OPENCODE_SERVER_USERNAME=admin OPENCODE_SERVER_PASSWORD=secret opencode web
 | GET | `/session/:id/message` | 列出会话消息 | `{ info, parts }[]` |
 | POST | `/session/:id/message` | 发送消息并等待响应 | `{ info, parts }` |
 | GET | `/session/:id/message/:messageID` | 单条消息详情 | `{ info, parts }` |
-| POST | `/session/:id/prompt_async` | 异步发送消息（不等待） | `204 No Content` |
+| POST | `/session/:id/prompt_async` | 异步发送消息（不等待）；body `parts` 可包含 `text` / `file`（图片使用 `data:` URL） | `204 No Content` |
 | POST | `/session/:id/command` | 执行 slash 命令 | `{ info, parts }` |
 | POST | `/session/:id/shell` | 执行 shell 命令 | `{ info, parts }` |
 

--- a/docs/OpenCode_iOS_Client_RFC.md
+++ b/docs/OpenCode_iOS_Client_RFC.md
@@ -151,6 +151,17 @@ iOS 客户端支持 Web 端同源的 message revert MVP，用于从某条 user m
 - 消息可见性：`AppState.visibleMessages(_:revertMessageID:)` 按 OpenCode Web 语义隐藏 `message.id >= revert.messageID` 的已回滚消息；临时 optimistic message 保留
 - 非目标：MVP 不提供 `unrevert` / restore dock / part-level revert；这些行为留给后续需要时再补
 
+#### 3.1.3 Image attachments（已实现 Phase 1/2）
+
+iOS 图片支持与 OpenCode Web 保持同构：图片作为 prompt 的 `file` part 发送，`url` 使用 `data:<mime>;base64,...`，不新增独立 upload endpoint。
+
+- 发送模型：`APIClient.promptAsync` 支持 mixed parts；文本生成 `type: "text"`，图片生成 `type: "file"`、`mime`、`filename`、`url`
+- Composer：`ChatTabView` 使用 `PhotosPicker` 选择图片，最多 4 张；本地转 JPEG data URL，最长边 2048，JPEG quality 0.82，压缩后单图上限 5MB
+- 失败恢复：发送失败时恢复文本和附件状态；optimistic user message 同时包含 text part 与 file part
+- 渲染模型：`Part` 解码 `mime`、`filename`、`url`、`source`；`MessageRowView` 对 `type == "file"` 渲染图片缩略图或 fallback file card
+- 图片预览：历史 image attachment 点击后复用现有 `ImageView` zoom/pan 预览
+- 非目标：本轮不做 Files app 文件选择、PDF/text 附件、跨重启附件草稿持久化、server-side upload 或大 payload 分片
+
 #### 3.2 SSE 连接
 
 - 连接 `GET /global/event`

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -5,9 +5,19 @@
 ## 当前状态
 
 - **最后更新**：2026-06-18
-- **分支**：`feature/revert-message-edit`
+- **分支**：`feature/image-attachments`
 - **编译/测试**：✅ `xcodebuild test` on iPhone 16 Simulator OS 18.4 通过
-- **Phase**：Message revert MVP ready to merge
+- **Phase**：Image attachments Phase 1/2 ready to merge
+
+### 2026-06-18 — Image attachments Phase 1/2
+
+- 范围按本轮决策收敛为前两阶段：发送相册图片 + 渲染历史 image/file part；不做 Files app、PDF/text 附件或 server-side upload。
+- 协议：`Part` 增加 `mime` / `filename` / `url` / `source`；`APIClient.promptAsync` 支持 mixed text/file parts，图片使用 Web 同构的 `data:image/jpeg;base64,...`。
+- Composer：新增 `PhotosPicker` 附件按钮和横向缩略图 strip；选择图片后本地转 JPEG，最长边 2048、quality 0.82、单图压缩后 5MB 上限；发送失败会恢复文本和附件。
+- Optimistic UI：`appendOptimisticUserMessage` 可生成 text + file parts，用户发送后立即看到图片附件。
+- 渲染：`MessageRowView` 对 user/assistant 的 `type == "file"` 都有显示路径；image part 显示缩略图并可点开 `ImageView` zoom/pan，非图片显示 fallback file card。
+- 测试：新增 `filePartDecoding`、`appendOptimisticUserMessageIncludesImageAttachmentPart`、`sendMessagePassesImageAttachmentsToAPI`。
+- 验证：`xcodebuild test -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4'` 通过。
 
 ### 2026-06-18 — Message revert / Edit from here MVP
 


### PR DESCRIPTION
## Summary
- add composer image selection with PhotosPicker and JPEG data URL conversion
- send mixed text/file prompt parts through prompt_async
- decode and render historical file/image parts with image preview support
- document image attachment Phase 1/2 scope

## Tests
- xcodebuild test -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4'