### PR TITLE
Fix SSH host key changes and unicode output

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+HostProfiles.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+HostProfiles.swift
@@ -45,6 +45,19 @@ extension AppState {
         UserDefaults.standard.set(data, forKey: Self.hostProfilesKey)
     }
 
+    func trustPendingSSHHostKeyAndReconnect() async {
+        #if !os(visionOS)
+        sshTunnelManager.trustPendingHostKey()
+        pendingSSHHostKeyMismatch = nil
+        sshTunnelManager.disconnect()
+        await testConnection()
+        #endif
+    }
+
+    func dismissPendingSSHHostKeyMismatch() {
+        pendingSSHHostKeyMismatch = nil
+    }
+
     func applyCurrentHostProfileToRuntime(persistLegacy: Bool = true) {
         guard let profile = currentHostProfile else { return }
 

--- a/OpenCodeClient/OpenCodeClient/AppState+Sessions.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Sessions.swift
@@ -54,6 +54,7 @@ extension AppState {
 
     func testConnection() async {
         connectionError = nil
+        pendingSSHHostKeyMismatch = nil
         updateConnectionDiagnostic(phase: .health, message: L10n.t(.hostDiagnosticCheckingHealth))
 
         #if !os(visionOS)
@@ -69,6 +70,7 @@ extension AppState {
             if case .error(let message) = sshTunnelManager.status {
                 isConnected = false
                 connectionError = L10n.t(.hostDiagnosticSSHTunnelFailed, message)
+                pendingSSHHostKeyMismatch = sshTunnelManager.pendingHostKeyMismatch
                 updateConnectionDiagnostic(
                     phase: .failed,
                     message: connectionError ?? message,

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -316,6 +316,7 @@ final class AppState {
     var serverVersion: String?
     var connectionError: String?
     var connectionDiagnostic: ConnectionDiagnostic?
+    var pendingSSHHostKeyMismatch: SSHHostKeyMismatch?
     var sendError: String?
 
     // Session activity (rendered in transcript; session-scoped)

--- a/OpenCodeClient/OpenCodeClient/Models/Message.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Message.swift
@@ -5,6 +5,83 @@
 
 import Foundation
 
+enum DisplayTextDecoder {
+    static func decodeJSONUnicodeEscapes(_ text: String) -> String {
+        var result = ""
+        var index = text.startIndex
+
+        func hexDigit(_ character: Character) -> UInt32? {
+            guard let value = character.unicodeScalars.first?.value else { return nil }
+            if (48...57).contains(value) { return value - 48 }
+            if (97...102).contains(value) { return value - 97 + 10 }
+            if (65...70).contains(value) { return value - 65 + 10 }
+            return nil
+        }
+
+        func hexValue(at start: String.Index) -> (value: UInt32, end: String.Index)? {
+            var value: UInt32 = 0
+            var cursor = start
+            for _ in 0..<4 {
+                guard cursor < text.endIndex, let digit = hexDigit(text[cursor]) else { return nil }
+                value = value * 16 + digit
+                cursor = text.index(after: cursor)
+            }
+            return (value, cursor)
+        }
+
+        while index < text.endIndex {
+            guard text[index] == "\\" else {
+                result.append(text[index])
+                index = text.index(after: index)
+                continue
+            }
+
+            let uIndex = text.index(after: index)
+            guard uIndex < text.endIndex, text[uIndex] == "u" else {
+                result.append(text[index])
+                index = uIndex
+                continue
+            }
+
+            let hexStart = text.index(after: uIndex)
+            guard let first = hexValue(at: hexStart) else {
+                result.append(text[index])
+                index = uIndex
+                continue
+            }
+
+            if (0xD800...0xDBFF).contains(first.value) {
+                let slash = first.end
+                if slash < text.endIndex,
+                   text[slash] == "\\" {
+                    let secondU = text.index(after: slash)
+                    if secondU < text.endIndex,
+                       text[secondU] == "u",
+                       let second = hexValue(at: text.index(after: secondU)),
+                       (0xDC00...0xDFFF).contains(second.value) {
+                        let scalar = 0x10000 + ((first.value - 0xD800) << 10) + (second.value - 0xDC00)
+                        if let unicodeScalar = UnicodeScalar(scalar) {
+                            result.append(Character(unicodeScalar))
+                            index = second.end
+                            continue
+                        }
+                    }
+                }
+            }
+
+            if let unicodeScalar = UnicodeScalar(first.value) {
+                result.append(Character(unicodeScalar))
+                index = first.end
+            } else {
+                result.append(text[index])
+                index = uIndex
+            }
+        }
+
+        return result
+    }
+}
+
 nonisolated struct Message: Codable, Identifiable {
     let id: String
     let sessionID: String
@@ -254,8 +331,14 @@ nonisolated struct Part: Codable, Identifiable {
     var toolReason: String? { state?.title }
     /// 命令/输入摘要
     var toolInputSummary: String? { state?.inputSummary }
+    var toolInputSummaryForDisplay: String? {
+        toolInputSummary.map(DisplayTextDecoder.decodeJSONUnicodeEscapes)
+    }
     /// 输出结果
     var toolOutput: String? { state?.output }
+    var toolOutputForDisplay: String? {
+        toolOutput.map(DisplayTextDecoder.decodeJSONUnicodeEscapes)
+    }
 
     var toolTodos: [TodoItem] {
         if let t = metadata?.todos, !t.isEmpty { return t }

--- a/OpenCodeClient/OpenCodeClient/Services/SSHTunnelManager.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/SSHTunnelManager.swift
@@ -77,6 +77,14 @@ enum SSHKnownHostStore {
     }
 }
 
+struct SSHHostKeyMismatch: Equatable {
+    let host: String
+    let port: Int
+    let expectedFingerprint: String
+    let presentedFingerprint: String
+    let presentedOpenSSHKey: String
+}
+
 #if !os(visionOS)
 private final class SSHTOFUHostKeyValidator: NIOSSHClientServerAuthenticationDelegate {
     private let host: String
@@ -97,7 +105,8 @@ private final class SSHTOFUHostKeyValidator: NIOSSHClientServerAuthenticationDel
             validationCompletePromise.fail(
                 SSHError.hostKeyMismatch(
                     expected: SSHKnownHostStore.fingerprint(openSSHKey: trusted),
-                    got: SSHKnownHostStore.fingerprint(openSSHKey: presented)
+                    got: SSHKnownHostStore.fingerprint(openSSHKey: presented),
+                    presentedOpenSSHKey: presented
                 )
             )
             return
@@ -170,6 +179,7 @@ struct SSHTunnelConfig: Codable, Equatable {
 final class SSHTunnelManager: ObservableObject {
     @Published private(set) var status: SSHConnectionStatus = .disconnected
     @Published private(set) var trustedHostFingerprint: String?
+    @Published private(set) var pendingHostKeyMismatch: SSHHostKeyMismatch?
     @Published var config: SSHTunnelConfig {
         didSet { saveConfig() }
     }
@@ -221,6 +231,10 @@ final class SSHTunnelManager: ObservableObject {
 
     func clearTrustedHost() {
         trustedHostFingerprint = nil
+        pendingHostKeyMismatch = nil
+    }
+
+    func trustPendingHostKey() {
     }
 }
 #else
@@ -228,6 +242,7 @@ final class SSHTunnelManager: ObservableObject {
 final class SSHTunnelManager: ObservableObject {
     @Published private(set) var status: SSHConnectionStatus = .disconnected
     @Published private(set) var trustedHostFingerprint: String?
+    @Published private(set) var pendingHostKeyMismatch: SSHHostKeyMismatch?
     @Published var config: SSHTunnelConfig {
         didSet {
             saveConfig()
@@ -279,11 +294,21 @@ final class SSHTunnelManager: ObservableObject {
         }
         
         status = .connecting
+        pendingHostKeyMismatch = nil
         
         do {
             try await establishTunnel(privateKeyData: privateKeyData)
             status = .connected
         } catch {
+            if case let SSHError.hostKeyMismatch(expected, got, presentedOpenSSHKey) = error {
+                pendingHostKeyMismatch = SSHHostKeyMismatch(
+                    host: config.host,
+                    port: config.port,
+                    expectedFingerprint: expected,
+                    presentedFingerprint: got,
+                    presentedOpenSSHKey: presentedOpenSSHKey
+                )
+            }
             disconnect()
             status = .error(error.localizedDescription)
         }
@@ -310,6 +335,7 @@ final class SSHTunnelManager: ObservableObject {
         let client = try await SSHClient.connect(to: settings)
         self.sshClient = client
         self.trustedHostFingerprint = SSHKnownHostStore.fingerprint(host: config.host, port: config.port)
+        self.pendingHostKeyMismatch = nil
         
         #if DEBUG
         print("[SSH] Connected successfully")
@@ -459,6 +485,14 @@ final class SSHTunnelManager: ObservableObject {
     func clearTrustedHost() {
         SSHKnownHostStore.clear(host: config.host, port: config.port)
         trustedHostFingerprint = SSHKnownHostStore.fingerprint(host: config.host, port: config.port)
+        pendingHostKeyMismatch = nil
+    }
+
+    func trustPendingHostKey() {
+        guard let pending = pendingHostKeyMismatch else { return }
+        SSHKnownHostStore.trust(host: pending.host, port: pending.port, openSSHKey: pending.presentedOpenSSHKey)
+        trustedHostFingerprint = SSHKnownHostStore.fingerprint(host: pending.host, port: pending.port)
+        pendingHostKeyMismatch = nil
     }
 
     private func connectionSnapshot() -> (localPort: Int, remotePort: Int) {
@@ -520,7 +554,7 @@ enum SSHError: LocalizedError {
     case keyNotFound
     case invalidKeyFormat
     case tunnelFailed(String)
-    case hostKeyMismatch(expected: String, got: String)
+    case hostKeyMismatch(expected: String, got: String, presentedOpenSSHKey: String)
     
     var errorDescription: String? {
         switch self {
@@ -534,7 +568,7 @@ enum SSHError: LocalizedError {
             return L10n.t(.sshErrorInvalidKeyFormat)
         case .tunnelFailed(let reason):
             return L10n.t(.sshErrorTunnelFailed, reason)
-        case .hostKeyMismatch(let expected, let got):
+        case .hostKeyMismatch(let expected, let got, _):
             return L10n.t(.sshErrorHostKeyMismatch, expected, got)
         }
     }

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -101,6 +101,9 @@ enum L10n {
         case settingsCommandCopied
         case settingsUntrusted
         case settingsRotate
+        case settingsTrustHostKeyTitle
+        case settingsTrustHostKeyMessage
+        case settingsTrustHostKeyConfirm
 
         case settingsConnecting
         case settingsProject
@@ -481,6 +484,9 @@ enum L10n {
         Key.settingsCommandCopied.rawValue: "Command Copied",
         Key.settingsUntrusted.rawValue: "Untrusted",
         Key.settingsRotate.rawValue: "Rotate",
+        Key.settingsTrustHostKeyTitle.rawValue: "Trust New SSH Host Key?",
+        Key.settingsTrustHostKeyMessage.rawValue: "%@:%d presented a different host key.\n\nPrevious: %@\nNew: %@\n\nTrust it only if you expected the server to be rebuilt or reinstalled.",
+        Key.settingsTrustHostKeyConfirm.rawValue: "Trust and Reconnect",
         Key.settingsConnecting.rawValue: "Connecting...",
         Key.settingsProject.rawValue: "Project (Workspace)",
         Key.settingsProjectServerDefault.rawValue: "Server default",
@@ -861,6 +867,9 @@ enum L10n {
         Key.settingsCommandCopied.rawValue: "命令已复制",
         Key.settingsUntrusted.rawValue: "未信任",
         Key.settingsRotate.rawValue: "更换",
+        Key.settingsTrustHostKeyTitle.rawValue: "信任新的 SSH Host Key？",
+        Key.settingsTrustHostKeyMessage.rawValue: "%@:%d 返回了不同的 host key。\n\n之前：%@\n新的：%@\n\n只有在你确认服务器刚重建或重装时，才信任这个新 key。",
+        Key.settingsTrustHostKeyConfirm.rawValue: "信任并重连",
         Key.errorServerAddressEmpty.rawValue: "服务器地址不能为空",
         Key.errorWanRequiresHttps.rawValue: "WAN 地址必须使用 HTTPS",
         Key.errorUsingLanHttp.rawValue: "正在使用 LAN HTTP",
@@ -1049,7 +1058,7 @@ enum L10n {
         Key.folderEmptyTitle.rawValue: "文件夹为空",
         Key.folderEmptyDescription.rawValue: "此目录没有条目。",
 
-        Key.patchFilesChangedOne.rawValue: "%d 文件已变更",
+        Key.patchFilesChangedOne.rawValue: "%d 个文件已变更",
         Key.patchFilesChangedMany.rawValue: "%d 个文件已变更",
 
         Key.contextUsageHelp.rawValue: "上下文用量",
@@ -1203,7 +1212,7 @@ enum L10n {
     static func t(_ key: Key, _ arguments: CVarArg...) -> String {
         let template = t(key)
         guard !arguments.isEmpty else { return template }
-        return String(format: template, locale: currentLocale, arguments)
+        return String(format: template, locale: currentLocale, arguments: arguments)
     }
 
     static func toolCallsCount(_ count: Int) -> String {

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ToolPartView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ToolPartView.swift
@@ -98,7 +98,7 @@ struct ToolPartView: View {
                     }
                 }
                 if part.tool != "todowrite",
-                   let input = part.toolInputSummary ?? part.metadata?.input,
+                   let input = part.toolInputSummaryForDisplay ?? part.metadata?.input.map(DisplayTextDecoder.decodeJSONUnicodeEscapes),
                    !input.isEmpty {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(L10n.t(.toolCommandInput))
@@ -113,7 +113,7 @@ struct ToolPartView: View {
                     LabeledContent(L10n.t(.toolPath), value: path)
                 }
                 if part.tool != "todowrite",
-                   let output = part.toolOutput,
+                   let output = part.toolOutputForDisplay,
                    !output.isEmpty {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(L10n.t(.toolOutput))

--- a/OpenCodeClient/OpenCodeClient/Views/HostProfilesView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/HostProfilesView.swift
@@ -142,6 +142,29 @@ struct HostProfilesView: View {
         } message: {
             Text(L10n.t(.settingsRotateKeyPrompt))
         }
+        .alert(
+            L10n.t(.settingsTrustHostKeyTitle),
+            isPresented: Binding(
+                get: { state.pendingSSHHostKeyMismatch != nil },
+                set: { if !$0 { state.dismissPendingSSHHostKeyMismatch() } }
+            ),
+            presenting: state.pendingSSHHostKeyMismatch
+        ) { _ in
+            Button(L10n.t(.commonCancel), role: .cancel) {
+                state.dismissPendingSSHHostKeyMismatch()
+            }
+            Button(L10n.t(.settingsTrustHostKeyConfirm)) {
+                Task { await state.trustPendingSSHHostKeyAndReconnect() }
+            }
+        } message: { mismatch in
+            Text(L10n.t(
+                .settingsTrustHostKeyMessage,
+                mismatch.host,
+                mismatch.port,
+                mismatch.expectedFingerprint,
+                mismatch.presentedFingerprint
+            ))
+        }
     }
 
     private func copyPublicKey() {

--- a/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
@@ -190,6 +190,29 @@ struct SettingsTabView: View {
             } message: {
                 Text(publicKeyLoadError ?? L10n.t(.settingsPublicKeyCopyFailed))
             }
+            .alert(
+                L10n.t(.settingsTrustHostKeyTitle),
+                isPresented: Binding(
+                    get: { state.pendingSSHHostKeyMismatch != nil },
+                    set: { if !$0 { state.dismissPendingSSHHostKeyMismatch() } }
+                ),
+                presenting: state.pendingSSHHostKeyMismatch
+            ) { _ in
+                Button(L10n.t(.commonCancel), role: .cancel) {
+                    state.dismissPendingSSHHostKeyMismatch()
+                }
+                Button(L10n.t(.settingsTrustHostKeyConfirm)) {
+                    Task { await state.trustPendingSSHHostKeyAndReconnect() }
+                }
+            } message: { mismatch in
+                Text(L10n.t(
+                    .settingsTrustHostKeyMessage,
+                    mismatch.host,
+                    mismatch.port,
+                    mismatch.expectedFingerprint,
+                    mismatch.presentedFingerprint
+                ))
+            }
         }
     }
 

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -228,6 +228,16 @@ struct OpenCodeClientTests {
         #expect(part.stateDisplay == "completed")
     }
 
+    @Test func toolDisplayDecodesJSONUnicodeEscapes() throws {
+        let partJson = """
+        {"id":"p1","messageID":"m1","sessionID":"s1","type":"tool","text":null,"tool":"bash","callID":"c1","state":{"status":"completed","input":{"command":"say \\u4f60\\u597d"},"output":"\\u4e2d\\u6587 \\ud83d\\ude00","title":"done","metadata":{},"time":{"start":0,"end":1}},"metadata":null,"files":null}
+        """
+        let data = partJson.data(using: .utf8)!
+        let part = try JSONDecoder().decode(Part.self, from: data)
+        #expect(part.toolInputSummaryForDisplay == "say 你好")
+        #expect(part.toolOutputForDisplay == "中文 😀")
+    }
+
     @Test func partDecodingAcceptsStringFileEntries() throws {
         let partJson = """
         {"id":"p1","messageID":"m1","sessionID":"s1","type":"patch","text":null,"tool":null,"callID":null,"state":null,"metadata":null,"files":["src/main.swift",{"path":"src/utils.swift"}]}
@@ -1509,7 +1519,7 @@ struct SSHTunnelTests {
         #expect(SSHError.keyNotFound.errorDescription?.contains("key not found") == true)
         #expect(SSHError.invalidKeyFormat.errorDescription?.contains("Invalid") == true)
         #expect(SSHError.tunnelFailed("x").errorDescription?.contains("Tunnel") == true)
-        #expect(SSHError.hostKeyMismatch(expected: "a", got: "b").errorDescription?.contains("Host key mismatch") == true)
+        #expect(SSHError.hostKeyMismatch(expected: "a", got: "b", presentedOpenSSHKey: "ssh-ed25519 AAAA").errorDescription?.contains("Host key mismatch") == true)
     }
 
     @Test @MainActor func sshTunnelManagerInitialStatus() {


### PR DESCRIPTION
## Summary
- Decode JSON unicode escapes when displaying tool input/output so Chinese text renders directly.
- Capture SSH host key mismatches and prompt users to trust the new key before reconnecting.
- Fix localized String(format:) varargs handling and Chinese changed-file count text.

## Tests
- OPENCODE_INTEGRATION_TESTS=0 xcodebuild test -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'id=302F88CA-C2D3-4DC0-8E12-B3ED82D5A3C8' -derivedDataPath "/var/folders/b8/9nrsfrx96g92cbmkrf8jb3lw0000gn/T/opencode/OpenCodeClientPRDerivedData" -parallel-testing-enabled NO -only-testing:OpenCodeClientTests/LocalizationTests -only-testing:OpenCodeClientTests/SSHTunnelTests -only-testing:OpenCodeClientTests/OpenCodeClientTests/toolDisplayDecodesJSONUnicodeEscapes
- OPENCODE_INTEGRATION_TESTS=0 xcodebuild test -project "OpenCodeClient.xcodeproj" -scheme "OpenCodeClient" -destination 'id=302F88CA-C2D3-4DC0-8E12-B3ED82D5A3C8' -derivedDataPath "/var/folders/b8/9nrsfrx96g92cbmkrf8jb3lw0000gn/T/opencode/OpenCodeClientPRDerivedData" -parallel-testing-enabled NO -only-testing:OpenCodeClientTests/OpenCodeClientTests