### PR TITLE
feat(models): bump Gemini 3.5 Flash to Gemini 3.6 Flash

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -457,7 +457,7 @@ final class AppState {
     var modelPresets: [ModelPreset] = [
         ModelPreset(displayName: "GLM-5.2", providerID: "zai-coding-plan", modelID: "glm-5.2"),
         ModelPreset(displayName: "GPT-5.6 Sol", providerID: "openai", modelID: "gpt-5.6-sol"),
-        ModelPreset(displayName: "Gemini 3.5 Flash", providerID: "google", modelID: "gemini-3.5-flash"),
+        ModelPreset(displayName: "Gemini 3.6 Flash", providerID: "google", modelID: "gemini-3.6-flash"),
         ModelPreset(displayName: "DeepSeek Local", providerID: "ds4", modelID: "deepseek-v4-flash"),
         ModelPreset(displayName: "DeepSeek V4 Pro", providerID: "deepseek", modelID: "deepseek-v4-pro"),
         ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2"),

--- a/OpenCodeClient/OpenCodeClientTests/AIUsageQuotaTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/AIUsageQuotaTests.swift
@@ -49,7 +49,7 @@ struct AIUsageQuotaTests {
     @Test func mapsSupportedModelsToQuotaProviders() {
         let gpt = ModelPreset(displayName: "GPT-5.6 Sol", providerID: "openai", modelID: "gpt-5.6-sol")
         let glm = ModelPreset(displayName: "GLM-5.2", providerID: "zai-coding-plan", modelID: "glm-5.2")
-        let gemini = ModelPreset(displayName: "Gemini 3.5 Flash", providerID: "google", modelID: "gemini-3.5-flash")
+        let gemini = ModelPreset(displayName: "Gemini 3.6 Flash", providerID: "google", modelID: "gemini-3.6-flash")
 
         #expect(gpt.primaryQuotaKey == AIUsageQuotaKey(provider: "codex", label: "5h"))
         #expect(glm.primaryQuotaKey == AIUsageQuotaKey(provider: "glm", label: "5h"))

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -2147,13 +2147,13 @@ struct ModelSelectionPersistenceTests {
         }
     }
 
-    @Test @MainActor func defaultSelectionUsesGemini35Flash() {
+    @Test @MainActor func defaultSelectionUsesGemini36Flash() {
         withIsolatedModelSelectionDefaults {
             let state = AppState()
 
             #expect(state.selectedModelIndex == 2)
-            #expect(state.modelPresets[state.selectedModelIndex].displayName == "Gemini 3.5 Flash")
-            #expect(state.modelPresets[state.selectedModelIndex].id == "google/gemini-3.5-flash")
+            #expect(state.modelPresets[state.selectedModelIndex].displayName == "Gemini 3.6 Flash")
+            #expect(state.modelPresets[state.selectedModelIndex].id == "google/gemini-3.6-flash")
         }
     }
 


### PR DESCRIPTION
Updates the model preset entry from Gemini 3.5 Flash (`gemini-3.5-flash`) to Gemini 3.6 Flash (`gemini-3.6-flash`) in both `AppState.swift` and the corresponding tests.

**Do not merge yet** — pending manual verification.