### PR TITLE
fix(models): remove unsupported GPT-5.6 Sol Pro preset

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+Models.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Models.swift
@@ -19,7 +19,7 @@ extension AppState {
         switch savedID {
         case "zai-coding-plan/glm-5.2", "zai-coding-plan/glm-5.1", "zai-coding-plan/glm-5-turbo":
             return "zai-coding-plan/glm-5.2"
-        case "openai/gpt-5.4", "openai/gpt-5.5":
+        case "openai/gpt-5.4", "openai/gpt-5.5", "openai/gpt-5.6-sol-pro":
             return "openai/gpt-5.6-sol"
         case "ollama-cloud/kimi-k2.6":
             return "ollama-cloud/glm-5.2"

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -423,7 +423,6 @@ final class AppState {
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),
         ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2"),
-        ModelPreset(displayName: "GPT-5.6 Sol Pro", providerID: "openai", modelID: "gpt-5.6-sol-pro"),
         ModelPreset(displayName: "GPT-5.6 Sol Fast", providerID: "openai", modelID: "gpt-5.6-sol-fast"),
     ]
     var selectedModelIndex: Int = 2

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -17,7 +17,6 @@ struct ModelPreset: Codable, Identifiable {
         case "DeepSeek Local": return "DS-L"
         case "DeepSeek V4 Pro": return "DS-Pro"
         case "Ollama GLM 5.2": return "OGLM-5.2"
-        case "GPT-5.6 Sol Pro": return "GPT-P"
         case "GPT-5.6 Sol Fast": return "GPT-F"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1920,11 +1920,9 @@ struct ModelPresetShortNameTests {
         #expect(preset.shortName == "GPT")
     }
 
-    @Test func gptSolModeShortNames() {
-        let pro = ModelPreset(displayName: "GPT-5.6 Sol Pro", providerID: "openai", modelID: "gpt-5.6-sol-pro")
+    @Test func gptSolFastShortName() {
         let fast = ModelPreset(displayName: "GPT-5.6 Sol Fast", providerID: "openai", modelID: "gpt-5.6-sol-fast")
 
-        #expect(pro.shortName == "GPT-P")
         #expect(fast.shortName == "GPT-F")
     }
     
@@ -1993,7 +1991,7 @@ struct ModelSelectionPersistenceTests {
     @Test @MainActor func legacyGPTSelectionMapsToCurrentGPT56SolPreset() {
         withIsolatedModelSelectionDefaults {
             let sessionID = "session-gpt"
-            for legacyID in ["openai/gpt-5.4", "openai/gpt-5.5"] {
+            for legacyID in ["openai/gpt-5.4", "openai/gpt-5.5", "openai/gpt-5.6-sol-pro"] {
                 UserDefaults.standard.removeObject(forKey: selectedModelDefaultsKey)
                 UserDefaults.standard.removeObject(forKey: currentSessionDefaultsKey)
                 let legacySelection = [sessionID: legacyID]
@@ -2071,13 +2069,11 @@ struct ModelSelectionPersistenceTests {
         }
     }
 
-    @Test @MainActor func defaultPresetsIncludeGPT56SolModes() {
+    @Test @MainActor func defaultPresetsIncludeGPT56SolFastAndExcludeRemovedPro() {
         withIsolatedModelSelectionDefaults {
             let state = AppState()
 
-            #expect(state.modelPresets.contains(where: {
-                $0.id == "openai/gpt-5.6-sol-pro" && $0.displayName == "GPT-5.6 Sol Pro"
-            }))
+            #expect(!state.modelPresets.contains(where: { $0.id == "openai/gpt-5.6-sol-pro" }))
             #expect(state.modelPresets.contains(where: {
                 $0.id == "openai/gpt-5.6-sol-fast" && $0.displayName == "GPT-5.6 Sol Fast"
             }))


### PR DESCRIPTION
## Summary
- remove the unsupported GPT-5.6 Sol Pro preset
- migrate saved Pro selections to GPT-5.6 Sol Fast
- update preset tests

## Validation
- commit passes git diff whitespace validation
- full iOS build and test will run on the Car Mode integration branch after merge