### PR TITLE
Surface sessions that need attention

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -485,7 +485,21 @@ final class AppState {
     }
 
     func sessionTree(archived: Bool) -> [SessionNode] {
-        Self.buildSessionTree(from: filteredSessions(archived: archived))
+        Self.prioritizeAttention(
+            Self.buildSessionTree(from: filteredSessions(archived: archived)),
+            attentionCounts: sessionAttentionCounts
+        )
+    }
+
+    var attentionSessionIDs: [String] {
+        pendingPermissions.map(\.sessionID) + pendingQuestions.map(\.sessionID)
+    }
+
+    var sessionAttentionCounts: [String: Int] {
+        Self.attentionCountsBySession(
+            sessions: sessions,
+            attentionSessionIDs: attentionSessionIDs
+        )
     }
 
     var projects: [Project] = []
@@ -718,6 +732,45 @@ final class AppState {
         roots.append(contentsOf: orphans)
         roots.sort { $0.session.time.updated > $1.session.time.updated }
         return roots
+    }
+
+    nonisolated static func attentionCountsBySession(
+        sessions: [Session],
+        attentionSessionIDs: [String]
+    ) -> [String: Int] {
+        let sessionsByID = Dictionary(uniqueKeysWithValues: sessions.map { ($0.id, $0) })
+        var counts: [String: Int] = [:]
+
+        for sourceSessionID in attentionSessionIDs {
+            var sessionID: String? = sourceSessionID
+            var visited: Set<String> = []
+            while let currentSessionID = sessionID, visited.insert(currentSessionID).inserted {
+                counts[currentSessionID, default: 0] += 1
+                sessionID = sessionsByID[currentSessionID]?.parentID
+            }
+        }
+        return counts
+    }
+
+    nonisolated static func prioritizeAttention(
+        _ nodes: [SessionNode],
+        attentionCounts: [String: Int]
+    ) -> [SessionNode] {
+        nodes
+            .map { node in
+                SessionNode(
+                    session: node.session,
+                    children: prioritizeAttention(node.children, attentionCounts: attentionCounts)
+                )
+            }
+            .sorted { lhs, rhs in
+                let lhsNeedsAttention = attentionCounts[lhs.id, default: 0] > 0
+                let rhsNeedsAttention = attentionCounts[rhs.id, default: 0] > 0
+                if lhsNeedsAttention != rhsNeedsAttention {
+                    return lhsNeedsAttention
+                }
+                return lhs.session.time.updated > rhs.session.time.updated
+            }
     }
 
     var currentSession: Session? {

--- a/OpenCodeClient/OpenCodeClient/ContentView.swift
+++ b/OpenCodeClient/OpenCodeClient/ContentView.swift
@@ -1071,7 +1071,7 @@ private struct TabletSessionsColumn: View {
                         }
 
                         if activeExpanded {
-                            sessionNodes(activeNodes, archived: false)
+                            sessionNodes(activeNodes, archived: false, attentionCounts: state.sessionAttentionCounts)
                         }
 
                         SessionSectionHeader(title: L10n.t(.sessionsArchived), isExpanded: archivedExpanded) {
@@ -1079,7 +1079,7 @@ private struct TabletSessionsColumn: View {
                         }
 
                         if archivedExpanded {
-                            sessionNodes(archivedNodes, archived: true)
+                            sessionNodes(archivedNodes, archived: true, attentionCounts: state.sessionAttentionCounts)
                         }
 
                         if state.isLoadingMoreSessions {
@@ -1170,7 +1170,12 @@ private struct TabletSessionsColumn: View {
         }
     }
 
-    private func sessionNodes(_ nodes: [SessionNode], archived: Bool, depth: Int = 0) -> AnyView {
+    private func sessionNodes(
+        _ nodes: [SessionNode],
+        archived: Bool,
+        depth: Int = 0,
+        attentionCounts: [String: Int]
+    ) -> AnyView {
         AnyView(
             ForEach(nodes) { node in
                 let session = node.session
@@ -1179,6 +1184,7 @@ private struct TabletSessionsColumn: View {
                 SessionRowView(
                     session: session,
                     status: status,
+                    attentionCount: attentionCounts[session.id, default: 0],
                     isSelected: state.currentSessionID == session.id,
                     isMutating: mutatingSessionID == session.id,
                     isArchived: archived,
@@ -1216,7 +1222,12 @@ private struct TabletSessionsColumn: View {
                 }
 
                 if state.expandedSessionIDs.contains(session.id) {
-                    sessionNodes(node.children, archived: archived, depth: depth + 1)
+                    sessionNodes(
+                        node.children,
+                        archived: archived,
+                        depth: depth + 1,
+                        attentionCounts: attentionCounts
+                    )
                 }
             }
         )

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -392,6 +392,7 @@ enum L10n {
         case sessionsStatusBusy
         case sessionsStatusRetry
         case sessionsStatusIdle
+        case sessionsStatusNeedAttention
         case sessionsActive
         case sessionsArchived
         case sessionsArchive
@@ -838,6 +839,7 @@ enum L10n {
         Key.sessionsStatusBusy.rawValue: "Running",
         Key.sessionsStatusRetry.rawValue: "Retrying",
         Key.sessionsStatusIdle.rawValue: "Idle",
+        Key.sessionsStatusNeedAttention.rawValue: "Need attention",
         Key.sessionsActive.rawValue: "Active",
         Key.sessionsArchived.rawValue: "Archived",
         Key.sessionsArchive.rawValue: "Archive",
@@ -1288,6 +1290,7 @@ enum L10n {
         Key.sessionsStatusBusy.rawValue: "运行中",
         Key.sessionsStatusRetry.rawValue: "重试中",
         Key.sessionsStatusIdle.rawValue: "空闲",
+        Key.sessionsStatusNeedAttention.rawValue: "需要关注",
         Key.sessionsActive.rawValue: "活跃",
         Key.sessionsArchived.rawValue: "已归档",
         Key.sessionsArchive.rawValue: "归档",

--- a/OpenCodeClient/OpenCodeClient/Views/SessionListView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SessionListView.swift
@@ -78,7 +78,7 @@ struct SessionListView: View {
                         }
 
                         if activeExpanded {
-                            sessionNodes(activeNodes, archived: false)
+                            sessionNodes(activeNodes, archived: false, attentionCounts: state.sessionAttentionCounts)
                         }
 
                         SessionSectionHeader(title: L10n.t(.sessionsArchived), isExpanded: archivedExpanded) {
@@ -86,7 +86,7 @@ struct SessionListView: View {
                         }
 
                         if archivedExpanded {
-                            sessionNodes(archivedNodes, archived: true)
+                            sessionNodes(archivedNodes, archived: true, attentionCounts: state.sessionAttentionCounts)
                         }
 
                         if state.isLoadingMoreSessions {
@@ -134,7 +134,12 @@ struct SessionListView: View {
         dismiss()
     }
 
-    private func sessionNodes(_ nodes: [SessionNode], archived: Bool, depth: Int = 0) -> AnyView {
+    private func sessionNodes(
+        _ nodes: [SessionNode],
+        archived: Bool,
+        depth: Int = 0,
+        attentionCounts: [String: Int]
+    ) -> AnyView {
         AnyView(
             ForEach(nodes) { node in
                 let session = node.session
@@ -143,6 +148,7 @@ struct SessionListView: View {
                 SessionRowView(
                     session: session,
                     status: status,
+                    attentionCount: attentionCounts[session.id, default: 0],
                     isSelected: state.currentSessionID == session.id,
                     isMutating: mutatingSessionID == session.id,
                     isArchived: archived,
@@ -180,7 +186,12 @@ struct SessionListView: View {
                 }
 
                 if state.expandedSessionIDs.contains(session.id) {
-                    sessionNodes(node.children, archived: archived, depth: depth + 1)
+                    sessionNodes(
+                        node.children,
+                        archived: archived,
+                        depth: depth + 1,
+                        attentionCounts: attentionCounts
+                    )
                 }
             }
         )
@@ -261,6 +272,7 @@ struct LoadMoreSessionsRow: View {
 struct SessionRowView: View {
     let session: Session
     let status: SessionStatus?
+    var attentionCount: Int = 0
     let isSelected: Bool
     let isMutating: Bool
     let isArchived: Bool
@@ -329,10 +341,10 @@ struct SessionRowView: View {
                         .font(DesignTypography.meta)
                         .foregroundStyle(isArchived ? DesignColors.Neutral.textTertiary : DesignColors.Neutral.textSecondary)
 
-                    if let status {
-                        Text(statusLabel(status))
+                    if attentionCount > 0 || status != nil {
+                        Text(statusLabel(status, attentionCount: attentionCount))
                             .font(DesignTypography.meta)
-                            .foregroundStyle(statusColor(status))
+                            .foregroundStyle(statusColor(status, attentionCount: attentionCount))
                     }
                 }
             }
@@ -368,16 +380,21 @@ struct SessionRowView: View {
         return formatter.localizedString(for: date, relativeTo: Date())
     }
 
-    private func statusLabel(_ status: SessionStatus) -> String {
-        switch status.type {
+    private func statusLabel(_ status: SessionStatus?, attentionCount: Int) -> String {
+        if attentionCount > 0 {
+            let label = L10n.t(.sessionsStatusNeedAttention)
+            return attentionCount > 1 ? "\(label) · \(attentionCount)" : label
+        }
+        switch status?.type {
         case "busy": return L10n.t(.sessionsStatusBusy)
         case "retry": return L10n.t(.sessionsStatusRetry)
         default: return L10n.t(.sessionsStatusIdle)
         }
     }
 
-    private func statusColor(_ status: SessionStatus) -> Color {
-        switch status.type {
+    private func statusColor(_ status: SessionStatus?, attentionCount: Int) -> Color {
+        if attentionCount > 0 { return DesignColors.Semantic.error }
+        switch status?.type {
         case "busy", "retry": return DesignColors.Brand.primary
         default: return DesignColors.Neutral.textSecondary
         }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -2516,6 +2516,38 @@ struct SessionTreeTests {
         #expect(tree.isEmpty)
     }
 
+    @Test func attentionCountsRollUpThroughAllAncestors() {
+        let sessions = [
+            makeSession(id: "root", updated: 100),
+            makeSession(id: "child", parentID: "root", updated: 90),
+            makeSession(id: "grandchild", parentID: "child", updated: 80),
+        ]
+
+        let counts = AppState.attentionCountsBySession(
+            sessions: sessions,
+            attentionSessionIDs: ["grandchild", "grandchild"]
+        )
+
+        #expect(counts["grandchild"] == 2)
+        #expect(counts["child"] == 2)
+        #expect(counts["root"] == 2)
+    }
+
+    @Test func attentionSessionsSortAheadOfNewerSessions() {
+        let sessions = [
+            makeSession(id: "newer", updated: 200),
+            makeSession(id: "attention", updated: 100),
+        ]
+        let tree = AppState.buildSessionTree(from: sessions)
+
+        let prioritized = AppState.prioritizeAttention(
+            tree,
+            attentionCounts: ["attention": 1]
+        )
+
+        #expect(prioritized.map(\.id) == ["attention", "newer"])
+    }
+
     @Test func sessionTreeExcludesArchivedWhenFiltered() {
         let sessions = [
             makeSession(id: "active", updated: 100),


### PR DESCRIPTION
## Summary
- derive pending permission/question counts for their source sessions and every parent session
- prioritize affected session trees and show red `Need attention` status with request counts
- apply the same behavior to the iPhone session sheet and iPad sidebar
- keep existing composer behavior: recording already disables send, while busy sessions still accept steering messages

## Verification
- iPhone 16 / iOS 18.4 simulator build passed
- `SessionTreeTests`: 12 tests passed

Not merging until device testing is complete.