### PR TITLE
Add GPT-5.6 Sol Pro and Fast presets

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -404,6 +404,8 @@ final class AppState {
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),
         ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2"),
+        ModelPreset(displayName: "GPT-5.6 Sol Pro", providerID: "openai", modelID: "gpt-5.6-sol-pro"),
+        ModelPreset(displayName: "GPT-5.6 Sol Fast", providerID: "openai", modelID: "gpt-5.6-sol-fast"),
     ]
     var selectedModelIndex: Int = 2
     

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -17,6 +17,8 @@ struct ModelPreset: Codable, Identifiable {
         case "DeepSeek Local": return "DS-L"
         case "DeepSeek V4 Pro": return "DS-Pro"
         case "Ollama GLM 5.2": return "OGLM-5.2"
+        case "GPT-5.6 Sol Pro": return "GPT-P"
+        case "GPT-5.6 Sol Fast": return "GPT-F"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"
         default: return displayName

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1911,6 +1911,14 @@ struct ModelPresetShortNameTests {
         let preset = ModelPreset(displayName: "GPT-5.3 Codex", providerID: "openai", modelID: "gpt-5.3-codex")
         #expect(preset.shortName == "GPT")
     }
+
+    @Test func gptSolModeShortNames() {
+        let pro = ModelPreset(displayName: "GPT-5.6 Sol Pro", providerID: "openai", modelID: "gpt-5.6-sol-pro")
+        let fast = ModelPreset(displayName: "GPT-5.6 Sol Fast", providerID: "openai", modelID: "gpt-5.6-sol-fast")
+
+        #expect(pro.shortName == "GPT-P")
+        #expect(fast.shortName == "GPT-F")
+    }
     
     @Test func unknownModelFallsBackToDisplayName() {
         let preset = ModelPreset(displayName: "Custom Model", providerID: "custom", modelID: "custom-1")
@@ -1979,6 +1987,7 @@ struct ModelSelectionPersistenceTests {
             let sessionID = "session-gpt"
             for legacyID in ["openai/gpt-5.4", "openai/gpt-5.5"] {
                 UserDefaults.standard.removeObject(forKey: selectedModelDefaultsKey)
+                UserDefaults.standard.removeObject(forKey: currentSessionDefaultsKey)
                 let legacySelection = [sessionID: legacyID]
                 let encoded = try! JSONEncoder().encode(legacySelection)
                 UserDefaults.standard.set(encoded, forKey: selectedModelDefaultsKey)
@@ -2051,6 +2060,19 @@ struct ModelSelectionPersistenceTests {
             #expect(state.modelPresets.contains(where: { $0.id == "ds4/deepseek-v4-flash" }))
             let preset = state.modelPresets.first(where: { $0.id == "ds4/deepseek-v4-flash" })
             #expect(preset?.displayName == "DeepSeek Local")
+        }
+    }
+
+    @Test @MainActor func defaultPresetsIncludeGPT56SolModes() {
+        withIsolatedModelSelectionDefaults {
+            let state = AppState()
+
+            #expect(state.modelPresets.contains(where: {
+                $0.id == "openai/gpt-5.6-sol-pro" && $0.displayName == "GPT-5.6 Sol Pro"
+            }))
+            #expect(state.modelPresets.contains(where: {
+                $0.id == "openai/gpt-5.6-sol-fast" && $0.displayName == "GPT-5.6 Sol Fast"
+            }))
         }
     }
 }


### PR DESCRIPTION
## Summary
- add GPT-5.6 Sol Pro (`openai/gpt-5.6-sol-pro`) and Fast (`openai/gpt-5.6-sol-fast`) presets
- use compact `GPT-P` and `GPT-F` toolbar labels
- append presets to preserve persisted model indexes
- strengthen model preset and migration test coverage

## Testing
- `xcodebuild build -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination "generic/platform=iOS Simulator" -derivedDataPath <isolated> CODE_SIGNING_ALLOWED=NO`
- 310 unit tests passed
- 29 UI tests passed with 3 environment-dependent tests skipped