### PR TITLE
fix(models): distinguish Ollama GLM shortName as OGLM-5.2

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -17,7 +17,7 @@ struct ModelPreset: Codable, Identifiable {
         case "DeepSeek Local": return "DS-L"
         case "DeepSeek V4 Pro": return "DS-Pro"
         case "Ollama DeepSeek V4 Pro": return "ODS-Pro"
-        case "Ollama GLM 5.2": return "GLM"
+        case "Ollama GLM 5.2": return "OGLM-5.2"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"
         default: return displayName

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1670,7 +1670,7 @@ struct ModelPresetShortNameTests {
 
     @Test func ollamaGLMShortName() {
         let preset = ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2")
-        #expect(preset.shortName == "GLM")
+        #expect(preset.shortName == "OGLM-5.2")
     }
     
     @Test func geminiShortName() {

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -46,7 +46,7 @@
 ### 2026-06-20 — Ollama Cloud GLM 5.2 model preset
 
 - 模型列表中将 `Ollama Kimi K2.6`（`ollama-cloud/kimi-k2.6`）替换为 `Ollama GLM 5.2`（`ollama-cloud/glm-5.2`）。OpenCode server 的 `ollama-cloud` provider registry 已通过 `scripts/regen_models_local.py` 的 `INJECTIONS` 注入 `glm-5.2` 条目（见 `opencode-official/skills/update_models.md`），model key 是 `glm-5.2`。
-- `ModelPreset.shortName` 从 `Ollama Kimi K2.6 -> Kimi` 改为 `Ollama GLM 5.2 -> GLM`，保持窄屏 model chip 简短。
+- `ModelPreset.shortName` 从 `Ollama Kimi K2.6 -> Kimi` 改为 `Ollama GLM 5.2 -> OGLM-5.2`（加 O 前缀和版本号，与顶部 `GLM-5.2` preset 的 shortName 区分），保持窄屏 model chip 简短。
 - `canonicalModelPresetID` 新增 `ollama-cloud/kimi-k2.6 -> ollama-cloud/glm-5.2`，让之前选中 Kimi 的 session 平滑迁移到新 preset 而非掉回默认。
 
 ### 2026-06-10 — Ollama Cloud Kimi model preset


### PR DESCRIPTION
Follow-up to #102. Top preset `GLM-5.2` (zai-coding-plan) and bottom `Ollama GLM 5.2` both collapsed to `GLM` chip, making them indistinguishable in the selector.

Change Ollama GLM 5.2 shortName to `OGLM-5.2` to preserve the Ollama provenance and version. Aligns with the Android client.

**Verification**
- `xcodebuild test`: TEST SUCCEEDED