### PR TITLE
Support cross-block chat text selection

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -277,6 +277,8 @@ enum L10n {
         case chatPullToLoadMore
         case chatLoadingMoreHistory
         case chatLargeMessagePreviewNotice
+        case chatSelectText
+        case chatCopyMessage
         case chatEditFromHere
         case chatForkFromHere
         case carTitle
@@ -724,6 +726,8 @@ enum L10n {
         Key.chatPullToLoadMore.rawValue: "Pull down to load more history",
         Key.chatLoadingMoreHistory.rawValue: "Loading more history...",
         Key.chatLargeMessagePreviewNotice.rawValue: "Large message: showing first %@ of %@ characters. Markdown rendering is skipped to keep the app responsive.",
+        Key.chatSelectText.rawValue: "Select Text",
+        Key.chatCopyMessage.rawValue: "Copy Message",
         Key.chatEditFromHere.rawValue: "Edit from here",
         Key.chatForkFromHere.rawValue: "Fork from here",
         Key.carTitle.rawValue: "Car Mode",
@@ -1175,6 +1179,8 @@ enum L10n {
         Key.chatPullToLoadMore.rawValue: "下拉加载更多历史消息",
         Key.chatLoadingMoreHistory.rawValue: "正在加载更多历史消息...",
         Key.chatLargeMessagePreviewNotice.rawValue: "消息较长：当前只显示前 %@ / %@ 个字符。为保持流畅，已跳过 Markdown 渲染。",
+        Key.chatSelectText.rawValue: "选择文本",
+        Key.chatCopyMessage.rawValue: "复制整条消息",
         Key.chatEditFromHere.rawValue: "从这里编辑",
         Key.carTitle.rawValue: "驾驶模式",
         Key.carReady.rawValue: "可以说话",

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import MarkdownUI
+import UIKit
 
 struct MessageRowView: View {
     private static let markdownRenderCharacterLimit = 12_000
@@ -21,6 +22,7 @@ struct MessageRowView: View {
     let onEditFromMessage: ((String) -> Void)?
     @Environment(\.horizontalSizeClass) private var sizeClass
     @Environment(\.colorScheme) private var colorScheme
+    @State private var showsTextSelection = false
 
     // iPhone packs tool/patch cards two-up to keep information density high;
     // iPad has room for a 3-up grid.
@@ -200,6 +202,96 @@ struct MessageRowView: View {
         return message.info.structured?.speech
     }
 
+    static func copyableText(for message: MessageWithParts) -> String {
+        let text = message.parts
+            .filter(\.isText)
+            .compactMap(\.text)
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
+        if !text.isEmpty { return text }
+        return structuredSpeechFallback(for: message) ?? ""
+    }
+
+    static func selectionText(from markdown: String) -> String {
+        var insideCodeFence = false
+        return markdown
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .compactMap { substring -> String? in
+                let line = String(substring)
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                    insideCodeFence.toggle()
+                    return nil
+                }
+                if insideCodeFence { return line }
+
+                var content = line
+                let leadingWhitespace = content.prefix { $0 == " " || $0 == "\t" }
+                var body = content.dropFirst(leadingWhitespace.count)
+                if let markerEnd = body.firstIndex(where: { $0 != "#" }),
+                   markerEnd != body.startIndex,
+                   body.distance(from: body.startIndex, to: markerEnd) <= 6,
+                   body[markerEnd] == " " {
+                    body = body[body.index(after: markerEnd)...]
+                    content = String(leadingWhitespace) + String(body)
+                } else if body.hasPrefix("> ") {
+                    content = String(leadingWhitespace) + String(body.dropFirst(2))
+                }
+
+                guard let inline = try? AttributedString(
+                    markdown: content,
+                    options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+                ) else { return content }
+                return String(inline.characters)
+            }
+            .joined(separator: "\n")
+    }
+
+    private var copyableText: String {
+        Self.copyableText(for: message)
+    }
+
+    private var messageActionsMenu: some View {
+        Menu {
+            Button {
+                showsTextSelection = true
+            } label: {
+                Label(L10n.t(.chatSelectText), systemImage: "text.viewfinder")
+            }
+
+            Button {
+                UIPasteboard.general.string = copyableText
+            } label: {
+                Label(L10n.t(.chatCopyMessage), systemImage: "doc.on.doc")
+            }
+
+            if message.info.isUser, let onEditFromMessage {
+                Button {
+                    onEditFromMessage(message.info.id)
+                } label: {
+                    Label(L10n.t(.chatEditFromHere), systemImage: "pencil")
+                }
+                .disabled(state.isBusy)
+            }
+
+            if let onForkFromMessage {
+                Button {
+                    onForkFromMessage(message.info.id)
+                } label: {
+                    Label(L10n.t(.chatForkFromHere), systemImage: "arrow.triangle.branch")
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 2)
+                .contentShape(Rectangle())
+        }
+        .accessibilityIdentifier("message-actions")
+    }
+
     private struct LargeMessagePreview: View {
         let text: String
         let preview: String
@@ -222,6 +314,9 @@ struct MessageRowView: View {
             } else {
                 assistantMessageView
             }
+        }
+        .sheet(isPresented: $showsTextSelection) {
+            MessageTextSelectionSheet(text: copyableText)
         }
     }
 
@@ -254,31 +349,7 @@ struct MessageRowView: View {
                 // User messages don't carry a model line — the model belongs to
                 // the assistant's reply, not to what the human said.
                 Spacer()
-                if onForkFromMessage != nil {
-                    Menu {
-                        if onEditFromMessage != nil {
-                            Button {
-                                onEditFromMessage?(message.info.id)
-                            } label: {
-                                Label(L10n.t(.chatEditFromHere), systemImage: "pencil")
-                            }
-                            .disabled(state.isBusy)
-                        }
-
-                        Button {
-                            onForkFromMessage?(message.info.id)
-                        } label: {
-                            Label(L10n.t(.chatForkFromHere), systemImage: "arrow.triangle.branch")
-                        }
-                    } label: {
-                        Image(systemName: "ellipsis")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 2)
-                            .contentShape(Rectangle())
-                    }
-                }
+                if !copyableText.isEmpty { messageActionsMenu }
             }
             .padding(.leading, 4)
         }
@@ -309,11 +380,17 @@ struct MessageRowView: View {
 
             // Model footer: same caption2/tertiary "providerID/modelID" treatment as
             // the user message, placed at the end of the assistant turn.
-            if let model = message.info.resolvedModel {
-                Text("\(model.providerID)/\(model.modelID)")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                    .padding(.leading, 4)
+            if message.info.resolvedModel != nil || !copyableText.isEmpty {
+                HStack {
+                    if let model = message.info.resolvedModel {
+                        Text("\(model.providerID)/\(model.modelID)")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    Spacer()
+                    if !copyableText.isEmpty { messageActionsMenu }
+                }
+                .padding(.leading, 4)
             }
 
             if let err = message.info.errorMessageForDisplay {
@@ -386,6 +463,52 @@ struct MessageRowView: View {
         .background(DesignColors.Neutral.text.opacity(DesignColors.surfaceFill(for: colorScheme)))
         .clipShape(RoundedRectangle(cornerRadius: DesignCorners.medium))
         .accessibilityIdentifier("toolcard.toolcalls")
+    }
+}
+
+private struct MessageTextSelectionSheet: View {
+    let text: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            SelectableMessageTextView(text: text)
+                .navigationTitle(L10n.t(.chatSelectText))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button(L10n.t(.appDone)) { dismiss() }
+                    }
+                }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}
+
+private struct SelectableMessageTextView: UIViewRepresentable {
+    let text: String
+
+    func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.alwaysBounceVertical = true
+        view.adjustsFontForContentSizeCategory = true
+        view.backgroundColor = .clear
+        view.textColor = .label
+        view.textContainerInset = UIEdgeInsets(top: 16, left: 12, bottom: 16, right: 12)
+        view.accessibilityIdentifier = "message-text-selection"
+        return view
+    }
+
+    func updateUIView(_ view: UITextView, context: Context) {
+        guard view.text != selectableText else { return }
+        view.font = .preferredFont(forTextStyle: .body)
+        view.text = selectableText
+    }
+
+    private var selectableText: String {
+        MessageRowView.selectionText(from: text)
     }
 }
 

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -285,8 +285,7 @@ struct MessageRowView: View {
             Image(systemName: "ellipsis")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
-                .padding(.horizontal, 4)
-                .padding(.vertical, 2)
+                .frame(width: 44, height: 44)
                 .contentShape(Rectangle())
         }
         .accessibilityIdentifier("message-actions")

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1478,6 +1478,49 @@ struct MessageRenderingHeuristicTests {
         #expect(MessageRowView.hasMarkdownSyntax("```swift\nprint(1)\n```") == true)
     }
 
+    @Test func copyableMessageTextJoinsTextPartsAcrossMarkdownBlocks() throws {
+        let json = """
+        {
+          "info": {
+            "id": "message-1",
+            "sessionID": "session-1",
+            "role": "assistant",
+            "time": { "created": 1 }
+          },
+          "parts": [
+            { "id": "part-1", "sessionID": "session-1", "messageID": "message-1", "type": "text", "text": "First paragraph" },
+            { "id": "part-2", "sessionID": "session-1", "messageID": "message-1", "type": "text", "text": "- second\\n- third" }
+          ]
+        }
+        """
+        let message = try JSONDecoder().decode(MessageWithParts.self, from: Data(json.utf8))
+
+        #expect(
+            MessageRowView.copyableText(for: message)
+                == "First paragraph\n\n- second\n- third"
+        )
+    }
+
+    @Test func selectionTextPreservesMarkdownBlockBoundaries() {
+        let markdown = """
+        # Heading
+
+        First **paragraph**.
+
+        - second
+        - third
+
+        ```swift
+        print("**literal**")
+        ```
+        """
+
+        #expect(
+            MessageRowView.selectionText(from: markdown)
+                == "Heading\n\nFirst paragraph.\n\n- second\n- third\n\nprint(\"**literal**\")"
+        )
+    }
+
     @Test func largeMessageDetectionSkipsExpensiveMarkdownRendering() {
         let text = String(repeating: "- Wells Fargo agreement\n", count: 3_000)
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,10 +4,19 @@
 
 ## 当前状态
 
-- **最后更新**：2026-07-15
-- **分支**：`feat/session-deep-links`
+- **最后更新**：2026-07-24
+- **分支**：`feat/message-text-selection`
 - **编译/测试**：iPhone 16 / iOS 18.4 build 与全量 test suite 通过；36 个 UI tests 中 4 个 opt-in tests 按预期 skip
 - **Phase**：`opencode://session/<id>` cold/warm launch 与 Chat Markdown navigation implemented
+
+### 2026-07-24 — Chat 跨 Markdown block 文本选择
+
+- 根因定位到 MarkdownUI 的 `BlockSequence`：一条 Markdown 消息会拆成多个 SwiftUI block view；iOS 的 `.textSelection(.enabled)` 只能在单个可选择 view 内工作，无法跨段落、列表和代码块扩展 selection。Chat 没有使用 WKWebView，也不是流式 DOM diff 问题。
+- 保留现有 MarkdownUI 阅读渲染，避免回归 workspace 图片、表格、代码块和链接；user/assistant 消息菜单新增“选择文本”和“复制整条消息”。
+- `Edit from here` 只显示在 user message；`Fork from here` 继续同时支持 user 和 assistant message，允许从任意 turn 分叉。
+- “选择文本”使用单一只读 `UITextView` sheet，逐行清理 Markdown 行内标记，保留段落、列表和代码块的原始换行，再支持 iOS 原生跨行、跨段拖选；“复制整条消息”直接复制完整原始文本。
+- 新增多 text part 拼接测试，确保一条消息的多个文本 part 使用空行连接，不再受 Markdown block 边界影响。
+- 验证：iPhone 16 / iOS 18.4 build 通过；`MessageRenderingHeuristicTests` 7 个定向测试通过。
 
 ### 2026-07-19 — Health Quantification client capability
 


### PR DESCRIPTION
## Summary
- add a Select Text sheet backed by one read-only UITextView so selection can span Markdown blocks
- add Copy Message for complete raw message text while preserving the existing MarkdownUI rendering
- show Edit from here only for user messages and keep Fork from here available for both user and assistant messages
- add English and Chinese localization plus focused text-processing tests

## Verification
- iPhone 16 / iOS 18.4 build passed
- MessageRenderingHeuristicTests passed (7/7)
- git diff --check passed