### PR TITLE
feat(models): replace Ollama Kimi K2.6 with Ollama GLM 5.2

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+Models.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Models.swift
@@ -21,6 +21,8 @@ extension AppState {
             return "zai-coding-plan/glm-5.2"
         case "openai/gpt-5.4":
             return "openai/gpt-5.5"
+        case "ollama-cloud/kimi-k2.6":
+            return "ollama-cloud/glm-5.2"
         default:
             return savedID
         }

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -389,7 +389,7 @@ final class AppState {
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),
         ModelPreset(displayName: "Ollama DeepSeek V4 Pro", providerID: "ollama-cloud", modelID: "deepseek-v4-pro"),
-        ModelPreset(displayName: "Ollama Kimi K2.6", providerID: "ollama-cloud", modelID: "kimi-k2.6"),
+        ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2"),
     ]
     var selectedModelIndex: Int = 2
     

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -17,7 +17,7 @@ struct ModelPreset: Codable, Identifiable {
         case "DeepSeek Local": return "DS-L"
         case "DeepSeek V4 Pro": return "DS-Pro"
         case "Ollama DeepSeek V4 Pro": return "ODS-Pro"
-        case "Ollama Kimi K2.6": return "Kimi"
+        case "Ollama GLM 5.2": return "GLM"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"
         default: return displayName

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1667,6 +1667,11 @@ struct ModelPresetShortNameTests {
         let preset = ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash")
         #expect(preset.shortName == "DS-L")
     }
+
+    @Test func ollamaGLMShortName() {
+        let preset = ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2")
+        #expect(preset.shortName == "GLM")
+    }
     
     @Test func geminiShortName() {
         let preset = ModelPreset(displayName: "Gemini 3.1 Pro", providerID: "google", modelID: "gemini-3.1-pro")
@@ -1766,6 +1771,34 @@ struct ModelSelectionPersistenceTests {
             #expect(state.selectedModelIndex == 1)
             #expect(state.modelPresets[state.selectedModelIndex].displayName == "GPT-5.5")
             #expect(state.modelPresets[state.selectedModelIndex].id == "openai/gpt-5.5")
+        }
+    }
+
+    @Test @MainActor func legacyKimiSelectionMapsToCurrentOllamaGLMPreset() {
+        withIsolatedModelSelectionDefaults {
+            let sessionID = "session-glm-ollama"
+            let legacySelection = [sessionID: "ollama-cloud/kimi-k2.6"]
+            let encoded = try! JSONEncoder().encode(legacySelection)
+            UserDefaults.standard.set(encoded, forKey: selectedModelDefaultsKey)
+
+            let state = AppState()
+            let session = Session(
+                id: sessionID,
+                slug: sessionID,
+                projectID: "p1",
+                directory: "/tmp",
+                parentID: nil,
+                title: sessionID,
+                version: "1",
+                time: .init(created: 0, updated: 100, archived: nil),
+                share: nil,
+                summary: nil
+            )
+
+            state.selectSession(session)
+
+            #expect(state.modelPresets[state.selectedModelIndex].displayName == "Ollama GLM 5.2")
+            #expect(state.modelPresets[state.selectedModelIndex].id == "ollama-cloud/glm-5.2")
         }
     }
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -43,6 +43,12 @@
   - "状态卡当百科条目写"被列为反模式，明确卡片/表格/`<details>` 的边界
 - **文档合并**：`Markdown_Web_Preview_PRD.md` / `Markdown_Web_Preview_RFC.md` 的最终决策状态合并进主 PRD §4.3.5 / 主 RFC §7.5（用 visual 表格 + `<details>` 形式，本身就是 dogfood）。两份子文档保留在磁盘但 `git rm --cached` 移除跟踪并加进 `.gitignore`，决策过程在此 WORKING.md。
 
+### 2026-06-20 — Ollama Cloud GLM 5.2 model preset
+
+- 模型列表中将 `Ollama Kimi K2.6`（`ollama-cloud/kimi-k2.6`）替换为 `Ollama GLM 5.2`（`ollama-cloud/glm-5.2`）。OpenCode server 的 `ollama-cloud` provider registry 已通过 `scripts/regen_models_local.py` 的 `INJECTIONS` 注入 `glm-5.2` 条目（见 `opencode-official/skills/update_models.md`），model key 是 `glm-5.2`。
+- `ModelPreset.shortName` 从 `Ollama Kimi K2.6 -> Kimi` 改为 `Ollama GLM 5.2 -> GLM`，保持窄屏 model chip 简短。
+- `canonicalModelPresetID` 新增 `ollama-cloud/kimi-k2.6 -> ollama-cloud/glm-5.2`，让之前选中 Kimi 的 session 平滑迁移到新 preset 而非掉回默认。
+
 ### 2026-06-10 — Ollama Cloud Kimi model preset
 
 - 模型列表中将 `MiniMax M3`（`ollama-cloud/minimax-m3`）替换为 `Ollama Kimi K2.6`（`ollama-cloud/kimi-k2.6`）。OpenCode server 的 `ollama-cloud` provider registry 暴露的 model key 是 `kimi-k2.6`；直接传 Ollama library tag `kimi-k2.6:cloud` 会让 `prompt_async` 返回 204 但后台不生成 assistant message。


### PR DESCRIPTION
Replace the bottom model preset from Ollama Kimi K2.6 (`ollama-cloud/kimi-k2.6`) to Ollama GLM 5.2 (`ollama-cloud/glm-5.2`).

**Changes**
- `AppState.swift`: preset displayName/modelID swapped
- `ModelPreset.swift`: shortName chip `Ollama GLM 5.2 -> GLM`
- `AppState+Models.swift`: legacy `ollama-cloud/kimi-k2.6` saved selection maps to `ollama-cloud/glm-5.2` so existing sessions migrate instead of falling back to default
- Tests: `ollamaGLMShortName` + `legacyKimiSelectionMapsToCurrentOllamaGLMPreset`
- `docs/WORKING.md` changelog

**Verification**
- `xcodebuild build` + `xcodebuild test -only-testing:OpenCodeClientTests` on iPhone 17 simulator: TEST SUCCEEDED