### PR TITLE
feat(models): replace GPT-5.5 with GPT-5.6 Sol

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+Models.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Models.swift
@@ -19,8 +19,8 @@ extension AppState {
         switch savedID {
         case "zai-coding-plan/glm-5.2", "zai-coding-plan/glm-5.1", "zai-coding-plan/glm-5-turbo":
             return "zai-coding-plan/glm-5.2"
-        case "openai/gpt-5.4":
-            return "openai/gpt-5.5"
+        case "openai/gpt-5.4", "openai/gpt-5.5":
+            return "openai/gpt-5.6-sol"
         case "ollama-cloud/kimi-k2.6":
             return "ollama-cloud/glm-5.2"
         default:

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -399,7 +399,7 @@ final class AppState {
 
     var modelPresets: [ModelPreset] = [
         ModelPreset(displayName: "GLM-5.2", providerID: "zai-coding-plan", modelID: "glm-5.2"),
-        ModelPreset(displayName: "GPT-5.5", providerID: "openai", modelID: "gpt-5.5"),
+        ModelPreset(displayName: "GPT-5.6 Sol", providerID: "openai", modelID: "gpt-5.6-sol"),
         ModelPreset(displayName: "Gemini 3.5 Flash", providerID: "google", modelID: "gemini-3.5-flash"),
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),

--- a/OpenCodeClient/OpenCodeClient/ContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/ContentView.swift
@@ -253,7 +253,7 @@ struct ContentView: View {
             role: "assistant",
             parentID: userMessageID,
             providerID: "openai",
-            modelID: "gpt-5.5",
+            modelID: "gpt-5.6-sol",
             model: nil,
             error: nil,
             time: .init(created: 1_100, completed: 1_200),

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1974,32 +1974,35 @@ struct ModelSelectionPersistenceTests {
         }
     }
 
-    @Test @MainActor func legacyGPT54SelectionMapsToCurrentGPT55Preset() {
+    @Test @MainActor func legacyGPTSelectionMapsToCurrentGPT56SolPreset() {
         withIsolatedModelSelectionDefaults {
             let sessionID = "session-gpt"
-            let legacySelection = [sessionID: "openai/gpt-5.4"]
-            let encoded = try! JSONEncoder().encode(legacySelection)
-            UserDefaults.standard.set(encoded, forKey: selectedModelDefaultsKey)
+            for legacyID in ["openai/gpt-5.4", "openai/gpt-5.5"] {
+                UserDefaults.standard.removeObject(forKey: selectedModelDefaultsKey)
+                let legacySelection = [sessionID: legacyID]
+                let encoded = try! JSONEncoder().encode(legacySelection)
+                UserDefaults.standard.set(encoded, forKey: selectedModelDefaultsKey)
 
-            let state = AppState()
-            let session = Session(
-                id: sessionID,
-                slug: sessionID,
-                projectID: "p1",
-                directory: "/tmp",
-                parentID: nil,
-                title: sessionID,
-                version: "1",
-                time: .init(created: 0, updated: 100, archived: nil),
-                share: nil,
-                summary: nil
-            )
+                let state = AppState()
+                let session = Session(
+                    id: sessionID,
+                    slug: sessionID,
+                    projectID: "p1",
+                    directory: "/tmp",
+                    parentID: nil,
+                    title: sessionID,
+                    version: "1",
+                    time: .init(created: 0, updated: 100, archived: nil),
+                    share: nil,
+                    summary: nil
+                )
 
-            state.selectSession(session)
+                state.selectSession(session)
 
-            #expect(state.selectedModelIndex == 1)
-            #expect(state.modelPresets[state.selectedModelIndex].displayName == "GPT-5.5")
-            #expect(state.modelPresets[state.selectedModelIndex].id == "openai/gpt-5.5")
+                #expect(state.selectedModelIndex == 1)
+                #expect(state.modelPresets[state.selectedModelIndex].displayName == "GPT-5.6 Sol")
+                #expect(state.modelPresets[state.selectedModelIndex].id == "openai/gpt-5.6-sol")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the GPT-5.5 preset with `openai/gpt-5.6-sol`
- migrate saved GPT-5.4 and GPT-5.5 selections to GPT-5.6 Sol
- update preview model metadata and migration coverage

## Test
- `xcodebuild test -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination id=3EB51FEF-C951-4485-AD0F-33463C66DBEB -derivedDataPath /var/folders/b8/9nrsfrx96g92cbmkrf8jb3lw0000gn/T/opencode/OpenCodeClient-DerivedData-gpt56 -only-testing:OpenCodeClientTests/OpenCodeClientTests/legacyGPTSelectionMapsToCurrentGPT56SolPreset`