### PR TITLE
Align SSH onboarding with gateway ports

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Services/SSHTunnelManager.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/SSHTunnelManager.swift
@@ -113,9 +113,9 @@ private final class SSHTOFUHostKeyValidator: NIOSSHClientServerAuthenticationDel
 struct SSHTunnelConfig: Codable, Equatable {
     var isEnabled: Bool = false
     var host: String = ""
-    var port: Int = 22
-    var username: String = ""
-    var remotePort: Int = 18080
+    var port: Int = 8006
+    var username: String = "opencode"
+    var remotePort: Int = 19001
     
     var isValid: Bool {
         !host.isEmpty && !username.isEmpty && port > 0 && remotePort > 0
@@ -132,7 +132,7 @@ struct SSHTunnelConfig: Codable, Equatable {
             return "SSH Port must be > 0"
         }
         if remotePort <= 0 {
-            return "VPS Port must be > 0"
+            return "Assigned Remote Port must be > 0"
         }
         return nil
     }
@@ -343,7 +343,7 @@ final class SSHTunnelManager: ObservableObject {
         conn.start(queue: queue)
 
         Task { [weak self] in
-            let snapshot = await self?.connectionSnapshot() ?? (localPort: 4096, remotePort: 18080)
+            let snapshot = await self?.connectionSnapshot() ?? (localPort: 4096, remotePort: 19001)
 
             do {
                 let originator = try SocketAddress(ipAddress: "127.0.0.1", port: snapshot.localPort)

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -42,6 +42,7 @@ enum L10n {
         case settingsVpsHost
         case settingsSshPort
         case settingsVpsPort
+        case settingsAssignedRemotePort
         case settingsSetServerAddress
         case settingsKnownHost
         case settingsResetTrustedHost
@@ -51,6 +52,9 @@ enum L10n {
         case settingsNoTunnelCommand
         case settingsSshTunnel
         case settingsSshTunnelHelp
+        case settingsSshSetupGuide
+        case settingsSshSetupGuideTitle
+        case settingsSshSetupGuideBody
         case settingsAutoTheme
         case settingsLightTheme
         case settingsDarkTheme
@@ -279,17 +283,21 @@ enum L10n {
         Key.settingsAfterEnableSshTip.rawValue: "After enabling SSH Tunnel, tap Test Connection in Server Connection above.",
         Key.settingsVpsHost.rawValue: "VPS Host",
         Key.settingsSshPort.rawValue: "SSH Port",
-        Key.settingsVpsPort.rawValue: "VPS Port",
+        Key.settingsVpsPort.rawValue: "Remote Port",
+        Key.settingsAssignedRemotePort.rawValue: "Assigned Remote Port",
         Key.settingsSetServerAddress.rawValue: "Set Server Address to 127.0.0.1:4096",
         Key.settingsKnownHost.rawValue: "Known Host",
         Key.settingsResetTrustedHost.rawValue: "Reset Trusted Host",
         Key.settingsCopyPublicKey.rawValue: "Copy Public Key",
         Key.settingsPublicKeyCopied.rawValue: "Public Key Copied",
         Key.settingsViewPublicKey.rawValue: "View Public Key",
-        Key.settingsReverseTunnelCommand.rawValue: "Reverse Tunnel Command",
-        Key.settingsNoTunnelCommand.rawValue: "Fill VPS Host, SSH Port, Username, and VPS Port to generate the reverse tunnel command.",
+        Key.settingsReverseTunnelCommand.rawValue: "SSH Tunnel Command",
+        Key.settingsNoTunnelCommand.rawValue: "Fill Host, SSH Port, Username, and Assigned Remote Port.",
         Key.settingsSshTunnel.rawValue: "SSH Tunnel",
-        Key.settingsSshTunnelHelp.rawValue: "Forwards iOS 127.0.0.1:4096 to VPS 127.0.0.1:<VPS Port>. 1) Copy the public key and add it to VPS ~/.ssh/authorized_keys. 2) Run the generated reverse tunnel command on your computer. 3) First connect uses TOFU to trust host key; later connections must match. 4) Set Server Address to 127.0.0.1:4096 and tap Test Connection above.",
+        Key.settingsSshTunnelHelp.rawValue: "Connects local 127.0.0.1:4096 through SSH to the assigned OpenCode remote port. Copy this device's public key to the server admin before connecting.",
+        Key.settingsSshSetupGuide.rawValue: "Setup Guide",
+        Key.settingsSshSetupGuideTitle.rawValue: "SSH Gateway Setup",
+        Key.settingsSshSetupGuideBody.rawValue: "1. Tap Copy Public Key and send it to the server admin.\n\n2. The admin adds this device key to your user and gives you Host, SSH Port, Username, and Assigned Remote Port. For opencode-private-host, Username is usually opencode, SSH Port is usually 8006, and the first user's Remote Port is usually 19001.\n\n3. Fill those values here, enable SSH Tunnel, then tap Set Server Address to 127.0.0.1:4096.\n\n4. Tap Test Connection. The app will connect to local 127.0.0.1:4096; the SSH tunnel forwards it to your private OpenCode container.\n\n5. If provider auth is not configured yet, ask the admin to complete the first provider login in the OpenCode Web UI.",
         Key.settingsAutoTheme.rawValue: "Auto",
         Key.settingsLightTheme.rawValue: "Light",
         Key.settingsDarkTheme.rawValue: "Dark",
@@ -307,7 +315,7 @@ enum L10n {
         Key.settingsRotateKeyTitle.rawValue: "Rotate SSH Key?",
         Key.settingsRotateKeyPrompt.rawValue: "This will generate a new key pair. You will need to update the public key on your VPS.",
         Key.settingsPublicKeyTitle.rawValue: "Your Public Key",
-        Key.settingsPublicKeyFooter.rawValue: "Add this key to your VPS: ~/.ssh/authorized_keys",
+        Key.settingsPublicKeyFooter.rawValue: "Send this public key to the server admin. Do not share your private key.",
         Key.settingsCopyToClipboard.rawValue: "Copy to Clipboard",
         Key.settingsPublicKeyCopyFailed.rawValue: "Unable to load SSH public key.",
         Key.settingsPublicKeyRotate.rawValue: "Rotate Key",
@@ -517,17 +525,21 @@ enum L10n {
         Key.settingsAfterEnableSshTip.rawValue: "开启 SSH 隧道后，请在上方 Server Connection 点击 Test Connection。",
         Key.settingsVpsHost.rawValue: "VPS 地址",
         Key.settingsSshPort.rawValue: "SSH 端口",
-        Key.settingsVpsPort.rawValue: "VPS 端口",
+        Key.settingsVpsPort.rawValue: "远端端口",
+        Key.settingsAssignedRemotePort.rawValue: "分配的远端端口",
         Key.settingsSetServerAddress.rawValue: "将服务器地址设置为 127.0.0.1:4096",
         Key.settingsKnownHost.rawValue: "Known Host",
         Key.settingsResetTrustedHost.rawValue: "重置已信任主机",
         Key.settingsCopyPublicKey.rawValue: "复制公钥",
         Key.settingsPublicKeyCopied.rawValue: "公钥已复制",
         Key.settingsViewPublicKey.rawValue: "查看公钥",
-        Key.settingsReverseTunnelCommand.rawValue: "反向隧道命令",
-        Key.settingsNoTunnelCommand.rawValue: "请先填写 VPS Host、SSH Port、Username、VPS Port 来生成反向隧道命令。",
+        Key.settingsReverseTunnelCommand.rawValue: "SSH 隧道命令",
+        Key.settingsNoTunnelCommand.rawValue: "请先填写 Host、SSH Port、Username 和分配的远端端口。",
         Key.settingsSshTunnel.rawValue: "SSH 隧道",
-        Key.settingsSshTunnelHelp.rawValue: "将 iOS 127.0.0.1:4096 转发到 VPS 127.0.0.1:<VPS Port>。1）将公钥加到 VPS ~/.ssh/authorized_keys。2）在本机运行生成的反向隧道命令。3）首次连接使用 TOFU 方式信任主机指纹，后续连接需匹配该主机。4）将 Server Address 设置为 127.0.0.1:4096 并点击上方 Test Connection。",
+        Key.settingsSshTunnelHelp.rawValue: "通过 SSH 把本机 127.0.0.1:4096 连到服务器分配的 OpenCode 远端端口。连接前先把本设备公钥发给管理员添加。",
+        Key.settingsSshSetupGuide.rawValue: "设置说明",
+        Key.settingsSshSetupGuideTitle.rawValue: "SSH 网关设置",
+        Key.settingsSshSetupGuideBody.rawValue: "1. 点击复制公钥，把它发给服务器管理员。\n\n2. 管理员把这台设备的 key 加到你的用户下面，并给你 Host、SSH Port、Username 和分配的 Remote Port。opencode-private-host 默认 Username 通常是 opencode，SSH Port 通常是 8006，第一个用户的 Remote Port 通常是 19001。\n\n3. 在这里填入这些值，开启 SSH Tunnel，然后点击“将服务器地址设置为 127.0.0.1:4096”。\n\n4. 点击测试连接。App 会访问本机 127.0.0.1:4096，SSH 隧道会把它转发到你的私有 OpenCode 容器。\n\n5. 如果 provider auth 还没配置，请让管理员先在 OpenCode Web UI 里完成第一次 provider 登录。",
         Key.settingsAutoTheme.rawValue: "自动",
         Key.settingsLightTheme.rawValue: "亮色",
         Key.settingsDarkTheme.rawValue: "暗色",
@@ -545,7 +557,7 @@ enum L10n {
         Key.settingsRotateKeyTitle.rawValue: "要更换 SSH Key 吗？",
         Key.settingsRotateKeyPrompt.rawValue: "这将生成新的一对密钥。请同步更新 VPS 上的公钥。",
         Key.settingsPublicKeyTitle.rawValue: "你的公钥",
-        Key.settingsPublicKeyFooter.rawValue: "请将公钥添加到 VPS 的 ~/.ssh/authorized_keys",
+        Key.settingsPublicKeyFooter.rawValue: "把这个公钥发给服务器管理员。不要分享私钥。",
         Key.settingsCopyToClipboard.rawValue: "复制到剪贴板",
         Key.settingsPublicKeyCopyFailed.rawValue: "无法加载 SSH 公钥。",
         Key.settingsPublicKeyRotate.rawValue: "旋转密钥",

--- a/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
@@ -11,8 +11,8 @@ struct SettingsTabView: View {
 
     @State private var showPublicKeySheet = false
     @State private var showRotateKeyAlert = false
+    @State private var showSSHSetupGuide = false
     @State private var copiedPublicKey = false
-    @State private var copiedTunnelCommand = false
     @State private var publicKeyForSheet = ""
     @State private var sshConfig: SSHTunnelConfig = .default
     @State private var publicKeyLoadError: String?
@@ -173,7 +173,7 @@ struct SettingsTabView: View {
                             }
                         
                         HStack {
-                            Text(L10n.t(.settingsVpsPort))
+                            Text(L10n.t(.settingsAssignedRemotePort))
                             Spacer()
                             TextField("", value: $sshConfig.remotePort, formatter: NumberFormatter())
                                 .keyboardType(.numberPad)
@@ -260,30 +260,12 @@ struct SettingsTabView: View {
                         Spacer(minLength: 0)
                     }
 
-                    if let command = state.sshTunnelManager.reverseTunnelCommand {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(L10n.t(.settingsReverseTunnelCommand))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(command)
-                                .font(.system(.caption, design: .monospaced))
-                                .textSelection(.enabled)
-                            Button {
-                                UIPasteboard.general.string = command
-                                copiedTunnelCommand = true
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                    copiedTunnelCommand = false
-                                }
-                            } label: {
-                                Label(copiedTunnelCommand ? L10n.t(.settingsCommandCopied) : L10n.t(.settingsCopyCommand), systemImage: copiedTunnelCommand ? "checkmark" : "terminal")
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    } else {
-                        Text(L10n.t(.settingsNoTunnelCommand))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                    Button {
+                        showSSHSetupGuide = true
+                    } label: {
+                        Label(L10n.t(.settingsSshSetupGuide), systemImage: "questionmark.circle")
                     }
+                    .buttonStyle(.plain)
                 } header: {
                     Text(L10n.t(.settingsSshTunnel))
                 } footer: {
@@ -373,6 +355,9 @@ struct SettingsTabView: View {
                     }
                 )
             }
+            .sheet(isPresented: $showSSHSetupGuide) {
+                SSHTunnelSetupGuideView()
+            }
             .alert(L10n.t(.settingsRotateKeyTitle), isPresented: $showRotateKeyAlert) {
                 Button(L10n.t(.commonCancel), role: .cancel) {}
                 Button(L10n.t(.settingsRotate), role: .destructive) {
@@ -444,6 +429,28 @@ struct SettingsTabView: View {
         }
         if current != state.serverURL {
             state.serverURL = current
+        }
+    }
+}
+
+struct SSHTunnelSetupGuideView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text(L10n.t(.settingsSshSetupGuideBody))
+                        .textSelection(.enabled)
+                }
+            }
+            .navigationTitle(L10n.t(.settingsSshSetupGuideTitle))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.t(.appDone)) { dismiss() }
+                }
+            }
         }
     }
 }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1235,9 +1235,9 @@ struct SSHTunnelTests {
         let config = SSHTunnelConfig()
         #expect(config.isEnabled == false)
         #expect(config.host == "")
-        #expect(config.port == 22)
-        #expect(config.username == "")
-        #expect(config.remotePort == 18080)
+        #expect(config.port == 8006)
+        #expect(config.username == "opencode")
+        #expect(config.remotePort == 19001)
     }
 
     @Test func sshTunnelConfigValidation() {
@@ -1275,9 +1275,9 @@ struct SSHTunnelTests {
     }
 
     @Test func sshTunnelConfigEquatable() {
-        let c1 = SSHTunnelConfig(isEnabled: true, host: "a.com", port: 22, username: "u", remotePort: 18080)
-        let c2 = SSHTunnelConfig(isEnabled: true, host: "a.com", port: 22, username: "u", remotePort: 18080)
-        let c3 = SSHTunnelConfig(isEnabled: false, host: "a.com", port: 22, username: "u", remotePort: 18080)
+        let c1 = SSHTunnelConfig(isEnabled: true, host: "a.com", port: 8006, username: "u", remotePort: 19001)
+        let c2 = SSHTunnelConfig(isEnabled: true, host: "a.com", port: 8006, username: "u", remotePort: 19001)
+        let c3 = SSHTunnelConfig(isEnabled: false, host: "a.com", port: 8006, username: "u", remotePort: 19001)
         
         #expect(c1 == c2)
         #expect(c1 != c3)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The app is designed for LAN use by default. Two options for remote access:
 
 **HTTPS + public server (recommended)**: deploy OpenCode on a public server with TLS. Point the iOS app to `https://your-server.com:4096` and configure Basic Auth credentials.
 
-**SSH Tunnel**: the app has a built-in SSH tunnel (powered by Citadel). Set up a reverse tunnel from your home machine to a VPS, then configure the tunnel in Settings > SSH Tunnel. See `docs/` for detailed steps.
+**SSH Tunnel**: the app has a built-in SSH tunnel (powered by Citadel). Ask your OpenCode host admin to add the device public key shown in Settings and give you the assigned remote port, then configure Settings > SSH Tunnel. The iOS app connects to `127.0.0.1:4096` through that SSH gateway.
 
 ## Repository layout
 

--- a/docs/OpenCode_iOS_Client_PRD.md
+++ b/docs/OpenCode_iOS_Client_PRD.md
@@ -391,25 +391,25 @@ Diff 渲染采用 unified diff 格式（类似 GitHub），绿色背景表示新
 
 #### 4.4.2 SSH Tunnel（远程访问）
 
-用于在非局域网环境下通过 SSH 隧道访问家里的 OpenCode Server。网络拓扑：
+用于在非局域网环境下通过 SSH gateway 访问托管好的 OpenCode Server。网络拓扑：
 
 ```
-iOS App → 公网 VPS (SSH) → VPS:18080 → 家里 OpenCode (127.0.0.1:4096)
+iOS App → SSH Gateway (:8006) → Assigned Remote Port (:19001) → OpenCode (127.0.0.1:4096)
 ```
 
 前提条件：
-- 家里机器需要先建立反向隧道到 VPS：`ssh -R 127.0.0.1:18080:127.0.0.1:4096 user@vps`
-- 用户需要在 VPS 上配置公钥认证
+- 管理员已经为用户创建独立 OpenCode 服务并分配 remote port
+- 用户把 iOS 设备公钥发给管理员；私钥只保存在设备 Keychain 中
 
 **配置项**：
 
 | 字段 | 说明 | 默认值 |
 |------|------|--------|
 | Enable SSH Tunnel | 开关 | Off |
-| VPS Host | VPS 地址 | - |
-| SSH Port | SSH 端口 | 22 |
-| Username | SSH 用户名 | - |
-| VPS Port | VPS 上转发的端口 | 18080 |
+| Gateway Host | SSH gateway 地址 | - |
+| SSH Port | SSH 端口 | 8006 |
+| Username | SSH 用户名 | opencode |
+| Assigned Remote Port | 管理员分配的 remote port | 19001 |
 
 **密钥管理**：
 
@@ -422,11 +422,10 @@ iOS App → 公网 VPS (SSH) → VPS:18080 → 家里 OpenCode (127.0.0.1:4096)
 
 1. 打开 Settings → SSH Tunnel
 2. App 自动生成密钥对
-3. 复制公钥，SSH 到 VPS 添加到 `~/.ssh/authorized_keys`
-4. 填写 VPS 地址、用户名、SSH 端口、VPS 端口
-5. 复制 app 生成的 reverse tunnel command，在电脑上执行
-6. 开启 SSH Tunnel 开关
-7. Server Address 改为 `127.0.0.1:4096`（通过隧道访问），并在上方点 `Test Connection`
+3. 复制公钥并发给 OpenCode host 管理员
+4. 管理员完成授权后提供 gateway host、SSH 端口、用户名和 assigned remote port
+5. 在 app 中填写这些参数并开启 SSH Tunnel 开关
+6. Server Address 改为 `127.0.0.1:4096`（通过隧道访问），并在上方点 `Test Connection`
 
 **连接状态**：
 

--- a/docs/OpenCode_iOS_Client_RFC.md
+++ b/docs/OpenCode_iOS_Client_RFC.md
@@ -98,7 +98,7 @@
 1. **无需升级 Swift 6.0**：支持 Swift 5.10+，避免 Swift 6 的并发安全 breaking changes
 2. **高级 API**：基于 Apple 的 SwiftNIO SSH 封装，比直接用 SwiftNIO SSH 简单
 3. **功能完整**：支持 Ed25519 密钥认证、DirectTCPIP 端口转发、SFTP
-4. **活跃维护**：44 个 release，最近刚加入反向隧道支持
+4. **活跃维护**：44 个 release，支持 SSH direct-tcpip 端口转发
 5. **文档齐全**：有 README 示例 + [官方文档](https://swiftpackageindex.com/orlandos-nl/Citadel/0.12.0/documentation/citadel)
 
 **使用示例**：
@@ -114,11 +114,11 @@ let settings = SSHClientSettings(
 )
 let client = try await SSHClient.connect(to: settings)
 
-// 本地端口转发：iOS:4096 -> VPS:18080 -> 家里 OpenCode
+// 本地端口转发：iOS:4096 -> SSH gateway assigned port -> OpenCode
 let channel = try await client.createDirectTCPIPChannel(
     using: .init(
         targetHost: "127.0.0.1",
-        targetPort: 18080,
+        targetPort: 19001,
         originatorAddress: try SocketAddress(ipAddress: "127.0.0.1", port: 4096)
     )
 )
@@ -188,15 +188,15 @@ iOS 图片支持与 OpenCode Web 保持同构：图片作为 prompt 的 `file` p
 
 ### 3.5 SSH 隧道架构
 
-用于远程访问场景，通过公网 VPS 中转到家里网络。
+用于远程访问场景，通过 SSH gateway 中转到用户独立的 OpenCode 服务。
 
 **网络拓扑**：
 
 ```
-┌─────────────┐      SSH Tunnel       ┌─────────────┐      反向隧道      ┌─────────────┐
-│  iOS App    │ ───────────────────▶  │    VPS      │ ─────────────────▶ │  家里 Mac   │
+┌─────────────┐      SSH Tunnel       ┌─────────────┐      internal      ┌─────────────┐
+│  iOS App    │ ───────────────────▶  │  Gateway    │ ─────────────────▶ │  OpenCode   │
 │ 127.0.0.1   │   DirectTCPIP         │ 127.0.0.1   │    (预先建立)       │ OpenCode    │
-│   :4096     │   :4096 → :18080      │   :18080    │                    │   :4096     │
+│   :4096     │   :4096 → :19001      │   :19001    │                    │   :4096     │
 └─────────────┘                       └─────────────┘                    └─────────────┘
 ```
 
@@ -205,10 +205,10 @@ iOS 图片支持与 OpenCode Web 保持同构：图片作为 prompt 的 `file` p
 ```swift
 struct SSHTunnelConfig: Codable {
     var isEnabled: Bool = false
-    var host: String = ""           // VPS 地址
-    var port: Int = 22              // SSH 端口
-    var username: String = ""       // SSH 用户名
-    var remotePort: Int = 18080     // VPS 上转发的端口
+    var host: String = ""           // SSH gateway 地址
+    var port: Int = 8006            // SSH 端口
+    var username: String = "opencode" // SSH 用户名
+    var remotePort: Int = 19001     // 管理员分配的 remote port
 }
 
 enum SSHConnectionStatus {
@@ -254,7 +254,7 @@ enum SSHKeyManager {
 | 认证失败 | 私钥不匹配 | "认证失败，请确认公钥已正确添加" |
 
 **SSH UX 补充**：
-- 在 Settings 内生成可复制的 reverse tunnel command（用户可直接在电脑端执行）
+- 在 Settings 内显示 setup guide：复制设备公钥给管理员，并填写管理员返回的 assigned remote port
 - 公钥复制入口常驻，不依赖 tunnel enable 状态
 - 在 SSH 配置区增加灰字提示：启用 SSH 后仍需到上方 `Server Connection` 点击 `Test Connection`
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -455,7 +455,7 @@ inline SVG/wide table/安全过滤/相对链接全部验证。截图存 `outputs
 - [x] **AppState 重构（PermissionController）**：权限事件解析/回写与 pending 映射从 AppState 抽离，补行为测试
 - [x] **AppState 重构（Iteration C - ActivityTracker）**：activity 状态推导/防抖/时长规则抽离，补行为测试
 - [x] **Activity Row 提前 completed 修复**：当 session.status 变 idle 但仍有 running/pending tool 或 streaming 时保持 running，不提前停表
-- [x] **SSH UX 完整化**：Settings 增加「Copy Public Key」「Reverse Tunnel Command + Copy」与灰字提示（启用 SSH 后需点上方 Test Connection）
+- [x] **SSH UX 完整化**：Settings 增加「Copy Public Key」、setup guide 与灰字提示（启用 SSH 后需点上方 Test Connection）
 - [x] **Session 快速切换竞态修复（全量拉取）**：对 `loadMessages/loadSessionDiff` 增加 requestedSessionID 校验，丢弃过期响应，避免 A→B→A 后被旧 B 结果覆盖
 - [x] **Activity Row 提前 completed（二次）修复**：`running/completed` 判定改为“当前 turn + busy 状态优先”，不再依赖 `completedAt == nil`，避免仍在运行时误显示 completed
 - [x] **SSH UX 修复**：默认 Server Address 改为 `127.0.0.1:4096`；开启 SSH 后配置变更自动重连；View Public Key 在 enabled 场景不再空白；`Set Server Address` CTA 改为显式蓝色按钮


### PR DESCRIPTION
## Summary
- Update SSH tunnel defaults for opencode-private-host gateway access: SSH port 8006, username opencode, assigned remote port 19001
- Replace reverse-tunnel UI/help with a setup guide for sending the device public key to the server admin
- Refresh README/PRD/RFC docs and tests for the assigned remote port flow

## Verification
- Stale-term scan: no remaining reverse-tunnel/18080/authorized_keys wording in Swift or Markdown
- Privacy-pattern scan: no new secrets in changed Swift/Markdown files
- xcodebuild test -scheme OpenCodeClient -destination 'id=302F88CA-C2D3-4DC0-8E12-B3ED82D5A3C8'