### PR TITLE
fix(models): remove Ollama DeepSeek V4 Pro preset

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -403,7 +403,6 @@ final class AppState {
         ModelPreset(displayName: "DeepSeek V4 Flash", providerID: "deepseek", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),
-        ModelPreset(displayName: "Ollama DeepSeek V4 Pro", providerID: "ollama-cloud", modelID: "deepseek-v4-pro"),
         ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2"),
     ]
     var selectedModelIndex: Int = 2

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -16,7 +16,6 @@ struct ModelPreset: Codable, Identifiable {
         case "DeepSeek V4 Flash": return "DS-Flash"
         case "DeepSeek Local": return "DS-L"
         case "DeepSeek V4 Pro": return "DS-Pro"
-        case "Ollama DeepSeek V4 Pro": return "ODS-Pro"
         case "Ollama GLM 5.2": return "OGLM-5.2"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"


### PR DESCRIPTION
Remove the `ollama-cloud/deepseek-v4-pro` model preset and its `ODS-Pro` shortName entry from the curated model list.

The direct `deepseek/deepseek-v4-pro` preset already covers the same model; the Ollama Cloud relay is redundant in the list.

**Changes:**
- `AppState.swift`: remove `ModelPreset(displayName: "Ollama DeepSeek V4 Pro", ...)` line
- `ModelPreset.swift`: remove `ODS-Pro` shortName case

**Tests:** `xcodebuild test -only-testing:OpenCodeClientTests` passes (unit tests green).