### PR TITLE
fix(models): derive model picker from live server config

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+Models.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Models.swift
@@ -60,4 +60,28 @@ extension AppState {
         selectedModelIDBySessionID[sessionID] = modelPresets[idx].id
         persistSelectedModelMap()
     }
+
+    /// Groups `modelPresets` by provider, in provider-first-appearance order, for the model
+    /// picker sheet. Needed once the list is populated from the live server (see
+    /// `applyDynamicModelPresets`): multiple providers commonly serve identically-named models
+    /// (e.g. a "Claude Sonnet 5" available via both `anthropic` and `openrouter`), and a flat
+    /// list makes those indistinguishable while scrolling. Falls back to the raw provider ID as
+    /// the group label when `providersResponse` hasn't loaded (or failed to load) yet.
+    var groupedModelPresetIndices: [(providerID: String, providerName: String, indices: [Int])] {
+        var order: [String] = []
+        var buckets: [String: [Int]] = [:]
+        for (index, preset) in modelPresets.enumerated() {
+            if buckets[preset.providerID] == nil {
+                order.append(preset.providerID)
+                buckets[preset.providerID] = []
+            }
+            buckets[preset.providerID]?.append(index)
+        }
+        let providerNames = Dictionary(
+            uniqueKeysWithValues: (providersResponse?.providers ?? []).map { ($0.id, $0.name ?? $0.id) }
+        )
+        return order.map { providerID in
+            (providerID: providerID, providerName: providerNames[providerID] ?? providerID, indices: buckets[providerID] ?? [])
+        }
+    }
 }

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -437,7 +437,11 @@ final class AppState {
     var streamingPartTexts: [String: String] { get { messageStore.streamingPartTexts } set { messageStore.streamingPartTexts = newValue } }
     var streamingReasoningPart: Part? { get { messageStore.streamingReasoningPart } set { messageStore.streamingReasoningPart = newValue } }
 
-    var modelPresets: [ModelPreset] = [
+    /// Fallback presets shown before the server's provider config has loaded (or if it fails to
+    /// load). Once `loadProvidersConfig()` succeeds, `modelPresets` is replaced with the live
+    /// server list — see `applyDynamicModelPresets(from:)` below. This array intentionally stays
+    /// small; it only needs to cover the "not connected yet" cold-start case.
+    static let defaultModelPresets: [ModelPreset] = [
         ModelPreset(displayName: "GLM-5.2", providerID: "zai-coding-plan", modelID: "glm-5.2"),
         ModelPreset(displayName: "GPT-5.6 Sol", providerID: "openai", modelID: "gpt-5.6-sol"),
         ModelPreset(displayName: "Gemini 3.5 Flash", providerID: "google", modelID: "gemini-3.5-flash"),
@@ -446,6 +450,7 @@ final class AppState {
         ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2"),
         ModelPreset(displayName: "GPT-5.6 Sol Fast", providerID: "openai", modelID: "gpt-5.6-sol-fast"),
     ]
+    var modelPresets: [ModelPreset] = AppState.defaultModelPresets
     var selectedModelIndex: Int = 2
     
     var agents: [AgentInfo] = [
@@ -729,6 +734,14 @@ final class AppState {
             _ = await providersResult
             _ = await projectsResult
             await loadMessages()
+            // Re-resolve the model picker against real message history now that both the
+            // messages and the live (possibly just-updated) provider/model list are loaded.
+            // Mirrors the same two-step pattern selectSession() uses: applySavedModelForCurrentSession()
+            // as a fast best-guess, syncModelFromMessageHistory() as the authoritative correction
+            // once history is available. Without this, connecting to a server for the first time
+            // (or reconnecting) leaves the picker on whatever applyDynamicModelPresets() fell back
+            // to, even when the session already has an assistant turn recorded.
+            syncModelFromMessageHistory()
             await refreshPendingPermissions()
             await loadSessionDiff()
             await loadSessionTodos()
@@ -751,8 +764,39 @@ final class AppState {
                 }
             }
             providerModelsIndex = idx
+            applyDynamicModelPresets(from: resp)
         } catch {
             providerConfigError = error.localizedDescription
+        }
+    }
+
+    /// Rebuilds `modelPresets` from the server's live provider/model list, replacing the
+    /// cold-start `defaultModelPresets` fallback. Preserves the current selection by ID across
+    /// the swap so an in-flight session doesn't silently jump to a different model out from
+    /// under the user. `providerID` is always taken from `ConfigProvider.id` (not
+    /// `ProviderModel.providerID`) to stay consistent with how `providerModelsIndex` keys are
+    /// built above, and with how `ContextUsageView` looks up `model.providerID` from message
+    /// history — all three need to agree on the same provider-ID namespace.
+    ///
+    /// See issue #99 (grapeot/opencode_ios_client): this data was already being fetched here,
+    /// just never fed back into the picker.
+    private func applyDynamicModelPresets(from resp: ProvidersResponse) {
+        var dynamicPresets: [ModelPreset] = []
+        for p in resp.providers {
+            for m in p.models.values.sorted(by: { $0.id < $1.id }) where !m.id.isEmpty {
+                dynamicPresets.append(
+                    ModelPreset(displayName: m.name ?? m.id, providerID: p.id, modelID: m.id)
+                )
+            }
+        }
+        guard !dynamicPresets.isEmpty else { return }
+
+        let previousSelectedID = selectedModel?.id
+        modelPresets = dynamicPresets
+        if let previousSelectedID, let idx = modelPresets.firstIndex(where: { $0.id == previousSelectedID }) {
+            selectedModelIndex = idx
+        } else {
+            selectedModelIndex = 0
         }
     }
 

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -20,7 +20,17 @@ struct ModelPreset: Codable, Identifiable {
         case "GPT-5.6 Sol Fast": return "GPT-F"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"
-        default: return displayName
+        default: return Self.truncated(displayName)
         }
+    }
+
+    /// Generic fallback for names not covered by the special cases above — mainly
+    /// dynamically-loaded models from the server's `/config/providers` response (see
+    /// `AppState.applyDynamicModelPresets`). Keeps the toolbar chip label from growing
+    /// unbounded for long server-provided model names.
+    private static func truncated(_ name: String, maxLength: Int = 16) -> String {
+        guard name.count > maxLength else { return name }
+        let cutoff = name.index(name.startIndex, offsetBy: maxLength)
+        return String(name[..<cutoff]) + "…"
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -442,6 +442,7 @@ enum L10n {
         case activityGatheringThoughts
         case configureTitle
         case configureModel
+        case configureModelSearch
         case configureAgent
         case configureNoAgents
 
@@ -872,6 +873,7 @@ enum L10n {
 
         Key.configureTitle.rawValue: "Configure",
         Key.configureModel.rawValue: "Model",
+        Key.configureModelSearch.rawValue: "Search models",
         Key.configureAgent.rawValue: "Agent",
         Key.configureNoAgents.rawValue: "No agents available",
 
@@ -1302,6 +1304,7 @@ enum L10n {
 
         Key.configureTitle.rawValue: "配置",
         Key.configureModel.rawValue: "模型",
+        Key.configureModelSearch.rawValue: "搜索模型",
         Key.configureAgent.rawValue: "智能体",
         Key.configureNoAgents.rawValue: "暂无可用智能体",
 

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatToolbarView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatToolbarView.swift
@@ -18,7 +18,24 @@ struct ChatToolbarView: View {
     @State private var showCreateDisabledAlert = false
     @State private var showConfigSheet = false
     @State private var showTodoPanel = false
+    @State private var modelSearchText = ""
     @Environment(\.horizontalSizeClass) private var sizeClass
+
+    /// `state.groupedModelPresetIndices` filtered by `modelSearchText`. A query matching the
+    /// provider name (e.g. "anthropic") shows that provider's full lineup; otherwise it filters
+    /// to models whose display name matches (e.g. "sonnet" across every provider that has one).
+    /// Groups with zero matches are dropped entirely so search doesn't leave empty headers behind.
+    private var filteredModelGroups: [(providerID: String, providerName: String, indices: [Int])] {
+        let query = modelSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return state.groupedModelPresetIndices }
+        return state.groupedModelPresetIndices.compactMap { group in
+            let indices = group.providerName.localizedCaseInsensitiveContains(query)
+                ? group.indices
+                : group.indices.filter { state.modelPresets[$0].displayName.localizedCaseInsensitiveContains(query) }
+            guard !indices.isEmpty else { return nil }
+            return (providerID: group.providerID, providerName: group.providerName, indices: indices)
+        }
+    }
     
     private var useCompactLabels: Bool {
 #if canImport(UIKit)
@@ -132,20 +149,29 @@ struct ChatToolbarView: View {
             NavigationStack {
                 List {
                     Section(L10n.t(.configureModel)) {
-                        ForEach(Array(state.modelPresets.enumerated()), id: \.element.id) { index, preset in
-                            Button {
-                                state.setSelectedModelIndex(index)
-                            } label: {
-                                HStack {
-                                    Text(preset.displayName)
-                                    Spacer()
-                                    if state.selectedModelIndex == index {
-                                        Image(systemName: "checkmark")
-                                            .foregroundColor(DesignColors.Brand.primary)
+                        ForEach(filteredModelGroups, id: \.providerID) { group in
+                            if filteredModelGroups.count > 1 {
+                                Text(group.providerName)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundColor(.secondary)
+                            }
+                            ForEach(group.indices, id: \.self) { index in
+                                let preset = state.modelPresets[index]
+                                Button {
+                                    state.setSelectedModelIndex(index)
+                                    showConfigSheet = false
+                                } label: {
+                                    HStack {
+                                        Text(preset.displayName)
+                                        Spacer()
+                                        if state.selectedModelIndex == index {
+                                            Image(systemName: "checkmark")
+                                                .foregroundColor(DesignColors.Brand.primary)
+                                        }
                                     }
                                 }
+                                .foregroundColor(.primary)
                             }
-                            .foregroundColor(.primary)
                         }
                     }
                     
@@ -188,6 +214,7 @@ struct ChatToolbarView: View {
                 }
                 .navigationTitle(L10n.t(.configureTitle))
                 .navigationBarTitleDisplayMode(.inline)
+                .searchable(text: $modelSearchText, prompt: L10n.t(.configureModelSearch))
                 .toolbar {
                     ToolbarItem(placement: .confirmationAction) {
                         Button(L10n.t(.appDone)) {
@@ -197,6 +224,7 @@ struct ChatToolbarView: View {
                 }
             }
             .presentationDetents([.medium, .large])
+            .onDisappear { modelSearchText = "" }
         }
     }
 


### PR DESCRIPTION
## Problem

`modelPresets` in `AppState.swift` was a hardcoded 7-entry array. `loadProvidersConfig()` already fetched the full `/config/providers` response and built `providerModelsIndex` from it, but per the issue's own note, that data was only ever used for the context-usage ring — never fed back into the picker itself.

## Fix

- `AppState`: the hardcoded array is renamed `defaultModelPresets` and now only used as a cold-start fallback (before the first successful connection, or if `loadProvidersConfig()` fails). On success, a new `applyDynamicModelPresets(from:)` rebuilds `modelPresets` from the live server response, preserving the current selection by ID across the swap.
- Provider IDs in the dynamic list are always taken from `ConfigProvider.id`, matching how `providerModelsIndex` is already keyed and how `ContextUsageView` already looks up `model.providerID` from message history — so this doesn't introduce a second, inconsistent ID namespace.

This directly fixes the `zai-` vs `zhipu-` style mismatch described in the issue, and resolves the exact symptom already called out there: `syncModelFromMessageHistory()`'s `"not in presets, keeping current selection"` warning, which fires whenever the server reports a model the hardcoded list didn't know about.

## Follow-on fixes surfaced by testing against a real server

Once the list is actually dynamic, three more things turned out to matter:

- **Provider grouping.** Multiple providers commonly serve identically-named models (e.g. the same model available directly and via OpenRouter) — indistinguishable in a flat list. Added `groupedModelPresetIndices` (`AppState+Models.swift`) and provider section headers in the picker.
- **Search/filter.** A real server's catalog can be large enough that scrolling a flat list isn't practical. Added a `.searchable()` filter matching model name or provider name.
- **Sync-on-connect.** `refresh()` (the "Test Connection" path) already called `loadMessages()`, but — unlike `selectSession()`, which does `applySavedModelForCurrentSession()` then `syncModelFromMessageHistory()` — it never re-synced the picker against message history afterward. So connecting to a server for the first time left the picker on whatever index the dynamic-list swap happened to fall back to, even when the session already had a resolvable model in its history. Now `refresh()` matches the same two-step pattern.

Also included: tapping a model now selects and dismisses the sheet immediately (standard iOS single-select pattern, e.g. Settings' sound/default-browser pickers) instead of requiring a separate Done tap.

## Testing

- Clean baseline build (unpatched) and patched build both verified via `xcodebuild` on Xcode 26.6 / iOS 26.5 simulator — zero errors, zero new warnings.
- Installed and ran on iPhone 17 simulator, connected to a real OpenCode server with a large multi-provider model catalog.
- Confirmed: dynamic list populates correctly on connect, provider grouping and search work, the picker auto-resolves to the session's actual running model, and tap-to-select-and-close behaves as expected.
- Cold-start fallback (no connection yet) verified unaffected — still shows `defaultModelPresets`.

Fixes #99
