### PR TITLE
Enlarge session disclosure touch target

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/SessionListView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SessionListView.swift
@@ -316,9 +316,11 @@ struct SessionRowView: View {
                     Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
                         .font(DesignTypography.micro)
                         .foregroundStyle(DesignColors.Neutral.textSecondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .frame(width: 12)
+                .padding(.horizontal, -16)
                 .accessibilityIdentifier("session-toggle-\(session.id)")
             } else if depth > 0 {
                 RoundedRectangle(cornerRadius: 1.5)


### PR DESCRIPTION
## Summary
- expand nested session disclosure controls to a 44 x 44 pt touch target
- preserve the existing chevron size, title alignment, and hierarchy indentation
- leave the already full-width Active/Archived section controls unchanged

## Verification
- iPhone 16 / iOS 18.4 build passed
- git diff --check passed