### PR TITLE
Always show archived sessions

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -167,7 +167,6 @@ final class AppState {
     static let aiBuilderLastOKTestedAtKey = "aiBuilderLastOKTestedAt"
     static let draftInputsBySessionKey = "draftInputsBySession"
     static let selectedModelBySessionKey = "selectedModelBySession"
-    static let showArchivedSessionsKey = "showArchivedSessions"
     static let selectedProjectWorktreeKey = "selectedProjectWorktree"
     static let customProjectPathKey = "customProjectPath"
     static let hostProfilesKey = "hostProfiles.v1"
@@ -201,7 +200,6 @@ final class AppState {
         _aiBuilderToken = KeychainHelper.load(forKey: Self.aiBuilderTokenKeychainKey) ?? ""
         _aiBuilderCustomPrompt = UserDefaults.standard.string(forKey: Self.aiBuilderCustomPromptKey) ?? Self.defaultAIBuilderCustomPrompt
         _aiBuilderTerminology = UserDefaults.standard.string(forKey: Self.aiBuilderTerminologyKey) ?? Self.defaultAIBuilderTerminology
-        _showArchivedSessions = UserDefaults.standard.bool(forKey: Self.showArchivedSessionsKey)
         _selectedProjectWorktree = UserDefaults.standard.string(forKey: Self.selectedProjectWorktreeKey)
         _customProjectPath = UserDefaults.standard.string(forKey: Self.customProjectPathKey) ?? ""
         _languagePreference = L10n.languagePreference
@@ -380,18 +378,15 @@ final class AppState {
     var sessions: [Session] { get { sessionStore.sessions } set { sessionStore.sessions = newValue } }
     var sortedSessions: [Session] {
         sessions
-            .filter { showArchivedSessions || !$0.isArchived }
             .sorted { $0.time.updated > $1.time.updated }
     }
     var sidebarSessions: [Session] {
         sessions
-            .filter { showArchivedSessions || !$0.isArchived }
             .filter { $0.parentID == nil }
             .sorted { $0.time.updated > $1.time.updated }
     }
     var sessionTree: [SessionNode] {
-        let filtered = sessions.filter { showArchivedSessions || !$0.isArchived }
-        return Self.buildSessionTree(from: filtered)
+        Self.buildSessionTree(from: sessions)
     }
     var currentSessionID: String? { get { sessionStore.currentSessionID } set { sessionStore.currentSessionID = newValue } }
     var sessionStatuses: [String: SessionStatus] { get { sessionStore.sessionStatuses } set { sessionStore.sessionStatuses = newValue } }
@@ -422,14 +417,6 @@ final class AppState {
     var selectedAgentIndex: Int = 0
     var isLoadingAgents: Bool = false
 
-    var showArchivedSessions: Bool {
-        get { _showArchivedSessions }
-        set {
-            _showArchivedSessions = newValue
-            UserDefaults.standard.set(newValue, forKey: Self.showArchivedSessionsKey)
-        }
-    }
-    var _showArchivedSessions: Bool = false
     var expandedSessionIDs: Set<String> = []
 
     func filteredSessions(archived: Bool) -> [Session] {

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -102,7 +102,6 @@ enum L10n {
         case settingsUntrusted
         case settingsRotate
 
-        case settingsShowArchivedSessions
         case settingsConnecting
         case settingsProject
         case settingsProjectServerDefault
@@ -482,7 +481,6 @@ enum L10n {
         Key.settingsCommandCopied.rawValue: "Command Copied",
         Key.settingsUntrusted.rawValue: "Untrusted",
         Key.settingsRotate.rawValue: "Rotate",
-        Key.settingsShowArchivedSessions.rawValue: "Show Archived Sessions",
         Key.settingsConnecting.rawValue: "Connecting...",
         Key.settingsProject.rawValue: "Project (Workspace)",
         Key.settingsProjectServerDefault.rawValue: "Server default",
@@ -866,7 +864,6 @@ enum L10n {
         Key.errorServerAddressEmpty.rawValue: "服务器地址不能为空",
         Key.errorWanRequiresHttps.rawValue: "WAN 地址必须使用 HTTPS",
         Key.errorUsingLanHttp.rawValue: "正在使用 LAN HTTP",
-        Key.settingsShowArchivedSessions.rawValue: "显示已归档会话",
         Key.settingsConnecting.rawValue: "连接中...",
         Key.settingsProject.rawValue: "项目（工作区）",
         Key.settingsProjectServerDefault.rawValue: "服务器默认",
@@ -1211,17 +1208,21 @@ enum L10n {
 
     static func toolCallsCount(_ count: Int) -> String {
         let key: Key = count == 1 ? .toolCallsCountOne : .toolCallsCountMany
-        return t(key, Int32(clamping: count))
+        return formatCount(key: key, count: count)
     }
 
     static func sessionsFiles(_ count: Int) -> String {
         let key: Key = count == 1 ? .sessionsFilesOne : .sessionsFilesMany
-        return t(key, Int32(clamping: count))
+        return formatCount(key: key, count: count)
     }
 
     static func patchFilesChanged(_ count: Int) -> String {
         let key: Key = count == 1 ? .patchFilesChangedOne : .patchFilesChangedMany
-        return t(key, Int32(clamping: count))
+        return formatCount(key: key, count: count)
+    }
+
+    private static func formatCount(key: Key, count: Int) -> String {
+        t(key).replacingOccurrences(of: "%d", with: count.formatted(.number.locale(currentLocale)))
     }
 
     static func toolOpenFileLabel(path: String) -> String {

--- a/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
@@ -90,9 +90,6 @@ struct SettingsTabView: View {
                         .labelsHidden()
                     }
 
-                    Toggle(L10n.t(.settingsShowArchivedSessions), isOn: $state.showArchivedSessions)
-                        .tint(DesignColors.Brand.primary)
-
                     VStack(alignment: .leading, spacing: DesignSpacing.sm) {
                         Text(L10n.t(.settingsLanguage))
                         Picker(L10n.t(.settingsLanguage), selection: $state.languagePreference) {

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1182,6 +1182,28 @@ struct LocalizationTests {
         L10n.languagePreference = .en
         #expect(L10n.t(.appChat) == "Chat")
     }
+
+    @Test func countHelpersFormatStableLocalizedIntegers() {
+        let key = L10n.languagePreferenceUserDefaultsKey
+        let previous = UserDefaults.standard.string(forKey: key)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        L10n.languagePreference = .en
+        #expect(L10n.toolCallsCount(2) == "2 tool calls")
+        #expect(L10n.sessionsFiles(2) == "2 files")
+        #expect(L10n.patchFilesChanged(2) == "2 files changed")
+
+        L10n.languagePreference = .zh
+        #expect(L10n.toolCallsCount(2) == "2 个工具调用")
+        #expect(L10n.sessionsFiles(2) == "2 个文件")
+        #expect(L10n.patchFilesChanged(2) == "2 个文件已变更")
+    }
 }
 
 // MARK: - LayoutConstants Tests
@@ -2022,27 +2044,14 @@ struct ArchivedSessionTests {
         #expect(session.time.archived == 1500)
     }
 
-    @Test @MainActor func filteredSessionsHidesArchivedByDefault() {
+    @Test @MainActor func sortedSessionsIncludesArchivedSessions() {
         let state = AppState()
-        state.showArchivedSessions = false
-        
-        let s1 = makeSession(id: "s1", archived: nil)
-        let s2 = makeSession(id: "s2", archived: 123)
-        state.sessions = [s1, s2]
-        
-        #expect(state.sortedSessions.count == 1)
-        #expect(state.sortedSessions.first?.id == "s1")
-    }
 
-    @Test @MainActor func filteredSessionsShowsArchivedWhenEnabled() {
-        let state = AppState()
-        state.showArchivedSessions = true
-        
         let s1 = makeSession(id: "s1", archived: nil)
         let s2 = makeSession(id: "s2", archived: 123)
         state.sessions = [s1, s2]
-        
-        #expect(state.sortedSessions.count == 2)
+
+        #expect(state.sortedSessions.map(\.id) == ["s1", "s2"])
     }
 
     @Test @MainActor func activeAndArchivedSessionFiltersUseArchivedTimestampSign() {
@@ -2383,7 +2392,6 @@ struct SessionTreeTests {
 
     @Test @MainActor func sessionTreeRemainsCanonicalListWhenSidebarSessionsHideChildren() {
         let state = AppState()
-        state.showArchivedSessions = false
         state.sessions = [
             makeSession(id: "root", updated: 100),
             makeSession(id: "child", parentID: "root", updated: 90),
@@ -2400,9 +2408,8 @@ struct SessionTreeTests {
         #expect(state.sessionTree[0].children[0].children[0].session.id == "grandchild")
     }
 
-    @Test @MainActor func archivedFilteringMatchesBetweenSidebarSessionsAndSessionTree() {
+    @Test @MainActor func sessionTreeIncludesActiveAndArchivedSessions() {
         let state = AppState()
-        state.showArchivedSessions = false
         state.sessions = [
             makeSession(id: "active-root", updated: 100),
             makeSession(id: "active-child", parentID: "active-root", updated: 90),
@@ -2410,10 +2417,12 @@ struct SessionTreeTests {
             makeSession(id: "archived-child", parentID: "active-root", updated: 70, archived: 2_000),
         ]
 
-        #expect(state.sidebarSessions.map(\.id) == ["active-root"])
-        #expect(state.sessionTree.count == 1)
+        #expect(state.sidebarSessions.map(\.id) == ["active-root", "archived-root"])
+        #expect(state.sessionTree.count == 2)
         #expect(state.sessionTree[0].session.id == "active-root")
-        #expect(state.sessionTree[0].children.map(\.session.id) == ["active-child"])
+        #expect(state.sessionTree[0].children.map(\.session.id) == ["active-child", "archived-child"])
+        #expect(state.filteredSessions(archived: false).map(\.id) == ["active-root", "active-child"])
+        #expect(state.filteredSessions(archived: true).map(\.id) == ["archived-root", "archived-child"])
     }
 
     @Test @MainActor func toggleSessionExpandedAddsAndRemovesSessionID() {
@@ -2953,7 +2962,6 @@ struct AppStateFlowTests {
 
         let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
         state.isConnected = true
-        state.showArchivedSessions = false
 
         await state.loadSessions()
         #expect(state.sessionTree.map(\.session.id) == ["root-1"])


### PR DESCRIPTION
## Summary
- remove the Settings toggle for showing archived sessions
- keep archived sessions visible in canonical session lists while preserving active/archived sections
- fix localized count helpers so tool/file counts do not render random large numbers

## Tests
- xcodebuild build-for-testing -scheme OpenCodeClient -destination 'id=302F88CA-C2D3-4DC0-8E12-B3ED82D5A3C8'
- xcodebuild test-without-building -scheme OpenCodeClient -destination 'id=302F88CA-C2D3-4DC0-8E12-B3ED82D5A3C8' (one unrelated ActivityTracker test failed once)
- xcodebuild test-without-building -scheme OpenCodeClient -destination 'id=302F88CA-C2D3-4DC0-8E12-B3ED82D5A3C8' -only-testing:OpenCodeClientTests/ActivityTrackerTests/thinkingTopicFromLeadingBoldText