### PR TITLE
Preview workspace links from chat Markdown

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+FileTree.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+FileTree.swift
@@ -55,18 +55,19 @@ extension AppState {
         }
     }
 
-    func loadFileContent(path: String) async throws -> FileContent {
-        let resolved = PathNormalizer.resolveWorkspaceRelativePath(path, workspaceDirectory: currentSession?.directory)
+    func loadFileContent(path: String, workspaceDirectory: String? = nil) async throws -> FileContent {
+        let directory = workspaceDirectory ?? currentSession?.directory
+        let resolved = PathNormalizer.resolveWorkspaceRelativePath(path, workspaceDirectory: directory)
         if resolved.hasPrefix("/") {
             let url = URL(fileURLWithPath: resolved)
             return try await apiClient.fileContent(path: url.lastPathComponent, directory: url.deletingLastPathComponent().path)
         }
-        return try await apiClient.fileContent(path: resolved, directory: nil)
+        return try await apiClient.fileContent(path: resolved, directory: directory)
     }
 
-    func loadFileContent(pathBytes: [UInt8]) async throws -> FileContent {
+    func loadFileContent(pathBytes: [UInt8], workspaceDirectory: String? = nil) async throws -> FileContent {
         let path = String(decoding: pathBytes, as: UTF8.self)
-        return try await loadFileContent(path: path)
+        return try await loadFileContent(path: path, workspaceDirectory: workspaceDirectory)
     }
 
     func toggleFileExpanded(_ path: String) {

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -503,9 +503,11 @@ final class AppState {
     var selectedDiffFile: String? { get { fileStore.selectedDiffFile } set { fileStore.selectedDiffFile = newValue } }
     var selectedTab: Int = 0  // 0=Chat, 1=Files, 2=Settings
     var fileToOpenInFilesTab: String?  // 从 Chat 中 tool 点击跳转时设置，Files tab 或 sheet 展示
+    var fileToOpenInFilesTabWorkspaceDirectory: String?
 
     /// iPad 三栏布局：中间栏文件预览
     var previewFilePath: String?
+    var previewFileWorkspaceDirectory: String?
 
     var sessionTodos: [String: [TodoItem]] { get { todoStore.sessionTodos } set { todoStore.sessionTodos = newValue } }
 

--- a/OpenCodeClient/OpenCodeClient/ContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/ContentView.swift
@@ -172,12 +172,15 @@ struct ContentView: View {
             get: {
                 // 仅在 iPhone / compact 时使用 sheet 预览；iPad 在中间栏内联预览。
                 guard !useSplitLayout else { return nil }
-                return state.fileToOpenInFilesTab.map { FilePathWrapper(path: $0) }
+                return state.fileToOpenInFilesTab.map {
+                    FilePathWrapper(path: $0, workspaceDirectory: state.fileToOpenInFilesTabWorkspaceDirectory)
+                }
             },
             set: { newValue, _ in
                 Task { @MainActor in
                     await Task.yield()
                     state.fileToOpenInFilesTab = newValue?.path
+                    state.fileToOpenInFilesTabWorkspaceDirectory = newValue?.workspaceDirectory
                     if newValue == nil, !useSplitLayout {
                         selectedTab = 0
                         state.selectedTab = 0
@@ -472,7 +475,9 @@ struct ContentView: View {
                 Task { @MainActor in
                     await Task.yield()
                     state.previewFilePath = p
+                    state.previewFileWorkspaceDirectory = state.fileToOpenInFilesTabWorkspaceDirectory
                     state.fileToOpenInFilesTab = nil
+                    state.fileToOpenInFilesTabWorkspaceDirectory = nil
                 }
             }
         }
@@ -494,12 +499,13 @@ struct ContentView: View {
         }
         .sheet(item: filePreviewSheetItem) { wrapper in
             NavigationStack {
-                FileContentView(state: state, filePath: wrapper.path)
+                FileContentView(state: state, filePath: wrapper.path, workspaceDirectory: wrapper.workspaceDirectory)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button {
                                 Task { @MainActor in
                                     state.fileToOpenInFilesTab = nil
+                                    state.fileToOpenInFilesTabWorkspaceDirectory = nil
                                     if !useSplitLayout {
                                         selectedTab = 0
                                         state.selectedTab = 0
@@ -609,7 +615,8 @@ struct ContentView: View {
 
 private struct FilePathWrapper: Identifiable {
     let path: String
-    var id: String { path }
+    let workspaceDirectory: String?
+    var id: String { "\(workspaceDirectory ?? ""):\(path)" }
 }
 
 private struct TabletFilesColumn: View {
@@ -621,7 +628,7 @@ private struct TabletFilesColumn: View {
         NavigationStack {
             Group {
                 if let path = state.previewFilePath, !path.isEmpty {
-                    FileContentView(state: state, filePath: path)
+                    FileContentView(state: state, filePath: path, workspaceDirectory: state.previewFileWorkspaceDirectory)
                 } else {
                     FileTreeView(state: state, forceSplitPreview: true)
                         .searchable(text: $state.fileSearchQuery, prompt: L10n.t(.appSearchFiles))
@@ -658,7 +665,9 @@ private struct TabletFilesColumn: View {
                     if let path = state.previewFilePath, !path.isEmpty {
                         Button {
                             state.previewFilePath = nil
+                            state.previewFileWorkspaceDirectory = nil
                             state.fileToOpenInFilesTab = nil
+                            state.fileToOpenInFilesTabWorkspaceDirectory = nil
                         } label: {
                             Image(systemName: "xmark")
                         }

--- a/OpenCodeClient/OpenCodeClient/Utils/WorkspaceLinkResolver.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/WorkspaceLinkResolver.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+nonisolated enum WorkspaceLinkResolution: Equatable {
+    case external(URL)
+    case file(path: String)
+    case fragmentOnly
+    case rejected(String)
+}
+
+nonisolated enum WorkspaceLinkResolver {
+    static func resolve(
+        _ rawHref: String,
+        workspaceDirectory: String?,
+        baseFilePath: String? = nil
+    ) -> WorkspaceLinkResolution {
+        let href = rawHref.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !href.isEmpty else { return .rejected("Empty link") }
+        guard !href.hasPrefix("#") else { return .fragmentOnly }
+
+        if href.hasPrefix("//") {
+            return .rejected("Scheme-relative links are not allowed")
+        }
+
+        if let components = URLComponents(string: href), let scheme = components.scheme?.lowercased() {
+            switch scheme {
+            case "http", "https":
+                guard let url = URL(string: href) else { return .rejected("Invalid URL") }
+                return .external(url)
+            case "file":
+                guard let workspace = normalizedAbsolutePath(workspaceDirectory), !workspace.isEmpty else {
+                    return .rejected("Cannot open workspace file link without a workspace directory")
+                }
+                return resolveFileURL(components, workspace: workspace)
+            case "javascript", "data":
+                return .rejected("Blocked unsafe link scheme: \(scheme)")
+            default:
+                return .rejected("Unsupported link scheme: \(scheme)")
+            }
+        }
+
+        guard let workspace = normalizedAbsolutePath(workspaceDirectory), !workspace.isEmpty else {
+            return .rejected("Cannot open workspace file link without a workspace directory")
+        }
+
+        let encodedPath = pathPart(from: href)
+        let (decodedPath, changedByDecoding) = decodedPercentEncoding(encodedPath)
+        if changedByDecoding, containsParentSegment(decodedPath) {
+            return .rejected("Encoded parent traversal is not allowed")
+        }
+
+        if decodedPath.hasPrefix("/") {
+            return resolveAbsolutePath(decodedPath, workspace: workspace)
+        }
+
+        guard let absolute = resolveRelativePath(decodedPath, workspace: workspace, baseFilePath: baseFilePath) else {
+            return .rejected("Relative link escapes the workspace")
+        }
+        return workspaceRelativeFile(absolutePath: absolute, workspace: workspace)
+    }
+
+    private static func resolveFileURL(_ components: URLComponents, workspace: String) -> WorkspaceLinkResolution {
+        if let host = components.host, !host.isEmpty, host.lowercased() != "localhost" {
+            return .rejected("Only local file:// links are allowed")
+        }
+        let encodedPath = components.percentEncodedPath
+        guard !encodedPath.isEmpty else { return .rejected("Empty file URL path") }
+        let (decodedPath, changedByDecoding) = decodedPercentEncoding(encodedPath)
+        if changedByDecoding, containsParentSegment(decodedPath) {
+            return .rejected("Encoded parent traversal is not allowed")
+        }
+        return resolveAbsolutePath(decodedPath, workspace: workspace)
+    }
+
+    private static func resolveAbsolutePath(_ path: String, workspace: String) -> WorkspaceLinkResolution {
+        guard let absolute = normalizedAbsolutePath(path) else {
+            return .rejected("Invalid absolute path")
+        }
+        return workspaceRelativeFile(absolutePath: absolute, workspace: workspace)
+    }
+
+    private static func workspaceRelativeFile(absolutePath: String, workspace: String) -> WorkspaceLinkResolution {
+        guard absolutePath != workspace else { return .rejected("Workspace root is not a file") }
+        guard absolutePath.hasPrefix(workspace + "/") else {
+            return .rejected("File link is outside the workspace")
+        }
+        let relative = String(absolutePath.dropFirst(workspace.count + 1))
+        guard !relative.isEmpty else { return .rejected("Empty file path") }
+        return .file(path: relative)
+    }
+
+    private static func resolveRelativePath(
+        _ path: String,
+        workspace: String,
+        baseFilePath: String?
+    ) -> String? {
+        var baseSegments = pathSegments(workspace)
+        if let baseFilePath, !baseFilePath.isEmpty {
+            let baseAbsolute: String
+            if baseFilePath.hasPrefix("/") {
+                guard let normalized = normalizedAbsolutePath(baseFilePath), normalized == workspace || normalized.hasPrefix(workspace + "/") else {
+                    return nil
+                }
+                baseAbsolute = normalized
+            } else {
+                guard let normalized = normalizedAbsolutePath(workspace + "/" + baseFilePath) else { return nil }
+                baseAbsolute = normalized
+            }
+            baseSegments = pathSegments(baseAbsolute)
+            if !baseSegments.isEmpty { baseSegments.removeLast() }
+        }
+
+        let workspaceDepth = pathSegments(workspace).count
+        var output = baseSegments
+        for segment in path.split(separator: "/", omittingEmptySubsequences: true).map(String.init) {
+            switch segment {
+            case ".":
+                continue
+            case "..":
+                guard output.count > workspaceDepth else { return nil }
+                output.removeLast()
+            default:
+                output.append(segment)
+            }
+        }
+        return "/" + output.joined(separator: "/")
+    }
+
+    private static func normalizedAbsolutePath(_ path: String?) -> String? {
+        guard let path else { return nil }
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/") else { return nil }
+
+        var segments: [String] = []
+        for segment in trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init) {
+            switch segment {
+            case ".":
+                continue
+            case "..":
+                if !segments.isEmpty { segments.removeLast() }
+            default:
+                segments.append(segment)
+            }
+        }
+        return "/" + segments.joined(separator: "/")
+    }
+
+    private static func pathSegments(_ absolutePath: String) -> [String] {
+        absolutePath.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    private static func pathPart(from href: String) -> String {
+        if let components = URLComponents(string: href), !components.percentEncodedPath.isEmpty {
+            return components.percentEncodedPath
+        }
+        return href.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? href
+    }
+
+    private static func decodedPercentEncoding(_ value: String) -> (String, Bool) {
+        var current = value
+        var changed = false
+        for _ in 0..<3 {
+            guard let decoded = current.removingPercentEncoding, decoded != current else { break }
+            current = decoded
+            changed = true
+        }
+        return (current, changed)
+    }
+
+    private static func containsParentSegment(_ path: String) -> Bool {
+        path.split(separator: "/", omittingEmptySubsequences: true).contains("..")
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -563,14 +563,16 @@ struct ChatTabView: View {
                                             case .group(let group):
                                                 switch group {
                                                 case .user(let msg):
+                                                    let workspaceDirectory = workspaceDirectory(for: msg.info.sessionID)
                                                     MessageRowView(
                                                         state: state,
                                                         message: msg,
                                                         sessionTodos: state.sessionTodos[msg.info.sessionID] ?? [],
-                                                         workspaceDirectory: state.currentSession?.directory,
-                                                         onOpenResolvedPath: openFileInChat,
-                                                         onOpenFilesTab: openFilesTab,
-                                                         onForkFromMessage: { messageID in
+                                                          workspaceDirectory: workspaceDirectory,
+                                                          onOpenResolvedPath: { openFileInChat($0) },
+                                                          onOpenMarkdownResolvedPath: { openFileInChat($0, workspaceDirectory: workspaceDirectory) },
+                                                          onOpenFilesTab: openFilesTab,
+                                                          onForkFromMessage: { messageID in
                                                              Task { await state.forkSession(messageID: messageID) }
                                                          },
                                                          onEditFromMessage: { messageID in
@@ -583,13 +585,15 @@ struct ChatTabView: View {
                                                 case .assistantMerged(let msgs):
                                                     if let first = msgs.first {
                                                         let merged = MessageWithParts(info: first.info, parts: msgs.flatMap(\.parts))
+                                                        let workspaceDirectory = workspaceDirectory(for: merged.info.sessionID)
                                                         MessageRowView(
                                                             state: state,
                                                             message: merged,
                                                             sessionTodos: state.sessionTodos[merged.info.sessionID] ?? [],
-                                                             workspaceDirectory: state.currentSession?.directory,
-                                                             onOpenResolvedPath: openFileInChat,
-                                                             onOpenFilesTab: openFilesTab,
+                                                              workspaceDirectory: workspaceDirectory,
+                                                              onOpenResolvedPath: { openFileInChat($0) },
+                                                              onOpenMarkdownResolvedPath: { openFileInChat($0, workspaceDirectory: workspaceDirectory) },
+                                                              onOpenFilesTab: openFilesTab,
                                                              onForkFromMessage: { messageID in
                                                                  Task { await state.forkSession(messageID: messageID) }
                                                              },
@@ -1047,13 +1051,20 @@ struct ChatTabView: View {
         }
     }
 
-    private func openFileInChat(_ resolvedPath: String) {
+    private func workspaceDirectory(for sessionID: String) -> String? {
+        state.sessions.first(where: { $0.id == sessionID })?.directory ?? state.currentSession?.directory
+    }
+
+    private func openFileInChat(_ resolvedPath: String, workspaceDirectory: String? = nil) {
         guard !resolvedPath.isEmpty else { return }
         if sizeClass == .regular {
             state.previewFilePath = resolvedPath
+            state.previewFileWorkspaceDirectory = workspaceDirectory
             state.fileToOpenInFilesTab = nil
+            state.fileToOpenInFilesTabWorkspaceDirectory = nil
         } else {
             state.fileToOpenInFilesTab = resolvedPath
+            state.fileToOpenInFilesTabWorkspaceDirectory = workspaceDirectory
             state.selectedTab = 1
         }
     }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -15,6 +15,7 @@ struct MessageRowView: View {
     let sessionTodos: [TodoItem]
     let workspaceDirectory: String?
     let onOpenResolvedPath: (String) -> Void
+    let onOpenMarkdownResolvedPath: (String) -> Void
     let onOpenFilesTab: () -> Void
     let onForkFromMessage: ((String) -> Void)?
     let onEditFromMessage: ((String) -> Void)?
@@ -96,7 +97,13 @@ struct MessageRowView: View {
                 .font(font)
                 .textSelection(.enabled)
         } else if shouldRenderMarkdown(text) {
-            ResolvedMarkdownView(text: text, state: state, workspaceDirectory: workspaceDirectory)
+            ResolvedMarkdownView(
+                text: text,
+                state: state,
+                workspaceDirectory: workspaceDirectory,
+                handlesWorkspaceLinks: !isUser,
+                onOpenResolvedPath: onOpenMarkdownResolvedPath
+            )
                 .font(font)
                 .textSelection(.enabled)
         } else {
@@ -110,23 +117,45 @@ struct MessageRowView: View {
         let text: String
         let state: AppState
         let workspaceDirectory: String?
+        let handlesWorkspaceLinks: Bool
+        let onOpenResolvedPath: (String) -> Void
+        @Environment(\.openURL) private var openURL
         @State private var resolvedText: String?
         
         var body: some View {
             Markdown(resolvedText ?? text)
                 .markdownImageProvider(
                     WorkspaceMarkdownImageProvider(
-                        loadFileContent: { pathBytes in try await state.loadFileContent(pathBytes: pathBytes) },
+                        loadFileContent: { pathBytes in try await state.loadFileContent(pathBytes: pathBytes, workspaceDirectory: workspaceDirectory) },
                         workspaceDirectory: workspaceDirectory
                     )
                 )
+                .environment(\.openURL, OpenURLAction { url in
+                    guard handlesWorkspaceLinks else {
+                        openURL(url)
+                        return .handled
+                    }
+                    switch WorkspaceLinkResolver.resolve(url.absoluteString, workspaceDirectory: workspaceDirectory) {
+                    case .external(let externalURL):
+                        openURL(externalURL)
+                        return .handled
+                    case .file(let path):
+                        onOpenResolvedPath(path)
+                        return .handled
+                    case .fragmentOnly:
+                        return .handled
+                    case .rejected(let reason):
+                        state.sendError = reason
+                        return .discarded
+                    }
+                })
                 .task(id: text) {
                     resolvedText = nil
                     let sourceText = text
                     let resolved = await MarkdownImageResolver.resolveImages(
                         in: sourceText,
                         workspaceDirectory: workspaceDirectory,
-                        fetchContent: { path in try await state.loadFileContent(path: path) }
+                        fetchContent: { path in try await state.loadFileContent(path: path, workspaceDirectory: workspaceDirectory) }
                     )
                     guard !Task.isCancelled, sourceText == text else { return }
                     resolvedText = resolved

--- a/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/FileContentView.swift
@@ -45,6 +45,7 @@ enum MarkdownPreviewMode: String, CaseIterable {
 struct FileContentView: View {
     @Bindable var state: AppState
     let filePath: String
+    var workspaceDirectory: String? = nil
     @State private var content: String?
     @State private var imageData: Data?
     @State private var isLoading = false
@@ -61,6 +62,10 @@ struct FileContentView: View {
 
     private var fileName: String {
         filePath.split(separator: "/").last.map(String.init) ?? filePath
+    }
+
+    private var effectiveWorkspaceDirectory: String? {
+        workspaceDirectory ?? state.currentSession?.directory
     }
 
     @ToolbarContentBuilder
@@ -166,7 +171,7 @@ struct FileContentView: View {
                         text: text,
                         state: state,
                         markdownFilePath: filePath,
-                        workspaceDirectory: state.currentSession?.directory
+                        workspaceDirectory: effectiveWorkspaceDirectory
                     )
                 }
             case .web:
@@ -174,7 +179,7 @@ struct FileContentView: View {
                     text: text,
                     state: state,
                     markdownFilePath: filePath,
-                    workspaceDirectory: state.currentSession?.directory,
+                    workspaceDirectory: effectiveWorkspaceDirectory,
                     isOversized: useRaw,
                     onSwitchToNative: { previewMode = .native },
                     onSwitchToSource: { previewMode = .source }
@@ -194,7 +199,7 @@ struct FileContentView: View {
         content = nil
         Task {
             do {
-                let fc = try await state.loadFileContent(path: filePath)
+                let fc = try await state.loadFileContent(path: filePath, workspaceDirectory: effectiveWorkspaceDirectory)
                 await MainActor.run {
                     if isImage {
                         if let rawContent = fc.content {
@@ -336,7 +341,7 @@ struct MarkdownPreviewView: View {
                     )
                         .markdownImageProvider(
                             WorkspaceMarkdownImageProvider(
-                                loadFileContent: { pathBytes in try await state.loadFileContent(pathBytes: pathBytes) },
+                                loadFileContent: { pathBytes in try await state.loadFileContent(pathBytes: pathBytes, workspaceDirectory: workspaceDirectory) },
                                 workspaceDirectory: workspaceDirectory
                             )
                         )
@@ -353,7 +358,7 @@ struct MarkdownPreviewView: View {
                 in: sourceText,
                 markdownFilePath: markdownFilePath,
                 workspaceDirectory: workspaceDirectory,
-                fetchContent: { path in try await state.loadFileContent(path: path) }
+                fetchContent: { path in try await state.loadFileContent(path: path, workspaceDirectory: workspaceDirectory) }
             )
             guard !Task.isCancelled, sourceText == Self.normalizeStandaloneImageBlocks(text) else { return }
             resolvedPreviewText = resolved

--- a/OpenCodeClient/OpenCodeClient/Views/FileTreeView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/FileTreeView.swift
@@ -35,6 +35,7 @@ struct FileTreeView: View {
                     if useSplitPreview {
                         Button {
                             state.previewFilePath = item.node.path
+                            state.previewFileWorkspaceDirectory = state.currentSession?.directory
                         } label: {
                             FileRow(
                                 node: item.node,
@@ -55,7 +56,7 @@ struct FileTreeView: View {
         }
         .listStyle(.plain)
         .navigationDestination(for: String.self) { path in
-            FileContentView(state: state, filePath: path)
+            FileContentView(state: state, filePath: path, workspaceDirectory: state.currentSession?.directory)
         }
         .onAppear {
             if state.fileTreeRoot.isEmpty {

--- a/OpenCodeClient/OpenCodeClient/Views/MarkdownWebPreviewView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/MarkdownWebPreviewView.swift
@@ -42,6 +42,7 @@ struct MarkdownWebPreviewContainer: View {
 
     @State private var resolvedMarkdown: String?
     @State private var renderError: String?
+    @State private var linkError: String?
     @State private var proceedDespiteSize = false
 
     var body: some View {
@@ -72,10 +73,18 @@ struct MarkdownWebPreviewContainer: View {
                 in: source,
                 markdownFilePath: markdownFilePath,
                 workspaceDirectory: workspaceDirectory,
-                fetchContent: { path in try await state.loadFileContent(path: path) }
+                fetchContent: { path in try await state.loadFileContent(path: path, workspaceDirectory: workspaceDirectory) }
             )
             guard !Task.isCancelled, source == text else { return }
             resolvedMarkdown = resolved
+        }
+        .alert(L10n.t(.appError), isPresented: Binding(
+            get: { linkError != nil },
+            set: { if !$0 { linkError = nil } }
+        )) {
+            Button(L10n.t(.commonOk)) { linkError = nil }
+        } message: {
+            if let linkError { Text(linkError) }
         }
     }
 
@@ -87,17 +96,17 @@ struct MarkdownWebPreviewContainer: View {
     /// the app's Files preview (same target the Chat→file jump uses). Fragment-only
     /// hrefs are ignored (the WebView scrolls in place).
     private func openWorkspacePath(_ href: String) {
-        let trimmed = href.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return }
-        // Drop any fragment so `doc.md#section` opens `doc.md`.
-        let pathPart = trimmed.split(separator: "#", maxSplits: 1).first.map(String.init) ?? trimmed
-        let resolved = MarkdownImageResolver.resolveRelativeReference(
-            pathPart,
-            markdownFilePath: markdownFilePath,
-            workspaceDirectory: workspaceDirectory
-        )
-        guard !resolved.isEmpty else { return }
-        state.fileToOpenInFilesTab = resolved
+        switch WorkspaceLinkResolver.resolve(href, workspaceDirectory: workspaceDirectory, baseFilePath: markdownFilePath) {
+        case .external(let url):
+            openURL(url)
+        case .file(let path):
+            state.fileToOpenInFilesTab = path
+            state.fileToOpenInFilesTabWorkspaceDirectory = workspaceDirectory
+        case .fragmentOnly:
+            return
+        case .rejected(let reason):
+            linkError = reason
+        }
     }
 
     private var oversizeGate: some View {

--- a/OpenCodeClient/OpenCodeClientTests/WorkspaceLinkResolverTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/WorkspaceLinkResolverTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import OpenCodeClient
+
+struct WorkspaceLinkResolverTests {
+    private let workspace = "/Users/me/project"
+
+    @Test func httpAndHttpsOpenExternally() throws {
+        #expect(WorkspaceLinkResolver.resolve("https://example.com/a", workspaceDirectory: workspace) == .external(try #require(URL(string: "https://example.com/a"))))
+        #expect(WorkspaceLinkResolver.resolve("http://example.com/a", workspaceDirectory: workspace) == .external(try #require(URL(string: "http://example.com/a"))))
+    }
+
+    @Test func httpDoesNotRequireWorkspaceDirectory() throws {
+        #expect(WorkspaceLinkResolver.resolve("https://example.com/a", workspaceDirectory: nil) == .external(try #require(URL(string: "https://example.com/a"))))
+    }
+
+    @Test func relativeLinksResolveFromWorkspaceRoot() {
+        #expect(WorkspaceLinkResolver.resolve("README.md", workspaceDirectory: workspace) == .file(path: "README.md"))
+        #expect(WorkspaceLinkResolver.resolve("./docs/a.md", workspaceDirectory: workspace) == .file(path: "docs/a.md"))
+    }
+
+    @Test func relativeLinksResolveFromMarkdownFileDirectory() {
+        let result = WorkspaceLinkResolver.resolve(
+            "../README.md",
+            workspaceDirectory: workspace,
+            baseFilePath: "/Users/me/project/docs/a.md"
+        )
+        #expect(result == .file(path: "README.md"))
+    }
+
+    @Test func absoluteWorkspacePathBecomesWorkspaceRelative() {
+        #expect(
+            WorkspaceLinkResolver.resolve("/Users/me/project/docs/a.md", workspaceDirectory: workspace) == .file(path: "docs/a.md")
+        )
+    }
+
+    @Test func fileURLInsideWorkspaceOpensFile() {
+        #expect(
+            WorkspaceLinkResolver.resolve("file:///Users/me/project/docs/a.md", workspaceDirectory: workspace) == .file(path: "docs/a.md")
+        )
+        #expect(
+            WorkspaceLinkResolver.resolve("file://localhost/Users/me/project/docs/a.md", workspaceDirectory: workspace) == .file(path: "docs/a.md")
+        )
+    }
+
+    @Test func fileURLWithNonLocalhostAuthorityIsRejected() {
+        guard case .rejected = WorkspaceLinkResolver.resolve("file://example.com/Users/me/project/docs/a.md", workspaceDirectory: workspace) else {
+            Issue.record("Expected non-localhost file URL authority to be rejected")
+            return
+        }
+    }
+
+    @Test func fragmentOnlyDoesNotRequestFile() {
+        #expect(WorkspaceLinkResolver.resolve("#intro", workspaceDirectory: workspace) == .fragmentOnly)
+    }
+
+    @Test func fileAnchorOpensFile() {
+        #expect(WorkspaceLinkResolver.resolve("README.md#intro", workspaceDirectory: workspace) == .file(path: "README.md"))
+    }
+
+    @Test func relativeTraversalOutsideWorkspaceIsRejected() {
+        guard case .rejected = WorkspaceLinkResolver.resolve("../secret.md", workspaceDirectory: workspace) else {
+            Issue.record("Expected workspace escape to be rejected")
+            return
+        }
+    }
+
+    @Test func encodedTraversalIsRejected() {
+        guard case .rejected = WorkspaceLinkResolver.resolve("%2e%2e/secret.md", workspaceDirectory: workspace) else {
+            Issue.record("Expected encoded traversal to be rejected")
+            return
+        }
+    }
+
+    @Test func prefixCollisionAbsolutePathIsRejected() {
+        guard case .rejected = WorkspaceLinkResolver.resolve("/Users/me/project-other/README.md", workspaceDirectory: workspace) else {
+            Issue.record("Expected prefix collision outside workspace to be rejected")
+            return
+        }
+    }
+
+    @Test func unsafeAndUnknownSchemesAreRejected() {
+        for href in ["javascript:alert(1)", "data:text/plain,hi", "ftp://example.com/a"] {
+            guard case .rejected = WorkspaceLinkResolver.resolve(href, workspaceDirectory: workspace) else {
+                Issue.record("Expected \(href) to be rejected")
+                return
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- resolve assistant Markdown links against the originating session workspace
- open workspace files in the existing file preview while preserving external HTTP links
- bind file reads to the clicked workspace and reject traversal or unsafe schemes
- reuse the same resolver for Markdown file previews

## Test plan
- `xcodebuild build -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination "platform=iOS Simulator,name=iPhone 16,OS=18.4" -derivedDataPath /tmp/opencode-ios-link-pr-dd CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination "platform=iOS Simulator,name=iPhone 16,OS=18.4" -only-testing:OpenCodeClientTests/WorkspaceLinkResolverTests -derivedDataPath /tmp/opencode-ios-link-pr-dd -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO` (13 tests)