### PR TITLE
Add FluidVoice transcription support

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+FluidVoice.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+FluidVoice.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+extension AppState {
+    @discardableResult
+    func normalizeFluidVoiceBaseURL() throws -> String {
+        let normalized = try FluidVoiceClient.normalizedBaseURL(fluidVoiceBaseURL).absoluteString
+        if normalized != fluidVoiceBaseURL {
+            fluidVoiceBaseURL = normalized
+        }
+        return normalized
+    }
+
+    func testFluidVoiceConnection() async {
+        guard !isTestingFluidVoiceConnection else { return }
+        isTestingFluidVoiceConnection = true
+        defer { isTestingFluidVoiceConnection = false }
+
+        fluidVoiceConnectionOK = false
+        fluidVoiceConnectionError = nil
+        fluidVoiceHealthStatus = nil
+        fluidVoiceHealthVersion = nil
+
+        do {
+            let normalized = try normalizeFluidVoiceBaseURL()
+            let health = try await fluidVoiceClient.health(baseURL: normalized)
+            fluidVoiceHealthStatus = health.status
+            fluidVoiceHealthVersion = health.version
+            fluidVoiceConnectionOK = health.status.lowercased() == "ok"
+            if !fluidVoiceConnectionOK {
+                fluidVoiceConnectionError = "FluidVoice reported status: \(health.status)"
+            }
+        } catch {
+            fluidVoiceConnectionError = error.localizedDescription
+        }
+    }
+
+    func transcribeWithFluidVoice(wavFileURL: URL) async throws -> String {
+        let normalized = try normalizeFluidVoiceBaseURL()
+        return try await fluidVoiceClient.transcribeAudio(
+            wavFileURL: wavFileURL,
+            baseURL: normalized,
+            postprocessWithFluidIntelligence: fluidVoicePostprocess
+        )
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -9,6 +9,13 @@ import Observation
 import os
 import VoiceFlowKit
 
+enum VoiceTranscriptionProvider: String, CaseIterable, Identifiable, Sendable {
+    case voiceFlow
+    case fluidVoice
+
+    var id: String { rawValue }
+}
+
 struct SessionNode: Identifiable {
     let session: Session
     let children: [SessionNode]
@@ -165,6 +172,9 @@ final class AppState {
     static let aiBuilderTerminologyKey = "aiBuilderTerminology"
     static let aiBuilderLastOKSignatureKey = "aiBuilderLastOKSignature"
     static let aiBuilderLastOKTestedAtKey = "aiBuilderLastOKTestedAt"
+    static let voiceTranscriptionProviderKey = "voiceTranscriptionProvider"
+    static let fluidVoiceBaseURLKey = "fluidVoiceBaseURL"
+    static let fluidVoicePostprocessKey = "fluidVoicePostprocess"
     static let draftInputsBySessionKey = "draftInputsBySession"
     static let selectedModelBySessionKey = "selectedModelBySession"
     static let selectedProjectWorktreeKey = "selectedProjectWorktree"
@@ -203,6 +213,11 @@ final class AppState {
         _aiBuilderToken = KeychainHelper.load(forKey: Self.aiBuilderTokenKeychainKey) ?? ""
         _aiBuilderCustomPrompt = UserDefaults.standard.string(forKey: Self.aiBuilderCustomPromptKey) ?? Self.defaultAIBuilderCustomPrompt
         _aiBuilderTerminology = UserDefaults.standard.string(forKey: Self.aiBuilderTerminologyKey) ?? Self.defaultAIBuilderTerminology
+        _voiceTranscriptionProvider = VoiceTranscriptionProvider(
+            rawValue: UserDefaults.standard.string(forKey: Self.voiceTranscriptionProviderKey) ?? ""
+        ) ?? .voiceFlow
+        _fluidVoiceBaseURL = UserDefaults.standard.string(forKey: Self.fluidVoiceBaseURLKey) ?? ""
+        _fluidVoicePostprocess = UserDefaults.standard.bool(forKey: Self.fluidVoicePostprocessKey)
         _selectedProjectWorktree = UserDefaults.standard.string(forKey: Self.selectedProjectWorktreeKey)
         _customProjectPath = UserDefaults.standard.string(forKey: Self.customProjectPathKey) ?? ""
         _languagePreference = L10n.languagePreference
@@ -316,6 +331,43 @@ final class AppState {
     var aiBuilderConnectionOK: Bool = false
     var aiBuilderLastTestedAt: Date? = nil
     var isTestingAIBuilderConnection: Bool = false
+
+    var _voiceTranscriptionProvider: VoiceTranscriptionProvider = .voiceFlow
+    var voiceTranscriptionProvider: VoiceTranscriptionProvider {
+        get { _voiceTranscriptionProvider }
+        set {
+            _voiceTranscriptionProvider = newValue
+            UserDefaults.standard.set(newValue.rawValue, forKey: Self.voiceTranscriptionProviderKey)
+        }
+    }
+
+    var _fluidVoiceBaseURL: String = ""
+    var fluidVoiceBaseURL: String {
+        get { _fluidVoiceBaseURL }
+        set {
+            _fluidVoiceBaseURL = newValue
+            UserDefaults.standard.set(newValue, forKey: Self.fluidVoiceBaseURLKey)
+            fluidVoiceConnectionOK = false
+            fluidVoiceConnectionError = nil
+            fluidVoiceHealthStatus = nil
+            fluidVoiceHealthVersion = nil
+        }
+    }
+
+    var _fluidVoicePostprocess = false
+    var fluidVoicePostprocess: Bool {
+        get { _fluidVoicePostprocess }
+        set {
+            _fluidVoicePostprocess = newValue
+            UserDefaults.standard.set(newValue, forKey: Self.fluidVoicePostprocessKey)
+        }
+    }
+
+    var fluidVoiceConnectionOK = false
+    var fluidVoiceConnectionError: String?
+    var fluidVoiceHealthStatus: String?
+    var fluidVoiceHealthVersion: String?
+    var isTestingFluidVoiceConnection = false
     var _aiUsageDashboardURL: String = ""
     var aiUsageDashboardURL: String {
         get { _aiUsageDashboardURL }
@@ -548,6 +600,7 @@ final class AppState {
     let sseClient: SSEClientProtocol
     let sshTunnelManager: SSHTunnelManager
     let aiUsageQuotaClient: AIUsageQuotaClientProtocol
+    let fluidVoiceClient = FluidVoiceClient()
     var sseTask: Task<Void, Never>?
 
     /// Guard against race conditions when rapidly switching sessions.

--- a/OpenCodeClient/OpenCodeClient/Services/FluidVoiceClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/FluidVoiceClient.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+nonisolated struct FluidVoiceHealthResponse: Codable, Equatable, Sendable {
+    let status: String
+    let version: String
+}
+
+nonisolated struct FluidVoiceTranscriptionResponse: Codable, Equatable, Sendable {
+    let confidence: Double
+    let provider: String
+    let sampleCount: Int
+    let text: String
+}
+
+nonisolated struct FluidVoicePostprocessResponse: Codable, Equatable, Sendable {
+    let model: String
+    let provider: String
+    let text: String
+}
+
+nonisolated private struct FluidVoicePostprocessRequest: Encodable {
+    let text: String
+}
+
+nonisolated private struct FluidVoiceErrorResponse: Decodable {
+    let error: String
+}
+
+nonisolated enum FluidVoiceClientError: LocalizedError, Equatable {
+    case invalidBaseURL
+    case invalidResponse
+    case httpError(statusCode: Int, message: String?)
+    case audioTooLarge
+    case timedOut
+    case cancelled
+    case connectionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidBaseURL:
+            return "Enter a valid FluidVoice base URL using http:// or https://."
+        case .invalidResponse:
+            return "FluidVoice returned an invalid response."
+        case .httpError(let statusCode, let message):
+            if let message, !message.isEmpty {
+                return "FluidVoice returned HTTP \(statusCode): \(message)"
+            }
+            return "FluidVoice returned HTTP \(statusCode)."
+        case .audioTooLarge:
+            return "The recording exceeds FluidVoice's 25 MB limit."
+        case .timedOut:
+            return "FluidVoice timed out while loading or transcribing. Try again."
+        case .cancelled:
+            return "FluidVoice transcription was cancelled."
+        case .connectionFailed(let detail):
+            return "Could not connect to FluidVoice: \(detail)"
+        }
+    }
+}
+
+actor FluidVoiceClient {
+    static let requestTimeout: TimeInterval = 180
+    static let maximumAudioByteCount = 25 * 1024 * 1024
+
+    private let session: URLSession
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    nonisolated static func normalizedBaseURL(_ rawValue: String) throws -> URL {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              var components = URLComponents(string: trimmed),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              components.host != nil,
+              components.query == nil,
+              components.fragment == nil else {
+            throw FluidVoiceClientError.invalidBaseURL
+        }
+
+        var path = components.percentEncodedPath
+        while path.hasSuffix("/") {
+            path.removeLast()
+        }
+        components.percentEncodedPath = path
+        guard let normalized = components.url else { throw FluidVoiceClientError.invalidBaseURL }
+        return normalized
+    }
+
+    func health(baseURL: String) async throws -> FluidVoiceHealthResponse {
+        let request = try makeRequest(baseURL: baseURL, path: "/v1/health")
+        let data = try await performDataRequest(request)
+        return try decode(FluidVoiceHealthResponse.self, from: data)
+    }
+
+    func transcribe(wavFileURL: URL, baseURL: String) async throws -> FluidVoiceTranscriptionResponse {
+        let fileSize = try wavFileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+        guard fileSize <= Self.maximumAudioByteCount else { throw FluidVoiceClientError.audioTooLarge }
+        _ = try FluidVoiceWAV.validate(fileURL: wavFileURL)
+
+        var request = try makeRequest(baseURL: baseURL, path: "/v1/transcribe", method: "POST")
+        request.setValue("audio/wav", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("dictation.wav", forHTTPHeaderField: "X-Filename")
+
+        let data = try await performUpload(request, fromFile: wavFileURL)
+        return try decode(FluidVoiceTranscriptionResponse.self, from: data)
+    }
+
+    func postprocess(text: String, baseURL: String) async throws -> FluidVoicePostprocessResponse {
+        var request = try makeRequest(baseURL: baseURL, path: "/v1/postprocess", method: "POST")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = try encoder.encode(FluidVoicePostprocessRequest(text: text))
+
+        let data = try await performDataRequest(request)
+        return try decode(FluidVoicePostprocessResponse.self, from: data)
+    }
+
+    func transcribeAudio(wavFileURL: URL, baseURL: String, postprocessWithFluidIntelligence: Bool) async throws -> String {
+        let transcription = try await transcribe(wavFileURL: wavFileURL, baseURL: baseURL)
+        guard postprocessWithFluidIntelligence else { return transcription.text }
+        return try await postprocess(text: transcription.text, baseURL: baseURL).text
+    }
+
+    private func makeRequest(baseURL: String, path: String, method: String = "GET") throws -> URLRequest {
+        let base = try Self.normalizedBaseURL(baseURL)
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else {
+            throw FluidVoiceClientError.invalidBaseURL
+        }
+        components.percentEncodedPath += path
+        guard let url = components.url else { throw FluidVoiceClientError.invalidBaseURL }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = Self.requestTimeout
+        return request
+    }
+
+    private func performDataRequest(_ request: URLRequest) async throws -> Data {
+        do {
+            let (data, response) = try await session.data(for: request)
+            return try validatedData(data, response: response)
+        } catch {
+            throw mapTransportError(error)
+        }
+    }
+
+    private func performUpload(_ request: URLRequest, fromFile fileURL: URL) async throws -> Data {
+        do {
+            let (data, response) = try await session.upload(for: request, fromFile: fileURL)
+            return try validatedData(data, response: response)
+        } catch {
+            throw mapTransportError(error)
+        }
+    }
+
+    private func validatedData(_ data: Data, response: URLResponse) throws -> Data {
+        guard let http = response as? HTTPURLResponse else { throw FluidVoiceClientError.invalidResponse }
+        guard (200..<300).contains(http.statusCode) else {
+            let message = try? decoder.decode(FluidVoiceErrorResponse.self, from: data).error
+            throw FluidVoiceClientError.httpError(statusCode: http.statusCode, message: message)
+        }
+        return data
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        do {
+            return try decoder.decode(type, from: data)
+        } catch let error as FluidVoiceClientError {
+            throw error
+        } catch {
+            throw FluidVoiceClientError.invalidResponse
+        }
+    }
+
+    private func mapTransportError(_ error: Error) -> Error {
+        if let fluidError = error as? FluidVoiceClientError { return fluidError }
+        if error is CancellationError { return FluidVoiceClientError.cancelled }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .cancelled:
+                return FluidVoiceClientError.cancelled
+            case .timedOut:
+                return FluidVoiceClientError.timedOut
+            default:
+                return FluidVoiceClientError.connectionFailed(urlError.localizedDescription)
+            }
+        }
+        return FluidVoiceClientError.connectionFailed(error.localizedDescription)
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -80,10 +80,17 @@ enum L10n {
         case settingsAppearance
         case settingsTheme
         case settingsSpeechRecognition
+        case settingsVoiceProvider
+        case settingsVoiceProviderVoiceFlow
+        case settingsVoiceProviderFluidVoice
         case settingsAiBuilderBaseURL
         case settingsAiBuilderToken
         case settingsCustomPrompt
         case settingsTerminology
+        case settingsFluidVoiceBaseURL
+        case settingsFluidVoicePostprocess
+        case settingsFluidVoiceStatus
+        case settingsFluidVoiceVersion
         case settingsTesting
         case settingsTested
         case settingsAbout
@@ -481,10 +488,17 @@ enum L10n {
         Key.settingsAppearance.rawValue: "Appearance",
         Key.settingsTheme.rawValue: "Theme",
         Key.settingsSpeechRecognition.rawValue: "Speech Recognition",
+        Key.settingsVoiceProvider.rawValue: "Voice Provider",
+        Key.settingsVoiceProviderVoiceFlow.rawValue: "VoiceFlow",
+        Key.settingsVoiceProviderFluidVoice.rawValue: "FluidVoice",
         Key.settingsAiBuilderBaseURL.rawValue: "AI Builder Base URL",
         Key.settingsAiBuilderToken.rawValue: "AI Builder Token",
         Key.settingsCustomPrompt.rawValue: "Custom Prompt",
         Key.settingsTerminology.rawValue: "Terminology (comma-separated)",
+        Key.settingsFluidVoiceBaseURL.rawValue: "FluidVoice Base URL",
+        Key.settingsFluidVoicePostprocess.rawValue: "Post-process with Fluid Intelligence",
+        Key.settingsFluidVoiceStatus.rawValue: "Status",
+        Key.settingsFluidVoiceVersion.rawValue: "Version",
         Key.settingsTesting.rawValue: "Testing...",
         Key.settingsTested.rawValue: "OK",
         Key.settingsAbout.rawValue: "About",
@@ -881,10 +895,17 @@ enum L10n {
         Key.settingsAppearance.rawValue: "外观",
         Key.settingsTheme.rawValue: "主题",
         Key.settingsSpeechRecognition.rawValue: "语音识别",
+        Key.settingsVoiceProvider.rawValue: "语音服务",
+        Key.settingsVoiceProviderVoiceFlow.rawValue: "VoiceFlow",
+        Key.settingsVoiceProviderFluidVoice.rawValue: "FluidVoice",
         Key.settingsAiBuilderBaseURL.rawValue: "AI Builder 服务地址",
         Key.settingsAiBuilderToken.rawValue: "AI Builder 访问令牌",
         Key.settingsCustomPrompt.rawValue: "自定义提示词",
         Key.settingsTerminology.rawValue: "术语（逗号分隔）",
+        Key.settingsFluidVoiceBaseURL.rawValue: "FluidVoice 服务地址",
+        Key.settingsFluidVoicePostprocess.rawValue: "使用 Fluid Intelligence 后处理",
+        Key.settingsFluidVoiceStatus.rawValue: "状态",
+        Key.settingsFluidVoiceVersion.rawValue: "版本",
         Key.settingsTesting.rawValue: "测试中...",
         Key.settingsTested.rawValue: "可用",
         Key.settingsAbout.rawValue: "关于",

--- a/OpenCodeClient/OpenCodeClient/Utils/FluidVoiceWAV.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/FluidVoiceWAV.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+nonisolated enum FluidVoiceWAVError: LocalizedError, Equatable {
+    case emptyAudio
+    case invalidPCM
+    case audioTooLong
+    case invalidWAV
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyAudio:
+            return "No audio was recorded."
+        case .invalidPCM:
+            return "The recorded audio is not valid PCM16 audio."
+        case .audioTooLong:
+            return "FluidVoice recordings are limited to 300 seconds."
+        case .invalidWAV:
+            return "The recorded audio is not a valid WAV file."
+        }
+    }
+}
+
+nonisolated struct FluidVoiceWAVMetadata: Equatable, Sendable {
+    let sampleRate: UInt32
+    let channelCount: UInt16
+    let bitsPerSample: UInt16
+    let pcmByteCount: Int
+
+    var duration: TimeInterval {
+        let bytesPerSecond = Double(sampleRate) * Double(channelCount) * Double(bitsPerSample / 8)
+        return bytesPerSecond > 0 ? Double(pcmByteCount) / bytesPerSecond : 0
+    }
+}
+
+nonisolated enum FluidVoiceWAV {
+    static let sampleRate: UInt32 = 24_000
+    static let channelCount: UInt16 = 1
+    static let bitsPerSample: UInt16 = 16
+    static let headerByteCount = 44
+    static let maximumDuration: TimeInterval = 300
+    static let maximumPCMByteCount = Int(sampleRate) * Int(channelCount) * Int(bitsPerSample / 8) * Int(maximumDuration)
+
+    static func makeData(pcmData: Data) throws -> Data {
+        guard !pcmData.isEmpty else { throw FluidVoiceWAVError.emptyAudio }
+        guard pcmData.count.isMultiple(of: 2) else { throw FluidVoiceWAVError.invalidPCM }
+        guard pcmData.count <= maximumPCMByteCount else { throw FluidVoiceWAVError.audioTooLong }
+        guard pcmData.count <= Int(UInt32.max) - 36 else { throw FluidVoiceWAVError.audioTooLong }
+
+        let byteRate = sampleRate * UInt32(channelCount) * UInt32(bitsPerSample / 8)
+        let blockAlign = channelCount * (bitsPerSample / 8)
+        var wav = Data(capacity: headerByteCount + pcmData.count)
+        appendASCII("RIFF", to: &wav)
+        appendUInt32LE(36 + UInt32(pcmData.count), to: &wav)
+        appendASCII("WAVE", to: &wav)
+        appendASCII("fmt ", to: &wav)
+        appendUInt32LE(16, to: &wav)
+        appendUInt16LE(1, to: &wav)
+        appendUInt16LE(channelCount, to: &wav)
+        appendUInt32LE(sampleRate, to: &wav)
+        appendUInt32LE(byteRate, to: &wav)
+        appendUInt16LE(blockAlign, to: &wav)
+        appendUInt16LE(bitsPerSample, to: &wav)
+        appendASCII("data", to: &wav)
+        appendUInt32LE(UInt32(pcmData.count), to: &wav)
+        wav.append(pcmData)
+        return wav
+    }
+
+    static func write(pcmData: Data, to url: URL) throws {
+        let wav = try makeData(pcmData: pcmData)
+        try wav.write(to: url, options: .atomic)
+    }
+
+    static func validate(fileURL: URL) throws -> FluidVoiceWAVMetadata {
+        let fileSize = try fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+        guard fileSize >= headerByteCount else { throw FluidVoiceWAVError.invalidWAV }
+
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+        guard let header = try handle.read(upToCount: headerByteCount), header.count == headerByteCount else {
+            throw FluidVoiceWAVError.invalidWAV
+        }
+
+        guard ascii(in: header, range: 0..<4) == "RIFF",
+              uint32LE(in: header, offset: 4) == UInt32(fileSize - 8),
+              ascii(in: header, range: 8..<12) == "WAVE",
+              ascii(in: header, range: 12..<16) == "fmt ",
+              uint32LE(in: header, offset: 16) == 16,
+              uint16LE(in: header, offset: 20) == 1,
+              ascii(in: header, range: 36..<40) == "data" else {
+            throw FluidVoiceWAVError.invalidWAV
+        }
+
+        let channels = uint16LE(in: header, offset: 22)
+        let rate = uint32LE(in: header, offset: 24)
+        let bits = uint16LE(in: header, offset: 34)
+        let dataSize = Int(uint32LE(in: header, offset: 40))
+        guard channels == channelCount,
+              rate == sampleRate,
+              bits == bitsPerSample,
+              uint32LE(in: header, offset: 28) == sampleRate * 2,
+              uint16LE(in: header, offset: 32) == 2,
+              dataSize > 0,
+              fileSize == headerByteCount + dataSize else {
+            throw FluidVoiceWAVError.invalidWAV
+        }
+
+        let metadata = FluidVoiceWAVMetadata(
+            sampleRate: rate,
+            channelCount: channels,
+            bitsPerSample: bits,
+            pcmByteCount: dataSize
+        )
+        guard metadata.duration <= maximumDuration else { throw FluidVoiceWAVError.audioTooLong }
+        return metadata
+    }
+
+    private static func appendASCII(_ value: String, to data: inout Data) {
+        data.append(Data(value.utf8))
+    }
+
+    private static func appendUInt16LE(_ value: UInt16, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        data.append(Data(bytes: &littleEndian, count: MemoryLayout<UInt16>.size))
+    }
+
+    private static func appendUInt32LE(_ value: UInt32, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        data.append(Data(bytes: &littleEndian, count: MemoryLayout<UInt32>.size))
+    }
+
+    private static func ascii(in data: Data, range: Range<Int>) -> String? {
+        String(data: data.subdata(in: range), encoding: .ascii)
+    }
+
+    private static func uint16LE(in data: Data, offset: Int) -> UInt16 {
+        UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+    }
+
+    private static func uint32LE(in data: Data, offset: Int) -> UInt32 {
+        UInt32(data[offset])
+            | (UInt32(data[offset + 1]) << 8)
+            | (UInt32(data[offset + 2]) << 16)
+            | (UInt32(data[offset + 3]) << 24)
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
@@ -6,10 +6,9 @@ import VoiceFlowKit
 @preconcurrency import AVFoundation
 #endif
 
-/// Mic-button voice input for the chat composer. Holds the speech
-/// session, microphone, heartbeat task, and event consumer task; calls
-/// into `AppState.startRealtimeSpeechSession()` to obtain a session
-/// from `VoiceFlowKit`. UI states (`isRecording`, `isTranscribing`,
+/// Mic-button voice input for the chat composer. VoiceFlow uses its
+/// realtime session while FluidVoice retains the same microphone's PCM
+/// chunks for one batch request after stop. UI states (`isRecording`, `isTranscribing`,
 /// `isStartingRecording`, `speechError`, `speechRecoveryActive`) and
 /// the session-bearing `@State` fields live on `ChatTabView` itself —
 /// SwiftUI requires `@State` on the containing struct — and this
@@ -35,8 +34,36 @@ final class SpeechPartialTranscriptBuffer: Sendable {
     }
 }
 
+/// FluidVoice is batch-only, so its PCM chunks are retained until the user
+/// stops recording. Storage is capped at exactly 300 seconds of PCM16/24 kHz
+/// mono audio even if the stop timer fires between audio callbacks.
+final class SpeechPCMBuffer: Sendable {
+    private let storage = OSAllocatedUnfairLock(initialState: Data())
+
+    nonisolated func append(_ chunk: Data) {
+        storage.withLock { data in
+            let remaining = FluidVoiceWAV.maximumPCMByteCount - data.count
+            guard remaining > 0 else { return }
+            data.append(chunk.prefix(remaining))
+        }
+    }
+
+    nonisolated func takeData() -> Data {
+        storage.withLock { data in
+            let captured = data
+            data.removeAll(keepingCapacity: false)
+            return captured
+        }
+    }
+
+    nonisolated func clear() {
+        storage.withLock { $0.removeAll(keepingCapacity: false) }
+    }
+}
+
 extension ChatTabView {
     static let speechHeartbeatIntervalSeconds: UInt64 = 12
+    static let fluidVoiceRecordingLimitSeconds: UInt64 = 300
 
     static func mergedSpeechInput(prefix: String, transcript: String) -> String {
         let cleanedTranscript = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -161,14 +188,90 @@ extension ChatTabView {
         }
     }
 
+    func removeTemporarySpeechFile(_ url: URL?) {
+        guard let url else { return }
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func stopSpeechRecordingLimit() {
+        speechRecordingLimitTask?.cancel()
+        speechRecordingLimitTask = nil
+    }
+
+    func scheduleFluidVoiceRecordingLimit() {
+        stopSpeechRecordingLimit()
+        speechRecordingLimitTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .seconds(Self.fluidVoiceRecordingLimitSeconds))
+            } catch {
+                return
+            }
+            guard isRecording, recordingVoiceProvider == .fluidVoice else { return }
+            speechRecordingLimitTask = nil
+            await toggleRecording()
+        }
+    }
+
+    func beginFluidVoiceTranscription(pcmData: Data, prefix: String) throws {
+        let wavURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wav")
+        do {
+            try FluidVoiceWAV.write(pcmData: pcmData, to: wavURL)
+        } catch {
+            removeTemporarySpeechFile(wavURL)
+            throw error
+        }
+
+        let operationID = UUID()
+        speechTranscriptionID = operationID
+        isTranscribing = true
+        speechTranscriptionTask = Task { @MainActor in
+            defer {
+                removeTemporarySpeechFile(wavURL)
+                if speechTranscriptionID == operationID {
+                    speechTranscriptionID = nil
+                    speechTranscriptionTask = nil
+                    isTranscribing = false
+                    recordingVoiceProvider = nil
+                }
+            }
+
+            do {
+                let transcript = try await state.transcribeWithFluidVoice(wavFileURL: wavURL)
+                try Task.checkCancellation()
+                guard speechTranscriptionID == operationID else { return }
+                let cleaned = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+                Self.logger.notice("[SpeechProfile] FluidVoice batch transcribe done chars=\(cleaned.count, privacy: .public)")
+                inputText = Self.mergedSpeechInput(prefix: prefix, transcript: cleaned)
+            } catch is CancellationError {
+                return
+            } catch FluidVoiceClientError.cancelled {
+                return
+            } catch {
+                guard speechTranscriptionID == operationID else { return }
+                Self.logger.error("[SpeechProfile] FluidVoice batch transcribe failed")
+                inputText = prefix
+                speechError = error.localizedDescription
+            }
+        }
+    }
+
     func stopSpeechForBackground() async {
+        stopSpeechRecordingLimit()
+        speechTranscriptionID = nil
+        speechTranscriptionTask?.cancel()
+        speechTranscriptionTask = nil
         stopSpeechHeartbeat()
         stopSpeechEventConsumer()
         stopSpeechAudioLevelConsumer()
-        _ = try? await microphone.stop()
+        let microphoneFile = try? await microphone.stop()
+        removeTemporarySpeechFile(microphoneFile)
+        fluidVoicePCMBuffer.clear()
 
         let session = speechSession
         speechSession = nil
+        recordingVoiceProvider = nil
         isRecording = false
         isTranscribing = false
         isStartingRecording = false
@@ -180,16 +283,33 @@ extension ChatTabView {
 
     func toggleRecording() async {
         if isRecording {
+            stopSpeechRecordingLimit()
             stopSpeechHeartbeat()
             stopSpeechEventConsumer()
             stopSpeechAudioLevelConsumer()
             let stopStart = ProcessInfo.processInfo.systemUptime
-            _ = try? await microphone.stop()
+            let microphoneFile = try? await microphone.stop()
+            removeTemporarySpeechFile(microphoneFile)
             isRecording = false
-            Self.logger.notice("[SpeechProfile] realtime capture stopped ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - stopStart) * 1000)), privacy: .public)")
+            Self.logger.notice("[SpeechProfile] speech capture stopped ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - stopStart) * 1000)), privacy: .public)")
+
+            let prefix = recordingInputPrefix
+            if recordingVoiceProvider == .fluidVoice {
+                let pcmData = fluidVoicePCMBuffer.takeData()
+                do {
+                    try beginFluidVoiceTranscription(pcmData: pcmData, prefix: prefix)
+                } catch {
+                    recordingVoiceProvider = nil
+                    isTranscribing = false
+                    inputText = prefix
+                    speechError = error.localizedDescription
+                }
+                return
+            }
 
             guard let session = speechSession else {
                 Self.logger.error("[SpeechProfile] realtime stop failed: missing session")
+                recordingVoiceProvider = nil
                 return
             }
 
@@ -198,9 +318,9 @@ extension ChatTabView {
                 if speechSession === session {
                     speechSession = nil
                     isTranscribing = false
+                    recordingVoiceProvider = nil
                 }
             }
-            let prefix = recordingInputPrefix
             let partialTranscriptBuffer = SpeechPartialTranscriptBuffer()
             let transcribeStart = ProcessInfo.processInfo.systemUptime
             do {
@@ -229,18 +349,31 @@ extension ChatTabView {
             // AsyncStream continuation. Recreate it per capture so repeated
             // start/stop cycles keep publishing real levels for the waveform.
             microphone = VoiceFlowMicrophone()
-            let token = state.aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            if token.isEmpty {
-                speechError = L10n.t(.chatSpeechTokenMissing)
-                return
-            }
-            if state.isTestingAIBuilderConnection {
-                speechError = L10n.t(.chatSpeechTesting)
-                return
-            }
-            guard state.aiBuilderConnectionOK else {
-                speechError = L10n.t(.chatSpeechNotPassed)
-                return
+            fluidVoicePCMBuffer = SpeechPCMBuffer()
+            let provider = state.voiceTranscriptionProvider
+
+            switch provider {
+            case .voiceFlow:
+                let token = state.aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines)
+                if token.isEmpty {
+                    speechError = L10n.t(.chatSpeechTokenMissing)
+                    return
+                }
+                if state.isTestingAIBuilderConnection {
+                    speechError = L10n.t(.chatSpeechTesting)
+                    return
+                }
+                guard state.aiBuilderConnectionOK else {
+                    speechError = L10n.t(.chatSpeechNotPassed)
+                    return
+                }
+            case .fluidVoice:
+                do {
+                    try state.normalizeFluidVoiceBaseURL()
+                } catch {
+                    speechError = error.localizedDescription
+                    return
+                }
             }
 
             let permissionStart = ProcessInfo.processInfo.systemUptime
@@ -254,46 +387,77 @@ extension ChatTabView {
             let startRecordingStart = ProcessInfo.processInfo.systemUptime
             do {
                 clearPreservedSpeechAudio()
-                let session = try await state.startRealtimeSpeechSession()
                 recordingInputPrefix = inputText
-                speechSession = session
-                startSpeechEventConsumer(for: session)
+                recordingVoiceProvider = provider
                 startSpeechAudioLevelConsumer()
 
-                try await microphone.start { chunk in
-                    Task {
-                        await session.sendAudioChunk(chunk)
+                switch provider {
+                case .voiceFlow:
+                    let session = try await state.startRealtimeSpeechSession()
+                    speechSession = session
+                    startSpeechEventConsumer(for: session)
+                    try await microphone.start { chunk in
+                        Task {
+                            await session.sendAudioChunk(chunk)
+                        }
+                    }
+                    startSpeechHeartbeat(for: session)
+                case .fluidVoice:
+                    let buffer = fluidVoicePCMBuffer
+                    try await microphone.start { chunk in
+                        buffer.append(chunk)
                     }
                 }
                 isRecording = true
                 isStartingRecording = false
-                startSpeechHeartbeat(for: session)
-                Self.logger.notice("[SpeechProfile] realtime capture started ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startRecordingStart) * 1000)), privacy: .public)")
+                if provider == .fluidVoice {
+                    scheduleFluidVoiceRecordingLimit()
+                }
+                Self.logger.notice("[SpeechProfile] speech capture started provider=\(provider.rawValue, privacy: .public) ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startRecordingStart) * 1000)), privacy: .public)")
             } catch {
-                _ = try? await microphone.stop()
+                let microphoneFile = try? await microphone.stop()
+                removeTemporarySpeechFile(microphoneFile)
                 stopSpeechHeartbeat()
                 stopSpeechEventConsumer()
                 stopSpeechAudioLevelConsumer()
+                stopSpeechRecordingLimit()
+                fluidVoicePCMBuffer.clear()
                 isStartingRecording = false
                 if let speechSession {
                     await terminateSpeechSession(speechSession)
                 }
                 speechSession = nil
-                Self.logger.error("[SpeechProfile] realtime capture start failed error=\(error.localizedDescription, privacy: .public)")
+                recordingVoiceProvider = nil
+                Self.logger.error("[SpeechProfile] speech capture start failed error=\(error.localizedDescription, privacy: .public)")
                 speechError = error.localizedDescription
             }
         }
     }
 
     func abortSpeechRecognition() async {
+        stopSpeechRecordingLimit()
         stopSpeechHeartbeat()
         stopSpeechEventConsumer()
         stopSpeechAudioLevelConsumer()
-        _ = try? await microphone.stop()
+        let microphoneFile = try? await microphone.stop()
+        removeTemporarySpeechFile(microphoneFile)
+
+        if recordingVoiceProvider == .fluidVoice || speechTranscriptionTask != nil {
+            speechTranscriptionID = nil
+            speechTranscriptionTask?.cancel()
+            speechTranscriptionTask = nil
+            fluidVoicePCMBuffer.clear()
+            recordingVoiceProvider = nil
+            isRecording = false
+            isTranscribing = false
+            isStartingRecording = false
+            return
+        }
 
         let session = speechSession
         let prefix = recordingInputPrefix
         speechSession = nil
+        recordingVoiceProvider = nil
         isRecording = false
         isTranscribing = false
         isStartingRecording = false

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -76,6 +76,11 @@ struct ChatTabView: View {
     @State var speechRecoveryActive = false
     @State var speechAudioLevel: Float = 0
     @State var speechAudioLevelTask: Task<Void, Never>?
+    @State var speechRecordingLimitTask: Task<Void, Never>?
+    @State var speechTranscriptionTask: Task<Void, Never>?
+    @State var speechTranscriptionID: UUID?
+    @State var recordingVoiceProvider: VoiceTranscriptionProvider?
+    @State var fluidVoicePCMBuffer = SpeechPCMBuffer()
     @State private var selectedPhotoItems: [PhotosPickerItem] = []
     @State private var imageAttachments: [ComposerImageAttachment] = []
     @State private var attachmentError: String?

--- a/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
@@ -142,44 +142,101 @@ struct SettingsTabView: View {
                 }
 
                 Section(L10n.t(.settingsSpeechRecognition)) {
-                    TextField(L10n.t(.settingsAiBuilderBaseURL), text: $state.aiBuilderBaseURL)
-                        .textContentType(.URL)
-                        .autocapitalization(.none)
+                    Picker(L10n.t(.settingsVoiceProvider), selection: $state.voiceTranscriptionProvider) {
+                        Text(L10n.t(.settingsVoiceProviderVoiceFlow)).tag(VoiceTranscriptionProvider.voiceFlow)
+                        Text(L10n.t(.settingsVoiceProviderFluidVoice)).tag(VoiceTranscriptionProvider.fluidVoice)
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityIdentifier("settings-voice-provider")
 
-                    SecureField(L10n.t(.settingsAiBuilderToken), text: $state.aiBuilderToken)
-                        .textContentType(.password)
+                    if state.voiceTranscriptionProvider == .voiceFlow {
+                        TextField(L10n.t(.settingsAiBuilderBaseURL), text: $state.aiBuilderBaseURL)
+                            .textContentType(.URL)
+                            .autocapitalization(.none)
 
-                    TextField(L10n.t(.settingsCustomPrompt), text: $state.aiBuilderCustomPrompt, axis: .vertical)
-                        .lineLimit(3...6)
+                        SecureField(L10n.t(.settingsAiBuilderToken), text: $state.aiBuilderToken)
+                            .textContentType(.password)
 
-                    TextField(L10n.t(.settingsTerminology), text: $state.aiBuilderTerminology)
-                        .textContentType(.none)
-                        .autocapitalization(.none)
+                        TextField(L10n.t(.settingsCustomPrompt), text: $state.aiBuilderCustomPrompt, axis: .vertical)
+                            .lineLimit(3...6)
 
-                    HStack {
-                        Button {
-                            Task { await state.testAIBuilderConnection() }
-                        } label: {
-                            if state.isTestingAIBuilderConnection {
-                                HStack(spacing: 8) {
-                                    ProgressView()
-                                        .scaleEffect(0.9)
-                                    Text(L10n.t(.settingsTesting))
+                        TextField(L10n.t(.settingsTerminology), text: $state.aiBuilderTerminology)
+                            .textContentType(.none)
+                            .autocapitalization(.none)
+
+                        HStack {
+                            Button {
+                                Task { await state.testAIBuilderConnection() }
+                            } label: {
+                                if state.isTestingAIBuilderConnection {
+                                    HStack(spacing: 8) {
+                                        ProgressView()
+                                            .scaleEffect(0.9)
+                                        Text(L10n.t(.settingsTesting))
+                                    }
+                                } else {
+                                    Text(L10n.t(.settingsTestConnection))
                                 }
-                            } else {
-                                Text(L10n.t(.settingsTestConnection))
+                            }
+                            .disabled(
+                                state.aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                    || state.isTestingAIBuilderConnection
+                            )
+                            Spacer()
+                            if state.aiBuilderConnectionOK {
+                                Label(L10n.t(.commonOk), systemImage: "checkmark.circle.fill")
+                                    .foregroundStyle(DesignColors.Semantic.success)
+                            } else if let err = state.aiBuilderConnectionError {
+                                Text(err)
+                                    .foregroundStyle(.red)
                             }
                         }
-                        .disabled(
-                            state.aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                                || state.isTestingAIBuilderConnection
-                        )
-                        Spacer()
-                        if state.aiBuilderConnectionOK {
-                            Label(L10n.t(.commonOk), systemImage: "checkmark.circle.fill")
-                                .foregroundStyle(DesignColors.Semantic.success)
-                        } else if let err = state.aiBuilderConnectionError {
-                            Text(err)
+                    } else {
+                        TextField(L10n.t(.settingsFluidVoiceBaseURL), text: $state.fluidVoiceBaseURL)
+                            .textContentType(.URL)
+                            .autocapitalization(.none)
+                            .accessibilityIdentifier("settings-fluidvoice-base-url")
+                            .onSubmit { _ = try? state.normalizeFluidVoiceBaseURL() }
+
+                        Toggle(L10n.t(.settingsFluidVoicePostprocess), isOn: $state.fluidVoicePostprocess)
+                            .accessibilityIdentifier("settings-fluidvoice-postprocess")
+
+                        HStack {
+                            Button {
+                                Task { await state.testFluidVoiceConnection() }
+                            } label: {
+                                if state.isTestingFluidVoiceConnection {
+                                    HStack(spacing: 8) {
+                                        ProgressView()
+                                            .scaleEffect(0.9)
+                                        Text(L10n.t(.settingsTesting))
+                                    }
+                                } else {
+                                    Text(L10n.t(.settingsTestConnection))
+                                }
+                            }
+                            .disabled(
+                                state.fluidVoiceBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                    || state.isTestingFluidVoiceConnection
+                            )
+                            .accessibilityIdentifier("settings-fluidvoice-test")
+
+                            Spacer()
+                            if state.fluidVoiceConnectionOK {
+                                Label(L10n.t(.commonOk), systemImage: "checkmark.circle.fill")
+                                    .foregroundStyle(DesignColors.Semantic.success)
+                            }
+                        }
+
+                        if let status = state.fluidVoiceHealthStatus {
+                            LabeledContent(L10n.t(.settingsFluidVoiceStatus), value: status)
+                        }
+                        if let version = state.fluidVoiceHealthVersion {
+                            LabeledContent(L10n.t(.settingsFluidVoiceVersion), value: version)
+                        }
+                        if let error = state.fluidVoiceConnectionError {
+                            Text(error)
+                                .font(.caption)
                                 .foregroundStyle(.red)
                         }
                     }

--- a/OpenCodeClient/OpenCodeClientTests/FluidVoiceTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/FluidVoiceTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import Testing
+@testable import OpenCodeClient
+
+private final class FluidVoiceMockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            var handledRequest = request
+            if handledRequest.httpBody == nil, let stream = handledRequest.httpBodyStream {
+                stream.open()
+                defer { stream.close() }
+                var body = Data()
+                let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4_096)
+                defer { buffer.deallocate() }
+                while stream.hasBytesAvailable {
+                    let count = stream.read(buffer, maxLength: 4_096)
+                    guard count > 0 else { break }
+                    body.append(buffer, count: count)
+                }
+                handledRequest.httpBodyStream = nil
+                handledRequest.httpBody = body
+            }
+            let (response, data) = try handler(handledRequest)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private final class FluidVoiceRequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedRequests: [URLRequest] = []
+
+    func append(_ request: URLRequest) {
+        lock.lock()
+        storedRequests.append(request)
+        lock.unlock()
+    }
+
+    var requests: [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedRequests
+    }
+}
+
+@Suite(.serialized)
+struct FluidVoiceTests {
+    @Test func decodesHealthResponse() throws {
+        let response = try JSONDecoder().decode(
+            FluidVoiceHealthResponse.self,
+            from: Data(#"{"status":"ok","version":"1.6.2"}"#.utf8)
+        )
+
+        #expect(response.status == "ok")
+        #expect(response.version == "1.6.2")
+    }
+
+    @Test func decodesTranscriptionResponse() throws {
+        let response = try JSONDecoder().decode(
+            FluidVoiceTranscriptionResponse.self,
+            from: Data(#"{"confidence":1,"provider":"Cohere Transcribe","sampleCount":103595,"text":"Texto reconocido."}"#.utf8)
+        )
+
+        #expect(response.confidence == 1)
+        #expect(response.provider == "Cohere Transcribe")
+        #expect(response.sampleCount == 103595)
+        #expect(response.text == "Texto reconocido.")
+    }
+
+    @Test func decodesPostprocessResponse() throws {
+        let response = try JSONDecoder().decode(
+            FluidVoicePostprocessResponse.self,
+            from: Data(#"{"model":"fluid-1","provider":"fluid-1","text":"Texto procesado"}"#.utf8)
+        )
+
+        #expect(response.model == "fluid-1")
+        #expect(response.provider == "fluid-1")
+        #expect(response.text == "Texto procesado")
+    }
+
+    @Test func normalizesBaseURLAndRemovesTrailingSlashes() throws {
+        #expect(try FluidVoiceClient.normalizedBaseURL("  https://voice.example.ts.net///  ").absoluteString == "https://voice.example.ts.net")
+        #expect(try FluidVoiceClient.normalizedBaseURL("http://127.0.0.1:47733/").absoluteString == "http://127.0.0.1:47733")
+        #expect(try FluidVoiceClient.normalizedBaseURL("https://example.com/proxy///").absoluteString == "https://example.com/proxy")
+        #expect(throws: FluidVoiceClientError.invalidBaseURL) {
+            try FluidVoiceClient.normalizedBaseURL("voice.example.ts.net")
+        }
+    }
+
+    @Test func generatedWAVHasValidHeaderAndSize() throws {
+        let pcm = Data([0x00, 0x00, 0xFF, 0x7F, 0x00, 0x80])
+        let wav = try FluidVoiceWAV.makeData(pcmData: pcm)
+
+        #expect(wav.count == FluidVoiceWAV.headerByteCount + pcm.count)
+        #expect(String(data: wav[0..<4], encoding: .ascii) == "RIFF")
+        #expect(String(data: wav[8..<12], encoding: .ascii) == "WAVE")
+        #expect(String(data: wav[36..<40], encoding: .ascii) == "data")
+        #expect(readUInt32LE(wav, at: 4) == UInt32(36 + pcm.count))
+        #expect(readUInt16LE(wav, at: 20) == 1)
+        #expect(readUInt16LE(wav, at: 22) == 1)
+        #expect(readUInt32LE(wav, at: 24) == 24_000)
+        #expect(readUInt16LE(wav, at: 34) == 16)
+        #expect(readUInt32LE(wav, at: 40) == UInt32(pcm.count))
+    }
+
+    @Test func convertsJSONHTTPError() async throws {
+        let session = makeMockSession()
+        let client = FluidVoiceClient(session: session)
+        FluidVoiceMockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 503,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"error":"Model is loading"}"#.utf8))
+        }
+        defer { FluidVoiceMockURLProtocol.handler = nil }
+
+        do {
+            _ = try await client.health(baseURL: "https://voice.example.ts.net")
+            Issue.record("Expected FluidVoice HTTP error")
+        } catch let error as FluidVoiceClientError {
+            #expect(error == .httpError(statusCode: 503, message: "Model is loading"))
+            #expect(error.localizedDescription.contains("Model is loading"))
+        }
+    }
+
+    @Test func transcribeThenPostprocessUsesExpectedRequests() async throws {
+        let session = makeMockSession()
+        let client = FluidVoiceClient(session: session)
+        let recorder = FluidVoiceRequestRecorder()
+        FluidVoiceMockURLProtocol.handler = { request in
+            recorder.append(request)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            switch request.url?.path {
+            case "/v1/transcribe":
+                return (response, Data(#"{"confidence":1,"provider":"Cohere Transcribe","sampleCount":2,"text":"raw text"}"#.utf8))
+            case "/v1/postprocess":
+                return (response, Data(#"{"model":"fluid-1","provider":"fluid-1","text":"processed text"}"#.utf8))
+            default:
+                throw URLError(.unsupportedURL)
+            }
+        }
+        defer { FluidVoiceMockURLProtocol.handler = nil }
+
+        let wavURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wav")
+        try FluidVoiceWAV.write(pcmData: Data([0, 0, 1, 0]), to: wavURL)
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+
+        let text = try await client.transcribeAudio(
+            wavFileURL: wavURL,
+            baseURL: "https://voice.example.ts.net/",
+            postprocessWithFluidIntelligence: true
+        )
+
+        #expect(text == "processed text")
+        let requests = recorder.requests
+        #expect(requests.map { $0.url?.path } == ["/v1/transcribe", "/v1/postprocess"])
+        #expect(requests[0].httpMethod == "POST")
+        #expect(requests[0].value(forHTTPHeaderField: "Content-Type") == "audio/wav")
+        #expect(requests[0].value(forHTTPHeaderField: "X-Filename") == "dictation.wav")
+        #expect(requests[1].value(forHTTPHeaderField: "Content-Type") == "application/json")
+
+        let postprocessBody = try #require(requests[1].httpBody)
+        let body = try JSONSerialization.jsonObject(with: postprocessBody) as? [String: String]
+        #expect(body?["text"] == "raw text")
+    }
+
+    @Test @MainActor func providerDefaultsAndPersistence() {
+        let keys = [
+            AppState.voiceTranscriptionProviderKey,
+            AppState.fluidVoiceBaseURLKey,
+            AppState.fluidVoicePostprocessKey,
+        ]
+        let previous = Dictionary(uniqueKeysWithValues: keys.map { ($0, UserDefaults.standard.object(forKey: $0)) })
+        keys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+        defer {
+            keys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+            for (key, value) in previous where value != nil {
+                UserDefaults.standard.set(value, forKey: key)
+            }
+        }
+
+        let initial = AppState()
+        #expect(initial.voiceTranscriptionProvider == .voiceFlow)
+        #expect(initial.fluidVoiceBaseURL.isEmpty)
+        #expect(initial.fluidVoicePostprocess == false)
+
+        initial.voiceTranscriptionProvider = .fluidVoice
+        initial.fluidVoiceBaseURL = "https://voice.example.ts.net"
+        initial.fluidVoicePostprocess = true
+
+        let restored = AppState()
+        #expect(restored.voiceTranscriptionProvider == .fluidVoice)
+        #expect(restored.fluidVoiceBaseURL == "https://voice.example.ts.net")
+        #expect(restored.fluidVoicePostprocess)
+    }
+
+    private func makeMockSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FluidVoiceMockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func readUInt16LE(_ data: Data, at offset: Int) -> UInt16 {
+        UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+    }
+
+    private func readUInt32LE(_ data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[offset])
+            | (UInt32(data[offset + 1]) << 8)
+            | (UInt32(data[offset + 2]) << 16)
+            | (UInt32(data[offset + 3]) << 24)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ and then reloads the compact quota endpoint. Details show both the API snapshot'
 generation time and the device's local fetch time. The app does not poll or
 trigger automatic provider refreshes, and the quota UI is absent when no URL is set.
 
+### FluidVoice transcription
+
+The voice provider can be selected in **Settings → Speech Recognition**. VoiceFlow remains the default. FluidVoice records locally while the microphone is active, then uploads one WAV file when recording stops; it does not provide streaming or partial transcripts.
+
+Enable FluidVoice's local API on the Mac:
+
+```bash
+defaults write com.FluidApp.app LocalAPIEnabled -bool true
+defaults write com.FluidApp.app LocalAPIPort -int 47733
+```
+
+Restart FluidVoice after changing these settings. To enable the optional **Post-process with Fluid Intelligence** setting, configure FluidVoice with:
+
+```bash
+defaults write com.FluidApp.app SelectedDictationPromptID -string '__FLUID_1__'
+defaults write com.FluidApp.app DictationPromptOff -bool false
+```
+
+Restart FluidVoice again after changing the Fluid Intelligence settings.
+
+FluidVoice accepts only loopback clients on the Mac. A physical iPhone therefore cannot connect directly to port `47733`. Use Tailscale Serve as an authenticated tailnet proxy whose backend is:
+
+```text
+http://127.0.0.1:47733
+```
+
+Enter the HTTPS URL assigned by Tailscale Serve as the FluidVoice Base URL in the app. Do not disable FluidVoice's loopback restriction or expose its unauthenticated local API port directly to a LAN or the internet.
+
 ## Remote Access
 
 The app is designed for LAN use by default. Two options for remote access:


### PR DESCRIPTION
## Summary

- add FluidVoice as a selectable batch transcription provider while keeping VoiceFlow as the default realtime provider
- reuse the existing microphone flow to generate validated PCM16 mono WAV uploads, with optional Fluid Intelligence post-processing
- add health checks, persisted settings, cancellation, 25 MB / 300 second limits, localized errors, tests, and setup documentation

## Testing

- iOS Simulator build passed on iPhone 17 Pro / iOS 26.5
- targeted `FluidVoiceTests` suite passed (8 tests)

The full test suite still has one unrelated existing failure in `LayoutConstantsTests/splitViewFractions()` due to exact floating-point comparisons; this PR does not modify that code.

Closes #119
