### PR TITLE
Add optional AI usage quota dashboard

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+AIUsageQuota.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+AIUsageQuota.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+extension AppState {
+    nonisolated static func aiUsageQuotaEndpointURL(_ raw: String) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let corrected = Self.correctMalformedServerURL(trimmed) ?? trimmed
+        let info = Self.serverURLInfo(corrected)
+        guard info.isAllowed, let normalized = info.normalized else { return nil }
+        let normalizedEndpoint = normalized
+        guard var components = URLComponents(string: normalizedEndpoint), components.host != nil else { return nil }
+
+        let normalizedPath = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if normalizedPath != "api/v1/quotas" {
+            components.path = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            components.path = components.path.isEmpty ? "/api/v1/quotas" : "/\(components.path)/api/v1/quotas"
+        }
+        return components.url
+    }
+
+    var isAIUsageQuotaConfigured: Bool {
+        Self.aiUsageQuotaEndpointURL(aiUsageDashboardURL) != nil
+    }
+
+    var selectedModelQuota: AIUsageQuota? {
+        guard let key = selectedModel?.primaryQuotaKey else { return nil }
+        return aiUsageQuotaState.snapshot?.quota(provider: key.provider, label: key.label)
+    }
+
+    var isSelectedModelQuotaStale: Bool {
+        guard let snapshot = aiUsageQuotaState.snapshot else { return false }
+        if case .failed = aiUsageQuotaState { return true }
+        return Date().timeIntervalSince(snapshot.fetchedAt) > 300
+    }
+
+    func refreshAIUsageQuotas(force: Bool = false) async {
+        guard let endpoint = Self.aiUsageQuotaEndpointURL(aiUsageDashboardURL) else {
+            aiUsageQuotaState = .idle
+            return
+        }
+
+        if !force,
+           let snapshot = aiUsageQuotaState.snapshot,
+           Date().timeIntervalSince(snapshot.fetchedAt) < 60 {
+            return
+        }
+
+        let previous = aiUsageQuotaState.snapshot
+        aiUsageQuotaState = .loading(previous: previous)
+        do {
+            let response = try await aiUsageQuotaClient.fetchQuotas(from: endpoint)
+            if response.quotas.isEmpty {
+                aiUsageQuotaState = .empty(generatedAt: response.generatedAt)
+            } else {
+                aiUsageQuotaState = .ready(.init(
+                    generatedAt: response.generatedAt,
+                    fetchedAt: Date(),
+                    quotas: response.quotas
+                ))
+            }
+            aiUsageQuotaTestOK = true
+            aiUsageQuotaError = nil
+        } catch {
+            let message = error.localizedDescription
+            aiUsageQuotaState = .failed(previous: previous, message: message)
+            aiUsageQuotaTestOK = false
+            aiUsageQuotaError = message
+        }
+    }
+
+    func refreshAIUsageDashboard() async {
+        guard let endpoint = Self.aiUsageQuotaEndpointURL(aiUsageDashboardURL) else {
+            aiUsageQuotaState = .idle
+            return
+        }
+
+        let previous = aiUsageQuotaState.snapshot
+        isRefreshingAIUsageProviders = true
+        aiUsageQuotaState = .loading(previous: previous)
+        defer { isRefreshingAIUsageProviders = false }
+
+        do {
+            try await aiUsageQuotaClient.refreshDashboard(from: endpoint)
+            let response = try await aiUsageQuotaClient.fetchQuotas(from: endpoint)
+            if response.quotas.isEmpty {
+                aiUsageQuotaState = .empty(generatedAt: response.generatedAt)
+            } else {
+                aiUsageQuotaState = .ready(.init(
+                    generatedAt: response.generatedAt,
+                    fetchedAt: Date(),
+                    quotas: response.quotas
+                ))
+            }
+            aiUsageQuotaTestOK = true
+            aiUsageQuotaError = nil
+        } catch {
+            let message = error.localizedDescription
+            aiUsageQuotaState = .failed(previous: previous, message: message)
+            aiUsageQuotaTestOK = false
+            aiUsageQuotaError = message
+        }
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -171,16 +171,19 @@ final class AppState {
     static let customProjectPathKey = "customProjectPath"
     static let hostProfilesKey = "hostProfiles.v1"
     static let currentHostProfileIDKey = "currentHostProfileID.v1"
+    static let aiUsageDashboardURLKey = "aiUsageDashboardURL"
     static let languagePreferenceKey = L10n.languagePreferenceUserDefaultsKey
 
     init(
         apiClient: APIClientProtocol = APIClient(),
         sseClient: SSEClientProtocol = SSEClient(),
-        sshTunnelManager: SSHTunnelManager? = nil
+        sshTunnelManager: SSHTunnelManager? = nil,
+        aiUsageQuotaClient: AIUsageQuotaClientProtocol = AIUsageQuotaClient()
     ) {
         self.apiClient = apiClient
         self.sseClient = sseClient
         self.sshTunnelManager = sshTunnelManager ?? SSHTunnelManager()
+        self.aiUsageQuotaClient = aiUsageQuotaClient
         if let storedServer = UserDefaults.standard.string(forKey: Self.serverURLKey) {
             if storedServer == APIConstants.legacyDefaultServer {
                 _serverURL = APIClient.defaultServer
@@ -203,6 +206,7 @@ final class AppState {
         _selectedProjectWorktree = UserDefaults.standard.string(forKey: Self.selectedProjectWorktreeKey)
         _customProjectPath = UserDefaults.standard.string(forKey: Self.customProjectPathKey) ?? ""
         _languagePreference = L10n.languagePreference
+        _aiUsageDashboardURL = UserDefaults.standard.string(forKey: Self.aiUsageDashboardURLKey) ?? ""
 
         // Restore last known-good AI Builder connection state if token/baseURL unchanged.
         let storedSig = UserDefaults.standard.string(forKey: Self.aiBuilderLastOKSignatureKey)
@@ -312,6 +316,21 @@ final class AppState {
     var aiBuilderConnectionOK: Bool = false
     var aiBuilderLastTestedAt: Date? = nil
     var isTestingAIBuilderConnection: Bool = false
+    var _aiUsageDashboardURL: String = ""
+    var aiUsageDashboardURL: String {
+        get { _aiUsageDashboardURL }
+        set {
+            _aiUsageDashboardURL = newValue
+            UserDefaults.standard.set(newValue, forKey: Self.aiUsageDashboardURLKey)
+            aiUsageQuotaState = .idle
+            aiUsageQuotaTestOK = false
+            aiUsageQuotaError = nil
+        }
+    }
+    var aiUsageQuotaState: AIUsageQuotaState = .idle
+    var isRefreshingAIUsageProviders = false
+    var aiUsageQuotaTestOK = false
+    var aiUsageQuotaError: String?
     var isConnected: Bool = false
     var serverVersion: String?
     var connectionError: String?
@@ -528,6 +547,7 @@ final class AppState {
     let apiClient: APIClientProtocol
     let sseClient: SSEClientProtocol
     let sshTunnelManager: SSHTunnelManager
+    let aiUsageQuotaClient: AIUsageQuotaClientProtocol
     var sseTask: Task<Void, Never>?
 
     /// Guard against race conditions when rapidly switching sessions.

--- a/OpenCodeClient/OpenCodeClient/ContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/ContentView.swift
@@ -40,6 +40,10 @@ struct ContentView: View {
         ProcessInfo.processInfo.arguments.contains("UITEST_HOST_PROFILES_FIXTURE")
     }
 
+    private static var hasUITestQuotaFixture: Bool {
+        ProcessInfo.processInfo.arguments.contains("UITEST_QUOTA_FIXTURE")
+    }
+
     /// Which bundled fixture markdown to render in the web preview. Defaults to
     /// the HTML-cards fixture; override via WEB_PREVIEW_FIXTURE_NAME env var.
     private static var webPreviewFixtureName: String {
@@ -59,6 +63,11 @@ struct ContentView: View {
 
     private static func makeInitialState() -> AppState {
         let state = AppState()
+
+        if hasUITestQuotaFixture {
+            applyQuotaFixture(to: state)
+            return state
+        }
 
         if hasUITestHostProfilesFixture {
             applyHostProfilesFixture(to: state)
@@ -131,6 +140,38 @@ struct ContentView: View {
         state.currentSessionID = "root-session"
         state.expandedSessionIDs = ["root-session", "archived-session"]
         return state
+    }
+
+    private static func applyQuotaFixture(to state: AppState) {
+        let sessionID = "quota-fixture-session"
+        state.sessions = [
+            Session(
+                id: sessionID,
+                slug: sessionID,
+                projectID: "p1",
+                directory: "/tmp/quota-fixture",
+                parentID: nil,
+                title: "Quota UX Review",
+                version: "1",
+                time: .init(created: 1_000, updated: 2_000, archived: nil),
+                share: nil,
+                summary: nil
+            )
+        ]
+        state.currentSessionID = sessionID
+        state.draftInputsBySessionID[sessionID] = ""
+        state.selectedModelIndex = 6
+        state.aiUsageDashboardURL = "http://usage-dashboard.local:7995"
+        state.aiUsageQuotaState = .ready(.init(
+            generatedAt: "2026-07-12T09:40:00",
+            fetchedAt: Date(),
+            quotas: [
+                AIUsageQuota(provider: "codex", label: "5h", usedPercentage: 29, remainingPercentage: 71, nextResetTimeMs: 1_783_842_841_000, nextResetISO: nil, usage: nil, remaining: nil),
+                AIUsageQuota(provider: "codex", label: "7d", usedPercentage: 62, remainingPercentage: 38, nextResetTimeMs: 1_783_950_000_000, nextResetISO: nil, usage: nil, remaining: nil),
+                AIUsageQuota(provider: "claude", label: "5h", usedPercentage: 84, remainingPercentage: 16, nextResetTimeMs: 1_783_850_000_000, nextResetISO: nil, usage: nil, remaining: nil),
+                AIUsageQuota(provider: "glm", label: "5h", usedPercentage: 8, remainingPercentage: 92, nextResetTimeMs: 1_783_860_000_000, nextResetISO: nil, usage: nil, remaining: nil),
+            ]
+        ))
     }
 
     private static func applyHostProfilesFixture(to state: AppState) {
@@ -370,7 +411,7 @@ struct ContentView: View {
     }
 
     private func restoreConnectionFlow() async {
-        if Self.hasUITestSessionTreeFixture || Self.hasUITestToolCardsFixture || Self.hasUITestF3ComposerFixture || Self.hasUITestWebPreviewFixture || Self.hasUITestWebPreviewModeFixture {
+        if Self.hasUITestSessionTreeFixture || Self.hasUITestToolCardsFixture || Self.hasUITestF3ComposerFixture || Self.hasUITestWebPreviewFixture || Self.hasUITestWebPreviewModeFixture || Self.hasUITestQuotaFixture {
             return
         }
 

--- a/OpenCodeClient/OpenCodeClient/Models/AIUsageQuota.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/AIUsageQuota.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+struct AIUsageQuotasResponse: Decodable, Equatable {
+    let generatedAt: String?
+    let quotas: [AIUsageQuota]
+
+    enum CodingKeys: String, CodingKey {
+        case generatedAt = "generated_at"
+        case quotas
+    }
+}
+
+struct AIUsageQuota: Decodable, Equatable, Identifiable {
+    var id: String { "\(provider)|\(label)" }
+
+    let provider: String
+    let label: String
+    let usedPercentage: Int
+    let remainingPercentage: Int
+    let nextResetTimeMs: Int64?
+    let nextResetISO: String?
+    let usage: Int?
+    let remaining: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case provider, label, usage, remaining
+        case usedPercentage = "used_percentage"
+        case remainingPercentage = "remaining_percentage"
+        case nextResetTimeMs = "next_reset_time_ms"
+        case nextResetISO = "next_reset_iso"
+    }
+
+    var clampedUsedPercentage: Int { min(max(usedPercentage, 0), 100) }
+    var clampedRemainingPercentage: Int { min(max(remainingPercentage, 0), 100) }
+    var resetDate: Date? {
+        nextResetTimeMs.map { Date(timeIntervalSince1970: Double($0) / 1_000) }
+    }
+}
+
+struct AIUsageQuotaSnapshot: Equatable {
+    let generatedAt: String?
+    let fetchedAt: Date
+    let quotas: [AIUsageQuota]
+
+    func quota(provider: String, label: String) -> AIUsageQuota? {
+        quotas.first {
+            $0.provider.caseInsensitiveCompare(provider) == .orderedSame
+                && $0.label.caseInsensitiveCompare(label) == .orderedSame
+        }
+    }
+}
+
+enum AIUsageQuotaState: Equatable {
+    case idle
+    case loading(previous: AIUsageQuotaSnapshot?)
+    case ready(AIUsageQuotaSnapshot)
+    case empty(generatedAt: String?)
+    case failed(previous: AIUsageQuotaSnapshot?, message: String)
+
+    var snapshot: AIUsageQuotaSnapshot? {
+        switch self {
+        case .ready(let snapshot), .loading(let snapshot?), .failed(let snapshot?, _):
+            return snapshot
+        case .idle, .loading(nil), .empty, .failed(nil, _):
+            return nil
+        }
+    }
+}
+
+struct AIUsageQuotaKey: Equatable {
+    let provider: String
+    let label: String
+}
+
+extension ModelPreset {
+    var primaryQuotaKey: AIUsageQuotaKey? {
+        switch providerID {
+        case "openai": return AIUsageQuotaKey(provider: "codex", label: "5h")
+        case "zai-coding-plan": return AIUsageQuotaKey(provider: "glm", label: "5h")
+        case "ollama-cloud": return AIUsageQuotaKey(provider: "ollama", label: "5h")
+        default: return nil
+        }
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/Services/AIUsageQuotaClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/AIUsageQuotaClient.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+protocol AIUsageQuotaClientProtocol: Sendable {
+    func fetchQuotas(from endpoint: URL) async throws -> AIUsageQuotasResponse
+    func refreshDashboard(from quotasEndpoint: URL) async throws
+}
+
+actor AIUsageQuotaClient: AIUsageQuotaClientProtocol {
+    func fetchQuotas(from endpoint: URL) async throws -> AIUsageQuotasResponse {
+        var request = URLRequest(url: endpoint)
+        request.timeoutInterval = 15
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AIUsageQuotaClientError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw AIUsageQuotaClientError.httpError(http.statusCode)
+        }
+        return try JSONDecoder().decode(AIUsageQuotasResponse.self, from: data)
+    }
+
+    func refreshDashboard(from quotasEndpoint: URL) async throws {
+        guard var components = URLComponents(url: quotasEndpoint, resolvingAgainstBaseURL: false),
+              components.path.hasSuffix("/api/v1/quotas") else {
+            throw AIUsageQuotaClientError.invalidURL
+        }
+        components.path.removeLast("/api/v1/quotas".count)
+        components.path += "/api/v1/display/update"
+        guard let endpoint = components.url else { throw AIUsageQuotaClientError.invalidURL }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 240
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "reason": "force_button",
+            "view": "7d",
+            "device_id": "opencode-ios",
+        ])
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AIUsageQuotaClientError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw AIUsageQuotaClientError.httpError(http.statusCode)
+        }
+    }
+}
+
+enum AIUsageQuotaClientError: LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case httpError(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalid AI Usage Dashboard URL"
+        case .invalidResponse: return "Invalid response from AI Usage Dashboard"
+        case .httpError(let status): return "AI Usage Dashboard returned HTTP \(status)"
+        }
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -88,6 +88,9 @@ enum L10n {
         case settingsTested
         case settingsAbout
         case settingsServerVersion
+        case settingsAIUsageDashboard
+        case settingsAIUsageDashboardURL
+        case settingsAIUsageDashboardFooter
         case settingsRotateKeyTitle
         case settingsRotateKeyPrompt
         case settingsPublicKeyTitle
@@ -315,6 +318,20 @@ enum L10n {
         case contextUsageLoadingConfig
         case contextUsageNoUsageData
         case contextUsageConfigNotLoaded
+        case quotaTitle
+        case quotaDataSource
+        case quotaNotLoaded
+        case quotaLoading
+        case quotaRefreshing
+        case quotaRefreshingProviders
+        case quotaNoCachedData
+        case quotaStale
+        case quotaLastFetched
+        case quotaGeneratedAt
+        case quotaRemainingFormat
+        case quotaUsedFormat
+        case quotaResetFormat
+        case quotaCurrentModelAccessibility
 
         case sessionTitle
         case sessionsTitle
@@ -472,6 +489,9 @@ enum L10n {
         Key.settingsTested.rawValue: "OK",
         Key.settingsAbout.rawValue: "About",
         Key.settingsServerVersion.rawValue: "Server Version",
+        Key.settingsAIUsageDashboard.rawValue: "AI Usage Dashboard",
+        Key.settingsAIUsageDashboardURL.rawValue: "Dashboard URL (optional)",
+        Key.settingsAIUsageDashboardFooter.rawValue: "Leave blank for no quota UI. Enter the dashboard base URL or the full /api/v1/quotas endpoint.",
         Key.settingsRotateKeyTitle.rawValue: "Rotate SSH Key?",
         Key.settingsRotateKeyPrompt.rawValue: "This will generate a new key pair for this device. Update the public key on your SSH server before using SSH tunnel hosts again.",
         Key.settingsPublicKeyTitle.rawValue: "Your Public Key",
@@ -697,6 +717,20 @@ enum L10n {
         Key.contextUsageLoadingConfig.rawValue: "Loading provider config...",
         Key.contextUsageNoUsageData.rawValue: "No usage data",
         Key.contextUsageConfigNotLoaded.rawValue: "Provider config not loaded",
+        Key.quotaTitle.rawValue: "Usage & Limits",
+        Key.quotaDataSource.rawValue: "Data Source",
+        Key.quotaNotLoaded.rawValue: "Quota data has not been loaded.",
+        Key.quotaLoading.rawValue: "Loading quota data...",
+        Key.quotaRefreshing.rawValue: "Refreshing cached quota data...",
+        Key.quotaRefreshingProviders.rawValue: "Refreshing providers...",
+        Key.quotaNoCachedData.rawValue: "No cached quota snapshot. Refresh AI Usage Dashboard on the host.",
+        Key.quotaStale.rawValue: "Showing stale quota data",
+        Key.quotaLastFetched.rawValue: "Last fetched",
+        Key.quotaGeneratedAt.rawValue: "Generated at",
+        Key.quotaRemainingFormat.rawValue: "%d%% left",
+        Key.quotaUsedFormat.rawValue: "%d%% used",
+        Key.quotaResetFormat.rawValue: "Resets %@",
+        Key.quotaCurrentModelAccessibility.rawValue: "Current model quota: %@",
 
         Key.sessionTitle.rawValue: "Session",
         Key.sessionsTitle.rawValue: "Sessions",
@@ -855,6 +889,9 @@ enum L10n {
         Key.settingsTested.rawValue: "可用",
         Key.settingsAbout.rawValue: "关于",
         Key.settingsServerVersion.rawValue: "服务器版本",
+        Key.settingsAIUsageDashboard.rawValue: "AI 用量面板",
+        Key.settingsAIUsageDashboardURL.rawValue: "面板地址（可选）",
+        Key.settingsAIUsageDashboardFooter.rawValue: "留空时不显示任何 quota 界面。可填写面板根地址或完整的 /api/v1/quotas 地址。",
         Key.settingsRotateKeyTitle.rawValue: "要更换 SSH 密钥吗？",
         Key.settingsRotateKeyPrompt.rawValue: "这将为本设备生成一对新密钥。再次使用 SSH Tunnel hosts 前，请同步更新 SSH server 上的公钥。",
         Key.settingsPublicKeyTitle.rawValue: "你的公钥",
@@ -1083,6 +1120,20 @@ enum L10n {
         Key.contextUsageLoadingConfig.rawValue: "正在加载服务商配置...",
         Key.contextUsageNoUsageData.rawValue: "无使用数据",
         Key.contextUsageConfigNotLoaded.rawValue: "未加载服务商配置",
+        Key.quotaTitle.rawValue: "用量与限额",
+        Key.quotaDataSource.rawValue: "数据来源",
+        Key.quotaNotLoaded.rawValue: "尚未加载 quota 数据。",
+        Key.quotaLoading.rawValue: "正在加载 quota 数据...",
+        Key.quotaRefreshing.rawValue: "正在刷新缓存的 quota 数据...",
+        Key.quotaRefreshingProviders.rawValue: "正在从服务商更新数据...",
+        Key.quotaNoCachedData.rawValue: "没有缓存的 quota 快照。请先在主机上刷新 AI Usage Dashboard。",
+        Key.quotaStale.rawValue: "正在显示过期 quota 数据",
+        Key.quotaLastFetched.rawValue: "上次获取",
+        Key.quotaGeneratedAt.rawValue: "生成时间",
+        Key.quotaRemainingFormat.rawValue: "剩余 %d%%",
+        Key.quotaUsedFormat.rawValue: "已用 %d%%",
+        Key.quotaResetFormat.rawValue: "%@ 重置",
+        Key.quotaCurrentModelAccessibility.rawValue: "当前模型 quota：%@",
 
         Key.sessionTitle.rawValue: "会话",
         Key.sessionsTitle.rawValue: "会话",

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/AIUsageQuotaView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/AIUsageQuotaView.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+struct AIUsageQuotaButton: View {
+    @Bindable var state: AppState
+    @State private var showSheet = false
+
+    private var quota: AIUsageQuota? { state.selectedModelQuota }
+
+    private var badgeColor: Color {
+        guard !state.isSelectedModelQuotaStale, let remaining = quota?.clampedRemainingPercentage else {
+            return DesignColors.Neutral.textSecondary
+        }
+        if remaining <= 10 { return DesignColors.Semantic.error }
+        if remaining <= 20 { return DesignColors.Semantic.warning }
+        return DesignColors.Neutral.textSecondary
+    }
+
+    private var badgeText: String {
+        if state.isSelectedModelQuotaStale { return "stale @ 5h" }
+        guard let quota else {
+            if case .loading = state.aiUsageQuotaState { return "... @ 5h" }
+            return "-- @ 5h"
+        }
+        return "\(quota.clampedRemainingPercentage)% @ \(quota.label)"
+    }
+
+    var body: some View {
+        if state.isAIUsageQuotaConfigured, state.selectedModel?.primaryQuotaKey != nil {
+            Button {
+                showSheet = true
+                Task { await state.refreshAIUsageQuotas(force: true) }
+            } label: {
+                Text(badgeText)
+                    .font(.caption2.weight(.semibold))
+                    .lineLimit(1)
+                    .foregroundStyle(badgeColor)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .overlay(
+                        Capsule()
+                            .stroke(badgeColor.opacity(0.45), lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("chat-toolbar-quota")
+            .accessibilityLabel(L10n.t(.quotaCurrentModelAccessibility, badgeText))
+            .sheet(isPresented: $showSheet) {
+                NavigationStack {
+                    AIUsageQuotaDetailView(state: state)
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button(L10n.t(.appDone)) { showSheet = false }
+                            }
+                            ToolbarItem(placement: .primaryAction) {
+                                Button {
+                                    Task { await state.refreshAIUsageDashboard() }
+                                } label: {
+                                    Image(systemName: "arrow.clockwise")
+                                }
+                                .disabled({
+                                    if case .loading = state.aiUsageQuotaState { return true }
+                                    return false
+                                }())
+                            }
+                        }
+                }
+                .presentationDetents([.medium, .large])
+            }
+        }
+    }
+}
+
+struct AIUsageQuotaDetailView: View {
+    @Bindable var state: AppState
+
+    private var groupedQuotas: [(String, [AIUsageQuota])] {
+        let quotas = state.aiUsageQuotaState.snapshot?.quotas ?? []
+        return Dictionary(grouping: quotas, by: \AIUsageQuota.provider)
+            .map { ($0.key, $0.value.sorted { $0.label < $1.label }) }
+            .sorted { $0.0 < $1.0 }
+    }
+
+    var body: some View {
+        List {
+            ForEach(groupedQuotas, id: \.0) { provider, quotas in
+                if !quotas.isEmpty {
+                    Section(providerDisplayName(provider)) {
+                        ForEach(quotas) { quota in
+                            quotaRow(quota)
+                        }
+                    }
+                }
+            }
+
+            statusSection
+        }
+        .navigationTitle(L10n.t(.quotaTitle))
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("quota-detail")
+    }
+
+    @ViewBuilder
+    private var statusSection: some View {
+        Section(L10n.t(.quotaDataSource)) {
+            switch state.aiUsageQuotaState {
+            case .idle:
+                Text(L10n.t(.quotaNotLoaded)).foregroundStyle(.secondary)
+            case .loading(let previous):
+                HStack {
+                    ProgressView()
+                    Text(state.isRefreshingAIUsageProviders
+                         ? L10n.t(.quotaRefreshingProviders)
+                         : (previous == nil ? L10n.t(.quotaLoading) : L10n.t(.quotaRefreshing)))
+                }
+            case .empty:
+                Text(L10n.t(.quotaNoCachedData)).foregroundStyle(.secondary)
+            case .failed(_, let message):
+                Label(L10n.t(.quotaStale), systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text(message).font(.caption).foregroundStyle(.secondary)
+            case .ready(let snapshot):
+                LabeledContent(L10n.t(.quotaLastFetched), value: snapshot.fetchedAt.formatted(date: .omitted, time: .shortened))
+                if let generatedAt = snapshot.generatedAt {
+                    LabeledContent(L10n.t(.quotaGeneratedAt), value: generatedAt)
+                }
+            }
+            Text(state.aiUsageDashboardURL)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func quotaRow(_ quota: AIUsageQuota) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(quota.label)
+                Spacer()
+                Text(L10n.t(.quotaRemainingFormat, quota.clampedRemainingPercentage))
+                    .font(.subheadline.monospacedDigit())
+                    .foregroundStyle(quotaColor(quota.clampedRemainingPercentage))
+            }
+            ProgressView(value: Double(quota.clampedRemainingPercentage), total: 100)
+                .tint(quotaColor(quota.clampedRemainingPercentage))
+            HStack {
+                Text(L10n.t(.quotaUsedFormat, quota.clampedUsedPercentage))
+                Spacer()
+                if let reset = quota.resetDate {
+                    Text(L10n.t(.quotaResetFormat, reset.formatted(date: .abbreviated, time: .shortened)))
+                }
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func quotaColor(_ remaining: Int) -> Color {
+        if remaining <= 10 { return DesignColors.Semantic.error }
+        if remaining <= 20 { return DesignColors.Semantic.warning }
+        return DesignColors.Brand.primary
+    }
+
+    private func providerDisplayName(_ provider: String) -> String {
+        switch provider.lowercased() {
+        case "codex": return "OpenAI / Codex"
+        case "glm": return "Z.ai / GLM"
+        case "ollama": return "Ollama Cloud"
+        case "claude": return "Claude"
+        case "antigravity": return "Antigravity"
+        default: return provider
+        }
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/AIUsageQuotaView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/AIUsageQuotaView.swift
@@ -112,6 +112,15 @@ struct AIUsageQuotaDetailView: View {
                          ? L10n.t(.quotaRefreshingProviders)
                          : (previous == nil ? L10n.t(.quotaLoading) : L10n.t(.quotaRefreshing)))
                 }
+                if let previous {
+                    LabeledContent(L10n.t(.quotaLastFetched), value: previous.fetchedAt.formatted(date: .omitted, time: .shortened))
+                    if let generatedAt = previous.generatedAt {
+                        LabeledContent(L10n.t(.quotaGeneratedAt)) {
+                            Text(generatedAt)
+                                .accessibilityIdentifier("quota-generated-at")
+                        }
+                    }
+                }
             case .empty:
                 Text(L10n.t(.quotaNoCachedData)).foregroundStyle(.secondary)
             case .failed(_, let message):
@@ -121,7 +130,10 @@ struct AIUsageQuotaDetailView: View {
             case .ready(let snapshot):
                 LabeledContent(L10n.t(.quotaLastFetched), value: snapshot.fetchedAt.formatted(date: .omitted, time: .shortened))
                 if let generatedAt = snapshot.generatedAt {
-                    LabeledContent(L10n.t(.quotaGeneratedAt), value: generatedAt)
+                    LabeledContent(L10n.t(.quotaGeneratedAt)) {
+                        Text(generatedAt)
+                            .accessibilityIdentifier("quota-generated-at")
+                    }
                 }
             }
             Text(state.aiUsageDashboardURL)

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatToolbarView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatToolbarView.swift
@@ -93,6 +93,7 @@ struct ChatToolbarView: View {
     private var rightButtons: some View {
         HStack(spacing: DesignSpacing.md) {
             configButton
+            AIUsageQuotaButton(state: state)
             todoButton
             ContextUsageButton(state: state)
             
@@ -126,6 +127,7 @@ struct ChatToolbarView: View {
                     .stroke(DesignColors.Brand.primary.opacity(0.30), lineWidth: 1)
             )
         }
+        .accessibilityIdentifier("chat-toolbar-model")
         .sheet(isPresented: $showConfigSheet) {
             NavigationStack {
                 List {

--- a/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
@@ -102,6 +102,45 @@ struct SettingsTabView: View {
                     }
                 }
 
+                Section {
+                    TextField(L10n.t(.settingsAIUsageDashboardURL), text: $state.aiUsageDashboardURL)
+                        .textContentType(.URL)
+                        .autocapitalization(.none)
+                        .accessibilityIdentifier("settings-ai-usage-url")
+
+                    HStack {
+                        Button(L10n.t(.settingsTestConnection)) {
+                            Task { await state.refreshAIUsageQuotas(force: true) }
+                        }
+                        .disabled(!state.isAIUsageQuotaConfigured || {
+                            if case .loading = state.aiUsageQuotaState { return true }
+                            return false
+                        }())
+                        .accessibilityIdentifier("settings-ai-usage-test")
+
+                        Spacer()
+                        if case .loading = state.aiUsageQuotaState {
+                            ProgressView()
+                        } else if state.aiUsageQuotaTestOK {
+                            Label(L10n.t(.commonOk), systemImage: "checkmark.circle.fill")
+                                .foregroundStyle(DesignColors.Semantic.success)
+                        } else if state.aiUsageQuotaError != nil {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(DesignColors.Semantic.warning)
+                        }
+                    }
+
+                    if let error = state.aiUsageQuotaError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                } header: {
+                    Text(L10n.t(.settingsAIUsageDashboard))
+                } footer: {
+                    Text(L10n.t(.settingsAIUsageDashboardFooter))
+                }
+
                 Section(L10n.t(.settingsSpeechRecognition)) {
                     TextField(L10n.t(.settingsAiBuilderBaseURL), text: $state.aiBuilderBaseURL)
                         .textContentType(.URL)

--- a/OpenCodeClient/OpenCodeClientTests/AIUsageQuotaTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/AIUsageQuotaTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import OpenCodeClient
+
+private actor MockAIUsageQuotaClient: AIUsageQuotaClientProtocol {
+    let result: Result<AIUsageQuotasResponse, Error>
+    private(set) var endpoints: [URL] = []
+    private(set) var events: [String] = []
+
+    init(result: Result<AIUsageQuotasResponse, Error>) {
+        self.result = result
+    }
+
+    func fetchQuotas(from endpoint: URL) async throws -> AIUsageQuotasResponse {
+        endpoints.append(endpoint)
+        events.append("fetch")
+        return try result.get()
+    }
+
+    func refreshDashboard(from quotasEndpoint: URL) async throws {
+        events.append("refresh")
+    }
+
+    func requestCount() -> Int { endpoints.count }
+    func recordedEvents() -> [String] { events }
+}
+
+@Suite(.serialized)
+struct AIUsageQuotaTests {
+    @Test func decodesQuotaContract() throws {
+        let data = Data(#"{"generated_at":"2026-07-12T09:00:00","quotas":[{"provider":"codex","label":"5h","used_percentage":29,"remaining_percentage":71,"next_reset_time_ms":1783842841000,"next_reset_iso":"2026-07-12T10:54:01","usage":null,"remaining":null}]}"#.utf8)
+
+        let response = try JSONDecoder().decode(AIUsageQuotasResponse.self, from: data)
+
+        #expect(response.generatedAt == "2026-07-12T09:00:00")
+        #expect(response.quotas.first?.provider == "codex")
+        #expect(response.quotas.first?.clampedRemainingPercentage == 71)
+        #expect(response.quotas.first?.resetDate != nil)
+    }
+
+    @Test func normalizesBaseAndFullEndpointURLs() {
+        #expect(AppState.aiUsageQuotaEndpointURL("192.168.1.20:7995")?.absoluteString == "http://192.168.1.20:7995/api/v1/quotas")
+        #expect(AppState.aiUsageQuotaEndpointURL("https://usage.example.com/api/v1/quotas")?.absoluteString == "https://usage.example.com/api/v1/quotas")
+        #expect(AppState.aiUsageQuotaEndpointURL("https://usage.example.com/")?.absoluteString == "https://usage.example.com/api/v1/quotas")
+        #expect(AppState.aiUsageQuotaEndpointURL("http://usage.example.com") == nil)
+        #expect(AppState.aiUsageQuotaEndpointURL("  ") == nil)
+    }
+
+    @Test func mapsSupportedModelsToQuotaProviders() {
+        let gpt = ModelPreset(displayName: "GPT-5.6 Sol", providerID: "openai", modelID: "gpt-5.6-sol")
+        let glm = ModelPreset(displayName: "GLM-5.2", providerID: "zai-coding-plan", modelID: "glm-5.2")
+        let gemini = ModelPreset(displayName: "Gemini 3.5 Flash", providerID: "google", modelID: "gemini-3.5-flash")
+
+        #expect(gpt.primaryQuotaKey == AIUsageQuotaKey(provider: "codex", label: "5h"))
+        #expect(glm.primaryQuotaKey == AIUsageQuotaKey(provider: "glm", label: "5h"))
+        #expect(gemini.primaryQuotaKey == nil)
+    }
+
+    @Test @MainActor func blankEndpointMakesNoRequest() async {
+        let previous = UserDefaults.standard.string(forKey: AppState.aiUsageDashboardURLKey)
+        defer {
+            if let previous { UserDefaults.standard.set(previous, forKey: AppState.aiUsageDashboardURLKey) }
+            else { UserDefaults.standard.removeObject(forKey: AppState.aiUsageDashboardURLKey) }
+        }
+        let mock = MockAIUsageQuotaClient(result: .success(.init(generatedAt: nil, quotas: [])))
+        let state = AppState(aiUsageQuotaClient: mock)
+        state.aiUsageDashboardURL = ""
+
+        await state.refreshAIUsageQuotas(force: true)
+
+        #expect(await mock.requestCount() == 0)
+        #expect(state.aiUsageQuotaState == .idle)
+    }
+
+    @Test @MainActor func refreshLoadsSelectedGPTQuota() async {
+        let previous = UserDefaults.standard.string(forKey: AppState.aiUsageDashboardURLKey)
+        defer {
+            if let previous { UserDefaults.standard.set(previous, forKey: AppState.aiUsageDashboardURLKey) }
+            else { UserDefaults.standard.removeObject(forKey: AppState.aiUsageDashboardURLKey) }
+        }
+        let quota = AIUsageQuota(
+            provider: "codex",
+            label: "5h",
+            usedPercentage: 29,
+            remainingPercentage: 71,
+            nextResetTimeMs: nil,
+            nextResetISO: nil,
+            usage: nil,
+            remaining: nil
+        )
+        let mock = MockAIUsageQuotaClient(result: .success(.init(generatedAt: "2026-07-12T09:00:00", quotas: [quota])))
+        let state = AppState(aiUsageQuotaClient: mock)
+        state.aiUsageDashboardURL = "https://usage.example.com"
+        state.selectedModelIndex = 1
+
+        await state.refreshAIUsageQuotas(force: true)
+
+        #expect(state.selectedModelQuota == quota)
+        #expect(state.aiUsageQuotaTestOK)
+        #expect(await mock.requestCount() == 1)
+    }
+
+    @Test @MainActor func manualRefreshUpdatesDashboardBeforeFetchingQuotas() async {
+        let previous = UserDefaults.standard.string(forKey: AppState.aiUsageDashboardURLKey)
+        defer {
+            if let previous { UserDefaults.standard.set(previous, forKey: AppState.aiUsageDashboardURLKey) }
+            else { UserDefaults.standard.removeObject(forKey: AppState.aiUsageDashboardURLKey) }
+        }
+        let mock = MockAIUsageQuotaClient(result: .success(.init(generatedAt: nil, quotas: [])))
+        let state = AppState(aiUsageQuotaClient: mock)
+        state.aiUsageDashboardURL = "https://usage.example.com"
+
+        await state.refreshAIUsageDashboard()
+
+        #expect(await mock.recordedEvents() == ["refresh", "fetch"])
+        #expect(!state.isRefreshingAIUsageProviders)
+    }
+}

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -39,14 +39,22 @@ struct OpenCodeClientTests {
     @Test @MainActor func migrateLegacyDefaultServerAddress() {
         let key = "serverURL"
         let previous = UserDefaults.standard.string(forKey: key)
+        let previousProfiles = UserDefaults.standard.data(forKey: AppState.hostProfilesKey)
+        let previousProfileID = UserDefaults.standard.string(forKey: AppState.currentHostProfileIDKey)
         defer {
             if let previous {
                 UserDefaults.standard.set(previous, forKey: key)
             } else {
                 UserDefaults.standard.removeObject(forKey: key)
             }
+            if let previousProfiles { UserDefaults.standard.set(previousProfiles, forKey: AppState.hostProfilesKey) }
+            else { UserDefaults.standard.removeObject(forKey: AppState.hostProfilesKey) }
+            if let previousProfileID { UserDefaults.standard.set(previousProfileID, forKey: AppState.currentHostProfileIDKey) }
+            else { UserDefaults.standard.removeObject(forKey: AppState.currentHostProfileIDKey) }
         }
 
+        UserDefaults.standard.removeObject(forKey: AppState.hostProfilesKey)
+        UserDefaults.standard.removeObject(forKey: AppState.currentHostProfileIDKey)
         UserDefaults.standard.set("localhost:4096", forKey: key)
         let state = AppState()
         #expect(state.serverURL == "127.0.0.1:4096")

--- a/OpenCodeClient/OpenCodeClientUITests/AIUsageQuotaUITests.swift
+++ b/OpenCodeClient/OpenCodeClientUITests/AIUsageQuotaUITests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+final class AIUsageQuotaUITests: XCTestCase {
+    @MainActor
+    func testQuotaBadgeAndDetailFixture() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["UITEST_QUOTA_FIXTURE"]
+        app.launch()
+
+        let badge = app.buttons["chat-toolbar-quota"]
+        XCTAssertTrue(badge.waitForExistence(timeout: 8))
+        XCTAssertTrue(badge.label.contains("71% @ 5h"))
+        saveScreenshot(app, name: "quota-toolbar")
+
+        badge.tap()
+        XCTAssertTrue(app.staticTexts["Usage & Limits"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.staticTexts["OpenAI / Codex"].waitForExistence(timeout: 8))
+        saveScreenshot(app, name: "quota-detail")
+    }
+
+    @MainActor
+    private func saveScreenshot(_ app: XCUIApplication, name: String) {
+        let screenshot = app.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        guard let directory = ProcessInfo.processInfo.environment["QUOTA_SCREENSHOT_DIR"] else { return }
+        let url = URL(fileURLWithPath: directory, isDirectory: true).appendingPathComponent("\(name).png")
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? screenshot.pngRepresentation.write(to: url, options: .atomic)
+    }
+}

--- a/OpenCodeClient/OpenCodeClientUITests/AIUsageQuotaUITests.swift
+++ b/OpenCodeClient/OpenCodeClientUITests/AIUsageQuotaUITests.swift
@@ -15,6 +15,10 @@ final class AIUsageQuotaUITests: XCTestCase {
         badge.tap()
         XCTAssertTrue(app.staticTexts["Usage & Limits"].waitForExistence(timeout: 8))
         XCTAssertTrue(app.staticTexts["OpenAI / Codex"].waitForExistence(timeout: 8))
+        app.swipeUp()
+        let generatedAt = app.descendants(matching: .any)["quota-generated-at"]
+        XCTAssertTrue(generatedAt.waitForExistence(timeout: 8))
+        XCTAssertTrue(generatedAt.label.contains("2026-07-12T09:40:00"))
         saveScreenshot(app, name: "quota-detail")
     }
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Current visionOS baseline limitations:
 Set an AI Usage Dashboard base URL in Settings to show the selected model's
 primary quota beside the model picker. Opening Usage & Limits reads the cached
 quota snapshot. The refresh button explicitly waits for a full provider update
-and then reloads the compact quota endpoint. The app does not poll or trigger
-automatic provider refreshes, and the quota UI is absent when no URL is set.
+and then reloads the compact quota endpoint. Details show both the API snapshot's
+generation time and the device's local fetch time. The app does not poll or
+trigger automatic provider refreshes, and the quota UI is absent when no URL is set.
 
 ## Remote Access
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ No Apple Developer account needed. Just tap the link on your iOS device.
 - **Chat**: send messages, switch models, view AI replies with streaming, inspect tool calls and reasoning
 - **Files**: file tree browser, session diffs, markdown preview, image preview with zoom/pan, code view with line numbers
 - **Settings**: server connection, Basic Auth, SSH tunnel, theme, voice transcription
+- **Usage limits**: optional AI Usage Dashboard integration for provider quota windows
 
 ### Apple Vision Pro support
 
@@ -43,6 +44,14 @@ Current visionOS baseline limitations:
 2. Open the iOS app, go to Settings, enter the server address (e.g. `http://192.168.x.x:4096`)
 3. Tap Test Connection
 4. Switch to Chat, create or select a session, and start talking
+
+### Optional usage limits
+
+Set an AI Usage Dashboard base URL in Settings to show the selected model's
+primary quota beside the model picker. Opening Usage & Limits reads the cached
+quota snapshot. The refresh button explicitly waits for a full provider update
+and then reloads the compact quota endpoint. The app does not poll or trigger
+automatic provider refreshes, and the quota UI is absent when no URL is set.
 
 ## Remote Access
 


### PR DESCRIPTION
## Summary
- add an optional global AI Usage Dashboard URL in Settings
- show compact selected-model quota as `71% @ 5h` with no UI when unconfigured
- load cached quotas only when Usage & Limits opens
- make manual refresh wait for `POST /api/v1/display/update` and then reload `GET /api/v1/quotas`
- group the detail sheet directly by API provider/window data
- preserve stale data on failures and localize the new UI

## Validation
- 315 deterministic unit tests passed (live-server integration excluded)
- 30 UI tests passed, 3 environment-driven tests skipped
- quota fixture screenshot test passed