### PR TITLE
feat(models): replace DeepSeek V4 Flash with Gemini 3.5 Flash

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -400,7 +400,7 @@ final class AppState {
     var modelPresets: [ModelPreset] = [
         ModelPreset(displayName: "GLM-5.2", providerID: "zai-coding-plan", modelID: "glm-5.2"),
         ModelPreset(displayName: "GPT-5.5", providerID: "openai", modelID: "gpt-5.5"),
-        ModelPreset(displayName: "DeepSeek V4 Flash", providerID: "deepseek", modelID: "deepseek-v4-flash"),
+        ModelPreset(displayName: "Gemini 3.5 Flash", providerID: "google", modelID: "gemini-3.5-flash"),
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),
         ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2"),

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -2023,13 +2023,13 @@ struct ModelSelectionPersistenceTests {
         }
     }
 
-    @Test @MainActor func defaultSelectionUsesDeepSeekV4Flash() {
+    @Test @MainActor func defaultSelectionUsesGemini35Flash() {
         withIsolatedModelSelectionDefaults {
             let state = AppState()
 
             #expect(state.selectedModelIndex == 2)
-            #expect(state.modelPresets[state.selectedModelIndex].displayName == "DeepSeek V4 Flash")
-            #expect(state.modelPresets[state.selectedModelIndex].id == "deepseek/deepseek-v4-flash")
+            #expect(state.modelPresets[state.selectedModelIndex].displayName == "Gemini 3.5 Flash")
+            #expect(state.modelPresets[state.selectedModelIndex].id == "google/gemini-3.5-flash")
         }
     }
 


### PR DESCRIPTION
Replace the DeepSeek API flash preset (`deepseek/deepseek-v4-flash`) with Gemini 3.5 Flash (`google/gemini-3.5-flash`) in the model selector list.

Changes:
- `AppState.swift`: swap the preset at index 2 (default selection) to Gemini 3.5 Flash
- `OpenCodeClientTests.swift`: update `defaultSelectionUsesDeepSeekV4Flash` to `defaultSelectionUsesGemini35Flash`

DeepSeek Local (ds4) and DeepSeek V4 Pro presets remain unchanged. Verified by `ModelPresetShortNameTests` and `ModelSelectionDefaultsTests` (both pass).

Do not merge yet — awaiting review.