### PR TITLE
Add dual recording strategies and pin VoiceFlowKit 0.3.0

### DIFF
--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
@@ -645,7 +645,7 @@
 			repositoryURL = "https://github.com/grapeot/voiceflow.git";
 			requirement = {
 				kind = revision;
-				revision = dbbe297ea52e3a3438d227a54001b23c138c47b7;
+				revision = 4a04d562965fe041b552570759ef6e419ab3b2d6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
@@ -644,8 +644,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/grapeot/voiceflow.git";
 			requirement = {
-				kind = revision;
-				revision = 4a04d562965fe041b552570759ef6e419ab3b2d6;
+				kind = exactVersion;
+				version = 0.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,7 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grapeot/voiceflow.git",
       "state" : {
-        "revision" : "4a04d562965fe041b552570759ef6e419ab3b2d6"
+        "revision" : "71b9fe6c8a2d4ff98bb1d349512f704c7cec44ed",
+        "version" : "0.3.0"
       }
     }
   ],

--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,7 +123,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grapeot/voiceflow.git",
       "state" : {
-        "revision" : "dbbe297ea52e3a3438d227a54001b23c138c47b7"
+        "revision" : "4a04d562965fe041b552570759ef6e419ab3b2d6"
       }
     }
   ],

--- a/OpenCodeClient/OpenCodeClient/AppState+VoiceFlowKit.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+VoiceFlowKit.swift
@@ -2,6 +2,10 @@ import Foundation
 import os
 import VoiceFlowKit
 
+extension VoiceFlowRecordingStrategy {
+    var usesRealtimeTransport: Bool { self == .openAIRealtime }
+}
+
 /// VoiceFlowKit speech recognition integration. Wraps the kit's
 /// `VoiceFlowClient` for OpenCode's three speech entry points:
 /// one-shot transcription of an audio file, real-time WS sessions for
@@ -36,13 +40,21 @@ extension AppState {
         return VoiceFlowClient(config: config)
     }
 
-    func transcribeAudio(audioFileURL: URL, onPartialTranscript: (@Sendable (String) -> Void)? = nil) async throws -> String {
+    func transcribeAudio(
+        audioFileURL: URL,
+        strategy: VoiceFlowRecordingStrategy = .openAIRealtime,
+        onPartialTranscript: (@Sendable (String) -> Void)? = nil
+    ) async throws -> String {
         let start = ProcessInfo.processInfo.systemUptime
         let fileName = audioFileURL.lastPathComponent.isEmpty ? "audio.m4a" : audioFileURL.lastPathComponent
         Self.logger.notice("[SpeechProfile] appState.transcribe begin file=\(fileName, privacy: .public)")
         do {
             let client = try makeVoiceFlowClient()
-            let result = try await client.transcribe(audioFile: audioFileURL, onPartialTranscript: onPartialTranscript)
+            let result = try await client.transcribe(
+                audioFile: audioFileURL,
+                strategy: strategy,
+                onPartialTranscript: onPartialTranscript
+            )
             let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
             Self.logger.notice("[SpeechProfile] appState.transcribe done ms=\(elapsedMs, privacy: .public) textChars=\(result.text.count, privacy: .public) requestID=\(result.requestID, privacy: .public)")
             return result.text

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -476,6 +476,7 @@ final class AppState {
         ModelPreset(displayName: "Ollama GLM 5.2", providerID: "ollama-cloud", modelID: "glm-5.2"),
         ModelPreset(displayName: "GPT-5.6 Sol Fast", providerID: "openai", modelID: "gpt-5.6-sol-fast"),
         ModelPreset(displayName: "GPT-5.6 Terra Fast", providerID: "openai", modelID: "gpt-5.6-terra-fast"),
+        ModelPreset(displayName: "Grok 4.5", providerID: "xai", modelID: "grok-4.5"),
     ]
     var selectedModelIndex: Int = 2
     

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -166,6 +166,7 @@ final class AppState {
     static let aiBuilderTokenKeychainKey = "aiBuilderToken"
     static let aiBuilderCustomPromptKey = "aiBuilderCustomPrompt"
     static let aiBuilderTerminologyKey = "aiBuilderTerminology"
+    static let aiBuilderRecordingStrategyKey = "aiBuilderRecordingStrategy"
     static let aiBuilderLastOKSignatureKey = "aiBuilderLastOKSignature"
     static let aiBuilderLastOKTestedAtKey = "aiBuilderLastOKTestedAt"
     static let draftInputsBySessionKey = "draftInputsBySession"
@@ -225,6 +226,9 @@ final class AppState {
         _aiBuilderToken = KeychainHelper.load(forKey: Self.aiBuilderTokenKeychainKey) ?? ""
         _aiBuilderCustomPrompt = UserDefaults.standard.string(forKey: Self.aiBuilderCustomPromptKey) ?? Self.defaultAIBuilderCustomPrompt
         _aiBuilderTerminology = UserDefaults.standard.string(forKey: Self.aiBuilderTerminologyKey) ?? Self.defaultAIBuilderTerminology
+        _aiBuilderRecordingStrategy = VoiceFlowRecordingStrategy(
+            rawValue: UserDefaults.standard.string(forKey: Self.aiBuilderRecordingStrategyKey) ?? ""
+        ) ?? .openAIRealtime
         _selectedProjectWorktree = UserDefaults.standard.string(forKey: Self.selectedProjectWorktreeKey)
         _customProjectPath = UserDefaults.standard.string(forKey: Self.customProjectPathKey) ?? ""
         _languagePreference = L10n.languagePreference
@@ -340,6 +344,15 @@ final class AppState {
         set {
             _aiBuilderTerminology = newValue
             UserDefaults.standard.set(newValue, forKey: Self.aiBuilderTerminologyKey)
+        }
+    }
+
+    var _aiBuilderRecordingStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
+    var aiBuilderRecordingStrategy: VoiceFlowRecordingStrategy {
+        get { _aiBuilderRecordingStrategy }
+        set {
+            _aiBuilderRecordingStrategy = newValue
+            UserDefaults.standard.set(newValue.rawValue, forKey: Self.aiBuilderRecordingStrategyKey)
         }
     }
 

--- a/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/ModelPreset.swift
@@ -19,6 +19,7 @@ struct ModelPreset: Codable, Identifiable {
         case "Ollama GLM 5.2": return "OGLM-5.2"
         case "GPT-5.6 Sol Fast": return "GPT-F"
         case "GPT-5.6 Terra Fast": return "GPT-TF"
+        case "Grok 4.5": return "Grok"
         case let name where name.contains("Gemini"): return "Gemini"
         case let name where name.contains("GPT"): return "GPT"
         default: return displayName

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -101,6 +101,9 @@ enum L10n {
         case settingsAppearance
         case settingsTheme
         case settingsSpeechRecognition
+        case settingsRecordingStrategy
+        case settingsOpenAIRealtime
+        case settingsGrokBatch
         case settingsAiBuilderBaseURL
         case settingsAiBuilderToken
         case settingsCustomPrompt
@@ -552,6 +555,9 @@ enum L10n {
         Key.settingsAppearance.rawValue: "Appearance",
         Key.settingsTheme.rawValue: "Theme",
         Key.settingsSpeechRecognition.rawValue: "Speech Recognition",
+        Key.settingsRecordingStrategy.rawValue: "Recording Strategy",
+        Key.settingsOpenAIRealtime.rawValue: "OpenAI Realtime",
+        Key.settingsGrokBatch.rawValue: "Grok Batch",
         Key.settingsAiBuilderBaseURL.rawValue: "AI Builder Base URL",
         Key.settingsAiBuilderToken.rawValue: "AI Builder Token",
         Key.settingsCustomPrompt.rawValue: "Custom Prompt",
@@ -1002,6 +1008,9 @@ enum L10n {
         Key.settingsAppearance.rawValue: "外观",
         Key.settingsTheme.rawValue: "主题",
         Key.settingsSpeechRecognition.rawValue: "语音识别",
+        Key.settingsRecordingStrategy.rawValue: "录音策略",
+        Key.settingsOpenAIRealtime.rawValue: "OpenAI 实时",
+        Key.settingsGrokBatch.rawValue: "Grok 批量",
         Key.settingsAiBuilderBaseURL.rawValue: "AI Builder 服务地址",
         Key.settingsAiBuilderToken.rawValue: "AI Builder 访问令牌",
         Key.settingsCustomPrompt.rawValue: "自定义提示词",

--- a/OpenCodeClient/OpenCodeClient/Views/Car/CarModeView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Car/CarModeView.swift
@@ -6,6 +6,10 @@ struct CarModeView: View {
     @Bindable var state: AppState
     @State private var microphone = VoiceFlowMicrophone()
     @State private var speechSession: VoiceFlowSession?
+    @State private var recordingStartID: UUID?
+    @State private var activeRecordingStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
+    @State private var pendingRecordingURL: URL?
+    @State private var pendingRecordingStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
     @State private var heartbeatTask: Task<Void, Never>?
     @State private var audioLevelTask: Task<Void, Never>?
     @State private var audioLevel: Float = 0
@@ -238,9 +242,14 @@ struct CarModeView: View {
             await stopRecordingAndSubmit()
         case .finalizing, .waitingReply, .speaking:
             speechFinalizationID = nil
+            discardPendingRecording()
             await state.cancelCarInteraction()
         case .failed:
-            await state.submitCarTurn(state.carLastTranscript)
+            if pendingRecordingURL != nil {
+                await retryPendingRecording()
+            } else {
+                await state.submitCarTurn(state.carLastTranscript)
+            }
         case .idle, .awaitingConfirmation:
             await startRecording()
         }
@@ -259,41 +268,116 @@ struct CarModeView: View {
             state.carPhase = .failed
             return
         }
+        let startID = UUID()
+        recordingStartID = startID
+        isStartingRecording = true
         guard await ChatTabView.requestMicrophonePermissionForRecording() else {
+            guard recordingStartID == startID else { return }
+            recordingStartID = nil
+            isStartingRecording = false
             state.carError = L10n.t(.chatMicrophoneDenied)
             state.carPhase = .failed
             return
         }
 
-        isStartingRecording = true
+        guard recordingStartID == startID else { return }
         speechFinalizationID = nil
+        discardPendingRecording()
         state.carSpeechOutput.stop()
-        microphone = VoiceFlowMicrophone()
+        let startingMicrophone = VoiceFlowMicrophone()
+        microphone = startingMicrophone
+        var startedSession: VoiceFlowSession?
         do {
-            let session = try await state.startRealtimeSpeechSession()
-            speechSession = session
-            try await microphone.start { chunk in
-                Task { await session.sendAudioChunk(chunk) }
+            let strategy = state.aiBuilderRecordingStrategy
+            activeRecordingStrategy = strategy
+            if strategy.usesRealtimeTransport {
+                let session = try await state.startRealtimeSpeechSession()
+                startedSession = session
+                guard recordingStartID == startID else {
+                    await terminate(session)
+                    return
+                }
+                speechSession = session
+                try await startingMicrophone.start(strategy: strategy) { chunk in
+                    Task { await session.sendAudioChunk(chunk) }
+                }
+            } else {
+                speechSession = nil
+                try await startingMicrophone.start(strategy: strategy)
+            }
+            guard recordingStartID == startID else {
+                if let audioURL = try? await startingMicrophone.stop() {
+                    try? FileManager.default.removeItem(at: audioURL)
+                }
+                startingMicrophone.discard()
+                if let startedSession {
+                    await terminate(startedSession)
+                    if speechSession === startedSession {
+                        speechSession = nil
+                    }
+                }
+                return
+            }
+            if let startedSession {
+                startHeartbeat(for: startedSession)
             }
             state.carError = nil
             state.carPhase = .recording
-            startHeartbeat(for: session)
             startAudioLevelConsumer()
         } catch {
-            speechSession = nil
+            if let audioURL = try? await startingMicrophone.stop() {
+                try? FileManager.default.removeItem(at: audioURL)
+            }
+            startingMicrophone.discard()
+            if let startedSession {
+                await terminate(startedSession)
+                if speechSession === startedSession {
+                    speechSession = nil
+                }
+            }
+            guard recordingStartID == startID else { return }
             state.carError = error.localizedDescription
             state.carPhase = .failed
         }
-        isStartingRecording = false
+        if recordingStartID == startID {
+            recordingStartID = nil
+            isStartingRecording = false
+        }
     }
 
     private func stopRecordingAndSubmit() async {
-        stopHeartbeat()
-        stopAudioLevelConsumer()
-        _ = try? await microphone.stop()
-        state.carPhase = .finalizing
         let finalizationID = UUID()
         speechFinalizationID = finalizationID
+        let stoppingMicrophone = microphone
+        stopHeartbeat()
+        stopAudioLevelConsumer()
+        let audioURL = try? await stoppingMicrophone.stop()
+        stoppingMicrophone.discard()
+        guard speechFinalizationID == finalizationID else {
+            if let audioURL {
+                try? FileManager.default.removeItem(at: audioURL)
+            }
+            return
+        }
+        state.carPhase = .finalizing
+        let strategy = activeRecordingStrategy
+
+        if !strategy.usesRealtimeTransport {
+            guard let audioURL else {
+                speechFinalizationID = nil
+                state.carError = L10n.t(.carTranscriptionFailed)
+                state.carPhase = .failed
+                return
+            }
+            pendingRecordingURL = audioURL
+            pendingRecordingStrategy = strategy
+            await transcribePendingRecording(finalizationID: finalizationID)
+            return
+        }
+
+        if let audioURL {
+            try? FileManager.default.removeItem(at: audioURL)
+        }
         guard let session = speechSession else {
             speechFinalizationID = nil
             state.carError = L10n.t(.carTranscriptionFailed)
@@ -309,6 +393,7 @@ struct CarModeView: View {
             guard !cleaned.isEmpty else { throw CarModeError.invalidResponse }
             guard speechFinalizationID == finalizationID else { return }
             speechFinalizationID = nil
+            discardPendingRecording()
             await state.submitCarTurn(cleaned)
         } catch {
             await terminate(session)
@@ -320,15 +405,58 @@ struct CarModeView: View {
     }
 
     private func stopForBackground() async {
+        recordingStartID = nil
+        isStartingRecording = false
         speechFinalizationID = nil
         stopHeartbeat()
         stopAudioLevelConsumer()
-        _ = try? await microphone.stop()
+        if let audioURL = try? await microphone.stop() {
+            try? FileManager.default.removeItem(at: audioURL)
+        }
+        microphone.discard()
         if let session = speechSession {
             speechSession = nil
             await terminate(session)
         }
         await state.cancelCarInteraction()
+        discardPendingRecording()
+    }
+
+    private func retryPendingRecording() async {
+        guard pendingRecordingURL != nil else { return }
+        state.carPhase = .finalizing
+        let finalizationID = UUID()
+        speechFinalizationID = finalizationID
+        await transcribePendingRecording(finalizationID: finalizationID)
+    }
+
+    private func transcribePendingRecording(finalizationID: UUID) async {
+        guard let audioURL = pendingRecordingURL else { return }
+        do {
+            let transcript = try await state.transcribeAudio(
+                audioFileURL: audioURL,
+                strategy: pendingRecordingStrategy
+            )
+            let cleaned = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !cleaned.isEmpty else { throw CarModeError.invalidResponse }
+            guard speechFinalizationID == finalizationID else { return }
+            speechFinalizationID = nil
+            discardPendingRecording()
+            await state.submitCarTurn(cleaned)
+        } catch {
+            guard speechFinalizationID == finalizationID else { return }
+            speechFinalizationID = nil
+            state.carError = error.localizedDescription
+            state.carPhase = .failed
+        }
+    }
+
+    private func discardPendingRecording() {
+        if let pendingRecordingURL {
+            try? FileManager.default.removeItem(at: pendingRecordingURL)
+        }
+        pendingRecordingURL = nil
+        pendingRecordingStrategy = .openAIRealtime
     }
 
     private func terminate(_ session: VoiceFlowSession) async {

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
@@ -162,51 +162,107 @@ extension ChatTabView {
     }
 
     func stopSpeechForBackground() async {
+        let hadActiveOperation = isRecording || isStartingRecording || isTranscribing || isRetryingSpeech
+        speechStartID = nil
+        speechFinalizationID = nil
+        speechRetryID = nil
         stopSpeechHeartbeat()
         stopSpeechEventConsumer()
         stopSpeechAudioLevelConsumer()
-        _ = try? await microphone.stop()
+        if let audioURL = try? await microphone.stop() {
+            try? FileManager.default.removeItem(at: audioURL)
+        }
+        microphone.discard()
 
         let session = speechSession
         speechSession = nil
         isRecording = false
         isTranscribing = false
         isStartingRecording = false
+        isRetryingSpeech = false
 
         if let session {
             await terminateSpeechSession(session)
+        }
+        if hadActiveOperation {
+            clearPreservedSpeechAudio()
         }
     }
 
     func toggleRecording() async {
         if isRecording {
+            let finalizationID = UUID()
+            speechFinalizationID = finalizationID
+            let stoppingMicrophone = microphone
             stopSpeechHeartbeat()
             stopSpeechEventConsumer()
             stopSpeechAudioLevelConsumer()
             let stopStart = ProcessInfo.processInfo.systemUptime
-            _ = try? await microphone.stop()
+            let audioURL = try? await stoppingMicrophone.stop()
+            stoppingMicrophone.discard()
+            guard speechFinalizationID == finalizationID else {
+                if let audioURL {
+                    try? FileManager.default.removeItem(at: audioURL)
+                }
+                return
+            }
             isRecording = false
             Self.logger.notice("[SpeechProfile] realtime capture stopped ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - stopStart) * 1000)), privacy: .public)")
 
-            guard let session = speechSession else {
-                Self.logger.error("[SpeechProfile] realtime stop failed: missing session")
+            isTranscribing = true
+            let prefix = recordingInputPrefix
+            let strategy = activeSpeechStrategy
+
+            if !strategy.usesRealtimeTransport {
+                guard let audioURL else {
+                    isTranscribing = false
+                    speechFinalizationID = nil
+                    speechError = L10n.t(.carTranscriptionFailed)
+                    return
+                }
+                preservedSpeechFileURL = audioURL
+                preservedSpeechStrategy = strategy
+                preservedSpeechInputPrefix = prefix
+                do {
+                    let transcript = try await state.transcribeAudio(audioFileURL: audioURL, strategy: strategy)
+                    guard speechFinalizationID == finalizationID else { return }
+                    inputText = Self.mergedSpeechInput(prefix: prefix, transcript: transcript)
+                    clearPreservedSpeechAudio()
+                } catch {
+                    guard speechFinalizationID == finalizationID else { return }
+                    Self.logger.error("[SpeechProfile] chat batch transcribe failed error=\(error.localizedDescription, privacy: .public)")
+                    speechError = error.localizedDescription
+                }
+                if speechFinalizationID == finalizationID {
+                    speechFinalizationID = nil
+                    isTranscribing = false
+                }
                 return
             }
 
-            isTranscribing = true
+            if let audioURL {
+                try? FileManager.default.removeItem(at: audioURL)
+            }
+            guard let session = speechSession else {
+                isTranscribing = false
+                speechFinalizationID = nil
+                Self.logger.error("[SpeechProfile] realtime stop failed: missing session")
+                return
+            }
             defer {
                 if speechSession === session {
                     speechSession = nil
+                    speechFinalizationID = nil
                     isTranscribing = false
                 }
             }
-            let prefix = recordingInputPrefix
             let partialTranscriptBuffer = SpeechPartialTranscriptBuffer()
             let transcribeStart = ProcessInfo.processInfo.systemUptime
             do {
                 let transcript = try await session.commitAndStop { partial in
                     partialTranscriptBuffer.update(partial)
                     Task { @MainActor in
+                        guard speechFinalizationID == finalizationID else { return }
                         inputText = Self.mergedSpeechInput(prefix: prefix, transcript: partial)
                     }
                 }
@@ -228,7 +284,8 @@ extension ChatTabView {
             // VoiceFlowMicrophone.audioLevel is tied to the microphone instance's
             // AsyncStream continuation. Recreate it per capture so repeated
             // start/stop cycles keep publishing real levels for the waveform.
-            microphone = VoiceFlowMicrophone()
+            let startingMicrophone = VoiceFlowMicrophone()
+            microphone = startingMicrophone
             let token = state.aiBuilderToken.trimmingCharacters(in: .whitespacesAndNewlines)
             if token.isEmpty {
                 speechError = L10n.t(.chatSpeechTokenMissing)
@@ -243,42 +300,88 @@ extension ChatTabView {
                 return
             }
 
+            let startID = UUID()
+            speechStartID = startID
+            isStartingRecording = true
             let permissionStart = ProcessInfo.processInfo.systemUptime
             let allowed = await Self.requestMicrophonePermissionForRecording()
             Self.logger.notice("[SpeechProfile] microphone permission allowed=\(allowed, privacy: .public) ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - permissionStart) * 1000)), privacy: .public)")
             guard allowed else {
+                guard speechStartID == startID else { return }
+                speechStartID = nil
+                isStartingRecording = false
                 speechError = L10n.t(.chatMicrophoneDenied)
                 return
             }
-            isStartingRecording = true
+            guard speechStartID == startID else { return }
             let startRecordingStart = ProcessInfo.processInfo.systemUptime
+            var startedSession: VoiceFlowSession?
             do {
+                speechRetryID = nil
                 clearPreservedSpeechAudio()
-                let session = try await state.startRealtimeSpeechSession()
+                let strategy = state.aiBuilderRecordingStrategy
                 recordingInputPrefix = inputText
-                speechSession = session
-                startSpeechEventConsumer(for: session)
+                activeSpeechStrategy = strategy
                 startSpeechAudioLevelConsumer()
 
-                try await microphone.start { chunk in
-                    Task {
-                        await session.sendAudioChunk(chunk)
+                if strategy.usesRealtimeTransport {
+                    let session = try await state.startRealtimeSpeechSession()
+                    startedSession = session
+                    guard speechStartID == startID else {
+                        await terminateSpeechSession(session)
+                        return
                     }
+                    speechSession = session
+                    startSpeechEventConsumer(for: session)
+                    try await startingMicrophone.start(strategy: strategy) { chunk in
+                        Task {
+                            await session.sendAudioChunk(chunk)
+                        }
+                    }
+                } else {
+                    speechSession = nil
+                    try await startingMicrophone.start(strategy: strategy)
+                }
+                guard speechStartID == startID else {
+                    if let audioURL = try? await startingMicrophone.stop() {
+                        try? FileManager.default.removeItem(at: audioURL)
+                    }
+                    startingMicrophone.discard()
+                    if let startedSession {
+                        await terminateSpeechSession(startedSession)
+                        if speechSession === startedSession {
+                            self.speechSession = nil
+                        }
+                    }
+                    return
+                }
+                if let startedSession {
+                    startSpeechHeartbeat(for: startedSession)
                 }
                 isRecording = true
+                speechStartID = nil
                 isStartingRecording = false
-                startSpeechHeartbeat(for: session)
-                Self.logger.notice("[SpeechProfile] realtime capture started ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startRecordingStart) * 1000)), privacy: .public)")
+                Self.logger.notice("[SpeechProfile] capture started strategy=\(strategy.rawValue, privacy: .public) ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startRecordingStart) * 1000)), privacy: .public)")
             } catch {
-                _ = try? await microphone.stop()
-                stopSpeechHeartbeat()
-                stopSpeechEventConsumer()
-                stopSpeechAudioLevelConsumer()
-                isStartingRecording = false
-                if let speechSession {
-                    await terminateSpeechSession(speechSession)
+                if let audioURL = try? await startingMicrophone.stop() {
+                    try? FileManager.default.removeItem(at: audioURL)
                 }
-                speechSession = nil
+                startingMicrophone.discard()
+                if let startedSession {
+                    await terminateSpeechSession(startedSession)
+                    if speechSession === startedSession {
+                        speechSession = nil
+                    }
+                }
+                let shouldReportError = speechStartID == startID
+                if shouldReportError {
+                    stopSpeechHeartbeat()
+                    stopSpeechEventConsumer()
+                    stopSpeechAudioLevelConsumer()
+                    speechStartID = nil
+                    isStartingRecording = false
+                }
+                guard shouldReportError else { return }
                 Self.logger.error("[SpeechProfile] realtime capture start failed error=\(error.localizedDescription, privacy: .public)")
                 speechError = error.localizedDescription
             }
@@ -286,18 +389,34 @@ extension ChatTabView {
     }
 
     func abortSpeechRecognition() async {
+        speechStartID = nil
+        speechFinalizationID = nil
+        speechRetryID = nil
         stopSpeechHeartbeat()
         stopSpeechEventConsumer()
         stopSpeechAudioLevelConsumer()
-        _ = try? await microphone.stop()
+        let audioURL = try? await microphone.stop()
 
         let session = speechSession
         let prefix = recordingInputPrefix
+        let strategy = activeSpeechStrategy
         speechSession = nil
         isRecording = false
         isTranscribing = false
         isStartingRecording = false
 
+        if !strategy.usesRealtimeTransport {
+            if let audioURL {
+                clearPreservedSpeechAudio()
+                preservedSpeechFileURL = audioURL
+                preservedSpeechStrategy = strategy
+                preservedSpeechInputPrefix = prefix
+            }
+            return
+        }
+        if let audioURL {
+            try? FileManager.default.removeItem(at: audioURL)
+        }
         guard let session else { return }
         do {
             if let preserved = try await session.abortPreservingAudio() {
@@ -313,20 +432,40 @@ extension ChatTabView {
     }
 
     func retryPreservedSpeechAudio() async {
-        guard let preserved = preservedSpeechAudio else { return }
+        guard preservedSpeechAudio != nil || preservedSpeechFileURL != nil else { return }
+        let retryID = UUID()
+        speechRetryID = retryID
         isRetryingSpeech = true
-        defer { isRetryingSpeech = false }
+        defer {
+            if speechRetryID == retryID {
+                speechRetryID = nil
+                isRetryingSpeech = false
+            }
+        }
 
         let prefix = preservedSpeechInputPrefix
         do {
-            let transcript = try await state.transcribePreservedAudio(preserved) { partial in
-                Task { @MainActor in
-                    inputText = Self.mergedSpeechInput(prefix: prefix, transcript: partial)
+            let transcript: String
+            if let audioURL = preservedSpeechFileURL {
+                transcript = try await state.transcribeAudio(
+                    audioFileURL: audioURL,
+                    strategy: preservedSpeechStrategy
+                )
+            } else if let preserved = preservedSpeechAudio {
+                transcript = try await state.transcribePreservedAudio(preserved) { partial in
+                    Task { @MainActor in
+                        guard speechRetryID == retryID else { return }
+                        inputText = Self.mergedSpeechInput(prefix: prefix, transcript: partial)
+                    }
                 }
+            } else {
+                return
             }
+            guard speechRetryID == retryID else { return }
             inputText = Self.mergedSpeechInput(prefix: prefix, transcript: transcript)
             clearPreservedSpeechAudio()
         } catch {
+            guard speechRetryID == retryID else { return }
             Self.logger.error("[SpeechProfile] preserved speech retry failed error=\(error.localizedDescription, privacy: .public)")
             speechError = error.localizedDescription
         }
@@ -337,6 +476,11 @@ extension ChatTabView {
             state.discardPreservedAudio(preservedSpeechAudio)
         }
         preservedSpeechAudio = nil
+        if let preservedSpeechFileURL {
+            try? FileManager.default.removeItem(at: preservedSpeechFileURL)
+        }
+        preservedSpeechFileURL = nil
+        preservedSpeechStrategy = .openAIRealtime
         preservedSpeechInputPrefix = ""
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -63,11 +63,17 @@ struct ChatTabView: View {
     @State private var renameText = ""
     @State var microphone = VoiceFlowMicrophone()
     @State var speechSession: VoiceFlowSession?
+    @State var speechStartID: UUID?
+    @State var activeSpeechStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
+    @State var speechFinalizationID: UUID?
+    @State var speechRetryID: UUID?
     @State var speechHeartbeatTask: Task<Void, Never>?
     @State var speechEventTask: Task<Void, Never>?
     @State var recordingInputPrefix = ""
     @State var preservedSpeechInputPrefix = ""
     @State var preservedSpeechAudio: VoiceFlowPreservedAudio?
+    @State var preservedSpeechFileURL: URL?
+    @State var preservedSpeechStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
     @State var isRecording = false
     @State var isStartingRecording = false
     @State var isTranscribing = false
@@ -102,7 +108,7 @@ struct ChatTabView: View {
     }
 
     private var hasPreservedSpeechAudioForUI: Bool {
-        preservedSpeechAudio != nil || Self.hasUITestF3RetryFixture
+        preservedSpeechAudio != nil || preservedSpeechFileURL != nil || Self.hasUITestF3RetryFixture
     }
 
     private var composerPlaceholderText: String {
@@ -866,6 +872,9 @@ struct ChatTabView: View {
             }
             .onChange(of: scenePhase) { _, newPhase in
                 guard newPhase == .background else { return }
+                Task { await stopSpeechForBackground() }
+            }
+            .onDisappear {
                 Task { await stopSpeechForBackground() }
             }
         }

--- a/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import VoiceFlowKit
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -170,6 +171,13 @@ struct SettingsTabView: View {
                 clientCapabilitiesSection
 
                 Section(L10n.t(.settingsSpeechRecognition)) {
+                    Picker(L10n.t(.settingsRecordingStrategy), selection: $state.aiBuilderRecordingStrategy) {
+                        Text(L10n.t(.settingsOpenAIRealtime)).tag(VoiceFlowRecordingStrategy.openAIRealtime)
+                        Text(L10n.t(.settingsGrokBatch)).tag(VoiceFlowRecordingStrategy.grokBatch)
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityIdentifier("settings-recording-strategy")
+
                     TextField(L10n.t(.settingsAiBuilderBaseURL), text: $state.aiBuilderBaseURL)
                         .textContentType(.URL)
                         .autocapitalization(.none)
@@ -177,8 +185,10 @@ struct SettingsTabView: View {
                     SecureField(L10n.t(.settingsAiBuilderToken), text: $state.aiBuilderToken)
                         .textContentType(.password)
 
-                    TextField(L10n.t(.settingsCustomPrompt), text: $state.aiBuilderCustomPrompt, axis: .vertical)
-                        .lineLimit(3...6)
+                    if state.aiBuilderRecordingStrategy == .openAIRealtime {
+                        TextField(L10n.t(.settingsCustomPrompt), text: $state.aiBuilderCustomPrompt, axis: .vertical)
+                            .lineLimit(3...6)
+                    }
 
                     TextField(L10n.t(.settingsTerminology), text: $state.aiBuilderTerminology)
                         .textContentType(.none)

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1381,6 +1381,23 @@ struct SpeechRecognitionDefaultsTests {
         UserDefaults.standard.removeObject(forKey: "aiBuilderCustomPrompt")
         UserDefaults.standard.removeObject(forKey: "aiBuilderTerminology")
     }
+
+    @Test @MainActor func recordingStrategyPersistsAndDefaultsToRealtime() async {
+        UserDefaults.standard.removeObject(forKey: AppState.aiBuilderRecordingStrategyKey)
+        let defaultState = AppState()
+        #expect(defaultState.aiBuilderRecordingStrategy == .openAIRealtime)
+
+        defaultState.aiBuilderRecordingStrategy = .grokBatch
+        let restoredState = AppState()
+        #expect(restoredState.aiBuilderRecordingStrategy == .grokBatch)
+
+        UserDefaults.standard.removeObject(forKey: AppState.aiBuilderRecordingStrategyKey)
+    }
+
+    @Test func onlyOpenAIRecordingUsesRealtimeTransport() {
+        #expect(VoiceFlowRecordingStrategy.openAIRealtime.usesRealtimeTransport)
+        #expect(!VoiceFlowRecordingStrategy.grokBatch.usesRealtimeTransport)
+    }
 }
 
 struct ChatComposerSpeechTests {

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -2084,6 +2084,12 @@ struct ModelPresetShortNameTests {
 
         #expect(terra.shortName == "GPT-TF")
     }
+
+    @Test func grok45ShortName() {
+        let preset = ModelPreset(displayName: "Grok 4.5", providerID: "xai", modelID: "grok-4.5")
+        #expect(preset.shortName == "Grok")
+    }
+
     @Test func unknownModelFallsBackToDisplayName() {
         let preset = ModelPreset(displayName: "Custom Model", providerID: "custom", modelID: "custom-1")
         #expect(preset.shortName == "Custom Model")
@@ -2237,6 +2243,10 @@ struct ModelSelectionPersistenceTests {
             }))
             #expect(state.modelPresets.contains(where: {
                 $0.id == "openai/gpt-5.6-terra-fast" && $0.displayName == "GPT-5.6 Terra Fast"
+            }))
+            #expect(state.modelPresets.last?.id == "xai/grok-4.5")
+            #expect(state.modelPresets.contains(where: {
+                $0.id == "xai/grok-4.5" && $0.displayName == "Grok 4.5"
             }))
         }
     }

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,14 +4,19 @@
 
 ## 当前状态
 
-- **最后更新**：2026-07-29
+- **最后更新**：2026-07-30
 - **分支**：`feat/dual-recording-strategies`
-- **编译/测试**：iPhone 16 / iOS 18.4 build 通过；双策略定向测试与 Tool Cards UI 隔离复跑通过
-- **Phase**：OpenAI Realtime / Grok Batch 双录音策略待真机验收
+- **编译/测试**：iPhone 16 build 通过；OpenCodeClientTests 中 speech/strategy 相关测试通过；已知无关失败：`LayoutConstantsTests.splitViewFractions`、`CarModeFlowTests.carSessionContextSeparatesHostsAndWorkspaces`
+- **Phase**：OpenAI Realtime / Grok Batch 双录音策略 + VoiceFlowKit exact `0.3.0`
+
+### 2026-07-30 — Pin VoiceFlowKit 0.3.0
+
+- SPM 依赖从 bare revision 改为 exact SemVer `0.3.0`（`Package.resolved` 对应 merge commit `71b9fe6`）。
+- iPhone 16 simulator build 通过；`SpeechRecognitionDefaultsTests` / `VoiceFlowKitIntegrationTests` / chat speech tests 通过。
 
 ### 2026-07-29 — OpenAI Realtime / Grok Batch 双录音策略
 
-- VoiceFlowKit pin 更新到 `4a04d562965fe041b552570759ef6e419ab3b2d6`；Settings 持久化 `OpenAI Realtime` / `Grok Batch`，Grok 模式隐藏 OpenAI-only prompt 但保留其值。
+- VoiceFlowKit pin 初值为 `4a04d562965fe041b552570759ef6e419ab3b2d6`；后续改为 exact `0.3.0`。Settings 持久化 `OpenAI Realtime` / `Grok Batch`，Grok 模式隐藏 OpenAI-only prompt 但保留其值。
 - Chat 与 Car 在 Start 时 snapshot strategy。OpenAI 维持 realtime session、PCM stream、heartbeat 与 recovery；Grok 只启动 AAC-LC M4A 本地录音，录音期不创建 ticket、WebSocket 或 heartbeat，Stop 后单次上传。
 - Chat preserved-audio 与 Car failed-state retry 都保存录音产生时的 strategy；录音后修改 Settings 不会重新解释旧文件。离开活跃录音页面、进入后台或取消 finalization 时会使 in-flight Start/finalization/retry generation 失效，阻止延迟 permission/session/microphone 或 transcript callback 恢复隐藏录音和写回旧结果，并清理临时文件与 realtime session。
 - VoiceFlowKit 同步修复 AAC/WAV finalize error 的 writer、buffer、临时文件与 audio session cleanup；package tests 12 个通过。

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,10 +4,18 @@
 
 ## 当前状态
 
-- **最后更新**：2026-07-24
-- **分支**：`feat/message-text-selection`
-- **编译/测试**：iPhone 16 / iOS 18.4 build 与全量 test suite 通过；36 个 UI tests 中 4 个 opt-in tests 按预期 skip
-- **Phase**：`opencode://session/<id>` cold/warm launch 与 Chat Markdown navigation implemented
+- **最后更新**：2026-07-29
+- **分支**：`feat/dual-recording-strategies`
+- **编译/测试**：iPhone 16 / iOS 18.4 build 通过；双策略定向测试与 Tool Cards UI 隔离复跑通过
+- **Phase**：OpenAI Realtime / Grok Batch 双录音策略待真机验收
+
+### 2026-07-29 — OpenAI Realtime / Grok Batch 双录音策略
+
+- VoiceFlowKit pin 更新到 `4a04d562965fe041b552570759ef6e419ab3b2d6`；Settings 持久化 `OpenAI Realtime` / `Grok Batch`，Grok 模式隐藏 OpenAI-only prompt 但保留其值。
+- Chat 与 Car 在 Start 时 snapshot strategy。OpenAI 维持 realtime session、PCM stream、heartbeat 与 recovery；Grok 只启动 AAC-LC M4A 本地录音，录音期不创建 ticket、WebSocket 或 heartbeat，Stop 后单次上传。
+- Chat preserved-audio 与 Car failed-state retry 都保存录音产生时的 strategy；录音后修改 Settings 不会重新解释旧文件。离开活跃录音页面、进入后台或取消 finalization 时会使 in-flight Start/finalization/retry generation 失效，阻止延迟 permission/session/microphone 或 transcript callback 恢复隐藏录音和写回旧结果，并清理临时文件与 realtime session。
+- VoiceFlowKit 同步修复 AAC/WAV finalize error 的 writer、buffer、临时文件与 audio session cleanup；package tests 12 个通过。
+- 验证：iPhone 16 / iOS 18.4 build 通过；新增 strategy persistence/transport contract 与 VoiceFlowKit integration 共 6 个定向测试通过；Tool Cards UI 隔离复跑通过。全量 suite 的 voice 相关测试通过，但仍报告既有 `LayoutConstantsTests.splitViewFractions` 精确 `CGFloat` 比较失败；同轮 Tool Cards fixture 首跑失败、隔离复跑通过。
 
 ### 2026-07-24 — Chat 跨 Markdown block 文本选择
 


### PR DESCRIPTION
## Summary
- Settings / Chat / Car Mode support **OpenAI Realtime** and **Grok Batch** recording strategies.
- Pin VoiceFlowKit to exact SemVer **`0.3.0`** (was bare revision).
- `Package.resolved` records `0.3.0` @ `71b9fe6`.

## Test plan
- [x] `xcodebuild build` iPhone 16 simulator
- [x] speech/strategy suites pass (`SpeechRecognitionDefaultsTests`, `VoiceFlowKitIntegrationTests`, chat speech)
- [x] Known unrelated failures only: `LayoutConstantsTests.splitViewFractions`, `CarModeFlowTests.carSessionContextSeparatesHostsAndWorkspaces`