### PR TITLE
fix(chat): avoid rendering crashes on large outputs

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -521,8 +521,6 @@ final class AppState {
     var providerModelsIndex: [String: ProviderModel] = [:]
     var providerConfigError: String? = nil
 
-    @ObservationIgnored var _cachedContextUsage: ContextUsageSnapshot?
-
     let apiClient: APIClientProtocol
     let sseClient: SSEClientProtocol
     let sshTunnelManager: SSHTunnelManager

--- a/OpenCodeClient/OpenCodeClient/ContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var showSettingsSheet = false
     @State private var showTabletSettings = false
+    @State private var selectedTab = 0
 
     init() {
         _state = State(initialValue: Self.makeInitialState())
@@ -174,9 +175,13 @@ struct ContentView: View {
                 return state.fileToOpenInFilesTab.map { FilePathWrapper(path: $0) }
             },
             set: { newValue, _ in
-                state.fileToOpenInFilesTab = newValue?.path
-                if newValue == nil, !useSplitLayout {
-                    state.selectedTab = 0
+                Task { @MainActor in
+                    await Task.yield()
+                    state.fileToOpenInFilesTab = newValue?.path
+                    if newValue == nil, !useSplitLayout {
+                        selectedTab = 0
+                        state.selectedTab = 0
+                    }
                 }
             }
         )
@@ -458,16 +463,33 @@ struct ContentView: View {
         }
         .preferredColorScheme(themeColorScheme)
         .environment(\.locale, L10n.currentLocale)
+        .onAppear {
+            selectedTab = state.selectedTab
+        }
         .onChange(of: sizeClass) { _, newValue in
             // iPhone → iPad 或 split layout 切换时，将 sheet 预览迁移到中间栏预览。
             if newValue == .regular, let p = state.fileToOpenInFilesTab {
-                state.previewFilePath = p
-                state.fileToOpenInFilesTab = nil
+                Task { @MainActor in
+                    await Task.yield()
+                    state.previewFilePath = p
+                    state.fileToOpenInFilesTab = nil
+                }
             }
         }
-        .onChange(of: state.selectedTab) { oldTab, newTab in
+        .onChange(of: selectedTab) { oldTab, newTab in
+            Task { @MainActor in
+                await Task.yield()
+                state.selectedTab = newTab
+            }
             if oldTab == 2 && newTab != 2 {
                 Task { await state.refresh() }
+            }
+        }
+        .onChange(of: state.selectedTab) { _, newTab in
+            guard selectedTab != newTab else { return }
+            Task { @MainActor in
+                await Task.yield()
+                selectedTab = newTab
             }
         }
         .sheet(item: filePreviewSheetItem) { wrapper in
@@ -476,8 +498,13 @@ struct ContentView: View {
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button {
-                                state.fileToOpenInFilesTab = nil
-                                if !useSplitLayout { state.selectedTab = 0 }
+                                Task { @MainActor in
+                                    state.fileToOpenInFilesTab = nil
+                                    if !useSplitLayout {
+                                        selectedTab = 0
+                                        state.selectedTab = 0
+                                    }
+                                }
                             } label: {
                                 Image(systemName: "xmark")
                             }
@@ -502,10 +529,7 @@ struct ContentView: View {
 
     /// iPhone：Tab Bar 三 Tab
     private var tabLayout: some View {
-        TabView(selection: Binding(
-            get: { state.selectedTab },
-            set: { state.selectedTab = $0 }
-        )) {
+        TabView(selection: $selectedTab) {
             ChatTabView(state: state)
                 .tabItem { Label(L10n.t(.appChat), systemImage: "bubble.left.and.text.bubble.right") }
                 .tag(0)

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -841,6 +841,7 @@ struct ChatTabView: View {
             .onChange(of: state.currentSessionID) { oldID, newID in
                 let draftText = inputText
                 Task { @MainActor in
+                    await Task.yield()
                     state.setDraftText(draftText, for: oldID)
                     syncDraftFromState(sessionID: newID)
                     isNearBottom = true
@@ -850,7 +851,11 @@ struct ChatTabView: View {
             }
             .onChange(of: inputText) { _, newValue in
                 guard !isSyncingDraft else { return }
-                state.setDraftText(newValue, for: state.currentSessionID)
+                Task { @MainActor in
+                    await Task.yield()
+                    guard !isSyncingDraft, inputText == newValue else { return }
+                    state.setDraftText(newValue, for: state.currentSessionID)
+                }
             }
             .onChange(of: selectedPhotoItems) { _, newItems in
                 Task { await loadSelectedPhotos(newItems) }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ContextUsageView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ContextUsageView.swift
@@ -21,7 +21,6 @@ extension AppState {
     var contextUsageSnapshot: ContextUsageSnapshot? {
         guard let sessionID = currentSessionID,
               let session = currentSession else {
-            _cachedContextUsage = nil
             return nil
         }
 
@@ -32,24 +31,18 @@ extension AppState {
         guard let last = assistantWithTokens,
               let tokens = last.info.tokens,
               let model = last.info.resolvedModel else {
-            if let cached = _cachedContextUsage, cached.sessionID == sessionID {
-                return cached
-            }
             return nil
         }
 
         let key = "\(model.providerID)/\(model.modelID)"
         guard let contextLimit = providerModelsIndex[key]?.limit?.context else {
-            if let cached = _cachedContextUsage, cached.sessionID == sessionID {
-                return cached
-            }
             return nil
         }
 
         let sumCost = messages.compactMap { $0.info.cost }.reduce(0.0, +)
         let totalCost: Double? = sumCost > 0 ? sumCost : nil
 
-        let snapshot = ContextUsageSnapshot(
+        return ContextUsageSnapshot(
             sessionID: sessionID,
             sessionTitle: session.title,
             providerID: model.providerID,
@@ -59,8 +52,6 @@ extension AppState {
             latestMessageCost: last.info.cost,
             totalSessionCost: totalCost
         )
-        _cachedContextUsage = snapshot
-        return snapshot
     }
 }
 

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import MarkdownUI
 
 struct MessageRowView: View {
-    private static let markdownRenderCharacterLimit = 50_000
+    private static let markdownRenderCharacterLimit = 12_000
     private static let largeMessagePreviewCharacterLimit = 12_000
 
     @Bindable var state: AppState

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ToolPartView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ToolPartView.swift
@@ -6,6 +6,8 @@
 import SwiftUI
 
 struct ToolPartView: View {
+    private static let outputPreviewCharacterLimit = 12_000
+
     @Environment(\.colorScheme) private var colorScheme
     let part: Part
     let sessionTodos: [TodoItem]
@@ -74,6 +76,15 @@ struct ToolPartView: View {
         return raw.split(separator: "/").last.map(String.init) ?? raw
     }
 
+    private static func outputPreview(_ output: String) -> String {
+        guard output.count > outputPreviewCharacterLimit else { return output }
+        return String(output.prefix(outputPreviewCharacterLimit))
+    }
+
+    private static func isOutputTruncated(_ output: String) -> Bool {
+        output.count > outputPreviewCharacterLimit
+    }
+
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
             VStack(alignment: .leading, spacing: 8) {
@@ -137,9 +148,14 @@ struct ToolPartView: View {
                                 }
                             }
                         } else {
-                            Text(output)
+                            Text(Self.outputPreview(output))
                                 .font(DesignTypography.microMono)
                                 .frame(maxWidth: .infinity, alignment: .leading)
+                            if Self.isOutputTruncated(output) {
+                                Text("Output truncated: showing first \(Self.outputPreviewCharacterLimit.formatted()) of \(output.count.formatted()) characters.")
+                                    .font(DesignTypography.micro)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
                 }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1383,6 +1383,14 @@ struct MessageRenderingHeuristicTests {
         #expect(MessageRowView.isLargeMessage(text) == true)
         #expect(MessageRowView.largeMessagePreview(text).count == 12_000)
     }
+
+    @Test func ringStatusConsolePasteSkipsExpensiveMarkdownRendering() {
+        let text = String(repeating: "$ smart_home git:(master) npm run ring:status\n", count: 360)
+
+        #expect(text.count > 12_000)
+        #expect(MessageRowView.isLargeMessage(text) == true)
+        #expect(MessageRowView.largeMessagePreview(text).count == 12_000)
+    }
 }
 
 struct ChatScrollBehaviorTests {


### PR DESCRIPTION
## Summary
- truncate very large chat markdown and tool outputs before rendering
- defer SwiftUI state writes that were happening during view updates
- remove context usage snapshot mutation from computed property
- add regression coverage for Ring-status-style long console output

## Testing
- xcodebuild build -scheme OpenCodeClient -destination 'generic/platform=iOS Simulator' -derivedDataPath '/var/folders/b8/9nrsfrx96g92cbmkrf8jb3lw0000gn/T/opencode/opencode_ios_dd7'
- xcodebuild test -scheme OpenCodeClient -destination 'id=41499CB8-029B-4528-B41D-18F0C3E913C3' -derivedDataPath '/var/folders/b8/9nrsfrx96g92cbmkrf8jb3lw0000gn/T/opencode/opencode_ios_test_dd2' -only-testing:OpenCodeClientTests/MessageRenderingHeuristicTests