### PR TITLE
Add GPT Live speech recognition

### DIFF
--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
@@ -645,7 +645,7 @@
 			repositoryURL = "https://github.com/grapeot/voiceflow.git";
 			requirement = {
 				kind = revision;
-				revision = 2be5dfa2925c451102aa9797bd35be757c9205bf;
+				revision = 1f4859913773020504d6fe237168b32a8e4eaa5d;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.pbxproj
@@ -644,8 +644,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/grapeot/voiceflow.git";
 			requirement = {
-				kind = exactVersion;
-				version = 0.3.0;
+				kind = revision;
+				revision = 2be5dfa2925c451102aa9797bd35be757c9205bf;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,8 +123,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grapeot/voiceflow.git",
       "state" : {
-        "revision" : "71b9fe6c8a2d4ff98bb1d349512f704c7cec44ed",
-        "version" : "0.3.0"
+        "revision" : "2be5dfa2925c451102aa9797bd35be757c9205bf"
       }
     }
   ],

--- a/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,7 +123,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grapeot/voiceflow.git",
       "state" : {
-        "revision" : "2be5dfa2925c451102aa9797bd35be757c9205bf"
+        "revision" : "1f4859913773020504d6fe237168b32a8e4eaa5d"
       }
     }
   ],

--- a/OpenCodeClient/OpenCodeClient/AppState+VoiceFlowKit.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+VoiceFlowKit.swift
@@ -2,8 +2,9 @@ import Foundation
 import os
 import VoiceFlowKit
 
-extension VoiceFlowRecordingStrategy {
-    var usesRealtimeTransport: Bool { self == .openAIRealtime }
+enum SpeechSurface: String {
+    case chat
+    case car
 }
 
 /// VoiceFlowKit speech recognition integration. Wraps the kit's
@@ -42,12 +43,12 @@ extension AppState {
 
     func transcribeAudio(
         audioFileURL: URL,
-        strategy: VoiceFlowRecordingStrategy = .openAIRealtime,
+        strategy: VoiceFlowRecordingStrategy,
+        surface: SpeechSurface,
         onPartialTranscript: (@Sendable (String) -> Void)? = nil
     ) async throws -> String {
         let start = ProcessInfo.processInfo.systemUptime
-        let fileName = audioFileURL.lastPathComponent.isEmpty ? "audio.m4a" : audioFileURL.lastPathComponent
-        Self.logger.notice("[SpeechProfile] appState.transcribe begin file=\(fileName, privacy: .public)")
+        Self.logger.notice("[SpeechProfile] surface=\(surface.rawValue, privacy: .public) strategy=\(strategy.rawValue, privacy: .public) phase=transcribe outcome=started")
         do {
             let client = try makeVoiceFlowClient()
             let result = try await client.transcribe(
@@ -56,48 +57,59 @@ extension AppState {
                 onPartialTranscript: onPartialTranscript
             )
             let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
-            Self.logger.notice("[SpeechProfile] appState.transcribe done ms=\(elapsedMs, privacy: .public) textChars=\(result.text.count, privacy: .public) requestID=\(result.requestID, privacy: .public)")
+            Self.logger.notice("[SpeechProfile] surface=\(surface.rawValue, privacy: .public) strategy=\(strategy.rawValue, privacy: .public) phase=transcribe outcome=succeeded ms=\(elapsedMs, privacy: .public)")
             return result.text
         } catch {
             let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
-            Self.logger.error("[SpeechProfile] appState.transcribe failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            Self.logger.error("[SpeechProfile] surface=\(surface.rawValue, privacy: .public) strategy=\(strategy.rawValue, privacy: .public) phase=transcribe outcome=failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             throw error
         }
     }
 
-    func startRealtimeSpeechSession() async throws -> VoiceFlowSession {
+    func startRealtimeSpeechSession(
+        strategy: VoiceFlowRecordingStrategy,
+        surface: SpeechSurface
+    ) async throws -> VoiceFlowSession {
         let start = ProcessInfo.processInfo.systemUptime
-        Self.logger.notice("[SpeechProfile] appState.realtime start begin")
+        Self.logger.notice("[SpeechProfile] surface=\(surface.rawValue, privacy: .public) strategy=\(strategy.rawValue, privacy: .public) phase=start outcome=started")
         do {
             let client = try makeVoiceFlowClient()
-            let session = try await client.startSession()
+            let session = try await client.startSession(strategy: strategy)
             let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
-            Self.logger.notice("[SpeechProfile] appState.realtime start done ms=\(elapsedMs, privacy: .public)")
+            Self.logger.notice("[SpeechProfile] surface=\(surface.rawValue, privacy: .public) strategy=\(strategy.rawValue, privacy: .public) phase=start outcome=succeeded ms=\(elapsedMs, privacy: .public)")
             return session
         } catch {
             let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
-            Self.logger.error("[SpeechProfile] appState.realtime start failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            Self.logger.error("[SpeechProfile] surface=\(surface.rawValue, privacy: .public) strategy=\(strategy.rawValue, privacy: .public) phase=start outcome=failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             throw error
         }
     }
 
     func transcribePreservedAudio(
         _ preservedAudio: VoiceFlowPreservedAudio,
+        surface: SpeechSurface,
         onPartialTranscript: (@Sendable (String) -> Void)? = nil
     ) async throws -> String {
-        let client = try makeVoiceFlowClient()
-        let result = try await client.transcribe(preservedAudio: preservedAudio, onPartialTranscript: onPartialTranscript)
-        return result.text
+        let strategy = preservedAudio.strategy
+        let start = ProcessInfo.processInfo.systemUptime
+        Self.logger.notice("[SpeechProfile] surface=\(surface.rawValue, privacy: .public) strategy=\(strategy.rawValue, privacy: .public) phase=retry outcome=started")
+        do {
+            let client = try makeVoiceFlowClient()
+            let result = try await client.transcribe(preservedAudio: preservedAudio, onPartialTranscript: onPartialTranscript)
+            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
+            Self.logger.notice("[SpeechProfile] surface=\(surface.rawValue, privacy: .public) strategy=\(strategy.rawValue, privacy: .public) phase=retry outcome=succeeded ms=\(elapsedMs, privacy: .public)")
+            return result.text
+        } catch {
+            let elapsedMs = max(0, Int((ProcessInfo.processInfo.systemUptime - start) * 1000))
+            Self.logger.error("[SpeechProfile] surface=\(surface.rawValue, privacy: .public) strategy=\(strategy.rawValue, privacy: .public) phase=retry outcome=failed ms=\(elapsedMs, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            throw error
+        }
     }
 
     func discardPreservedAudio(_ preservedAudio: VoiceFlowPreservedAudio) {
         Task {
-            do {
-                let client = try makeVoiceFlowClient()
-                await client.discardPreservedAudio(preservedAudio)
-            } catch {
-                Self.logger.error("[SpeechProfile] discard preserved audio failed error=\(error.localizedDescription, privacy: .public)")
-            }
+            let client = VoiceFlowClient(config: VoiceFlowConfig(tokenProvider: { "" }))
+            await client.discardPreservedAudio(preservedAudio)
         }
     }
 

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -228,7 +228,7 @@ final class AppState {
         _aiBuilderTerminology = UserDefaults.standard.string(forKey: Self.aiBuilderTerminologyKey) ?? Self.defaultAIBuilderTerminology
         _aiBuilderRecordingStrategy = VoiceFlowRecordingStrategy(
             rawValue: UserDefaults.standard.string(forKey: Self.aiBuilderRecordingStrategyKey) ?? ""
-        ) ?? .openAIRealtime
+        ) ?? .gptLiveTranscribe
         _selectedProjectWorktree = UserDefaults.standard.string(forKey: Self.selectedProjectWorktreeKey)
         _customProjectPath = UserDefaults.standard.string(forKey: Self.customProjectPathKey) ?? ""
         _languagePreference = L10n.languagePreference
@@ -347,7 +347,7 @@ final class AppState {
         }
     }
 
-    var _aiBuilderRecordingStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
+    var _aiBuilderRecordingStrategy: VoiceFlowRecordingStrategy = .gptLiveTranscribe
     var aiBuilderRecordingStrategy: VoiceFlowRecordingStrategy {
         get { _aiBuilderRecordingStrategy }
         set {

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -103,6 +103,7 @@ enum L10n {
         case settingsSpeechRecognition
         case settingsRecordingStrategy
         case settingsOpenAIRealtime
+        case settingsGPTLiveTranscribe
         case settingsGrokBatch
         case settingsStrategyHelp
         case settingsStrategyDialogTitle
@@ -113,6 +114,7 @@ enum L10n {
         case settingsTerminology
         case settingsTesting
         case settingsTested
+        case settingsTestConnectionScope
         case settingsAbout
         case settingsServerVersion
         case settingsExperimentalFeatures
@@ -560,16 +562,18 @@ enum L10n {
         Key.settingsSpeechRecognition.rawValue: "Speech Recognition",
         Key.settingsRecordingStrategy.rawValue: "Recording Strategy",
         Key.settingsOpenAIRealtime.rawValue: "GPT Realtime",
+        Key.settingsGPTLiveTranscribe.rawValue: "GPT Live Transcribe",
         Key.settingsGrokBatch.rawValue: "Grok STT",
         Key.settingsStrategyHelp.rawValue: "Which one should I choose?",
         Key.settingsStrategyDialogTitle.rawValue: "Which one should I choose?",
-        Key.settingsStrategyDialogBody.rawValue: "GPT Realtime — better formatting, punctuation, and accuracy. Shows a live transcript while you speak.\n\nGrok STT — about 10x cheaper, slightly lower accuracy, no live transcript. Records locally and uploads after Stop.\n\nRecommendation: For content a human will read (notes, messages, articles), prefer GPT Realtime. For content an AI agent will process (commands, prompts, logs), Grok STT is usually good enough — AI tolerates typos and messy formatting far better than people do.",
+        Key.settingsStrategyDialogBody.rawValue: "GPT Realtime — conversational realtime transcription with strong formatting and punctuation.\n\nGPT Live Transcribe — dedicated live transcription over the same realtime transport.\n\nGrok STT — lower-cost batch transcription. Records locally and uploads after Stop.",
         Key.settingsAiBuilderBaseURL.rawValue: "AI Builder Base URL",
         Key.settingsAiBuilderToken.rawValue: "AI Builder Token",
         Key.settingsCustomPrompt.rawValue: "Custom Prompt",
         Key.settingsTerminology.rawValue: "Terminology (comma-separated)",
         Key.settingsTesting.rawValue: "Testing...",
         Key.settingsTested.rawValue: "OK",
+        Key.settingsTestConnectionScope.rawValue: "Test Connection checks endpoint and token access only. It does not validate the selected transcription strategy.",
         Key.settingsAbout.rawValue: "About",
         Key.settingsServerVersion.rawValue: "Server Version",
         Key.settingsExperimentalFeatures.rawValue: "Experimental Features",
@@ -1016,16 +1020,18 @@ enum L10n {
         Key.settingsSpeechRecognition.rawValue: "语音识别",
         Key.settingsRecordingStrategy.rawValue: "录音策略",
         Key.settingsOpenAIRealtime.rawValue: "GPT Realtime",
+        Key.settingsGPTLiveTranscribe.rawValue: "GPT Live Transcribe",
         Key.settingsGrokBatch.rawValue: "Grok STT",
         Key.settingsStrategyHelp.rawValue: "我该选哪个？",
         Key.settingsStrategyDialogTitle.rawValue: "我该选哪个？",
-        Key.settingsStrategyDialogBody.rawValue: "GPT Realtime——排版、标点和准确率更好，说话时能看到实时字幕。\n\nGrok STT——价格约为前者的 1/10，准确率略低，无实时字幕；本地录音，停止后上传。\n\n建议：给人看的内容（笔记、消息、文章）用 GPT Realtime；给 AI 处理的内容（指令、prompt、日志）用 Grok STT 就够——AI 对错别字和排版的包容度比人高得多。",
+        Key.settingsStrategyDialogBody.rawValue: "GPT Realtime：对话式实时转写，排版和标点能力较强。\n\nGPT Live Transcribe：使用同一实时传输链路的专用实时转写。\n\nGrok STT：成本较低的批量转写；本地录音，停止后上传。",
         Key.settingsAiBuilderBaseURL.rawValue: "AI Builder 服务地址",
         Key.settingsAiBuilderToken.rawValue: "AI Builder 访问令牌",
         Key.settingsCustomPrompt.rawValue: "自定义提示词",
         Key.settingsTerminology.rawValue: "术语（逗号分隔）",
         Key.settingsTesting.rawValue: "测试中...",
         Key.settingsTested.rawValue: "可用",
+        Key.settingsTestConnectionScope.rawValue: "测试连接只检查服务地址和令牌是否可用，不验证当前选择的转写策略。",
         Key.settingsAbout.rawValue: "关于",
         Key.settingsServerVersion.rawValue: "服务器版本",
         Key.settingsExperimentalFeatures.rawValue: "实验性功能",

--- a/OpenCodeClient/OpenCodeClient/Utils/ChatSpeechRouting.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/ChatSpeechRouting.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+nonisolated enum SpeechAttemptGate {
+    static func owns(_ attemptID: UUID, activeAttemptID: UUID?) -> Bool {
+        attemptID == activeAttemptID
+    }
+
+    static func accepts(
+        _ attemptID: UUID,
+        activeAttemptID: UUID?,
+        originatingSessionID: String?,
+        currentSessionID: String?
+    ) -> Bool {
+        owns(attemptID, activeAttemptID: activeAttemptID)
+            && originatingSessionID == currentSessionID
+    }
+}
+
+struct ChatSpeechDraftRoute: Equatable {
+    let sourceSessionID: String?
+    let sourceDraftText: String
+    let currentComposerText: String?
+}
+
+enum ChatSpeechNavigationDisposition: Equatable {
+    case detachFinalization
+    case cancelAndPreserve
+}
+
+nonisolated enum ChatSpeechRouting {
+    static func mergedInput(prefix: String, transcript: String) -> String {
+        let cleanedTranscript = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedTranscript.isEmpty else { return prefix }
+        guard !prefix.isEmpty else { return cleanedTranscript }
+        return prefix + " " + cleanedTranscript
+    }
+
+    static func draftRoute(
+        prefix: String,
+        transcript: String,
+        sourceSessionID: String?,
+        currentSessionID: String?
+    ) -> ChatSpeechDraftRoute {
+        let text = mergedInput(prefix: prefix, transcript: transcript)
+        return ChatSpeechDraftRoute(
+            sourceSessionID: sourceSessionID,
+            sourceDraftText: text,
+            currentComposerText: sourceSessionID == currentSessionID ? text : nil
+        )
+    }
+
+    static func navigationDisposition(
+        detachFinalizationOnSessionSwitch: Bool,
+        finalizationID: UUID?,
+        sourceSessionID: String?,
+        currentSessionID: String?
+    ) -> ChatSpeechNavigationDisposition {
+        if detachFinalizationOnSessionSwitch,
+           finalizationID != nil,
+           sourceSessionID != currentSessionID {
+            return .detachFinalization
+        }
+        return .cancelAndPreserve
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/Utils/OrderedSpeechAudioSender.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/OrderedSpeechAudioSender.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+nonisolated final class OrderedSpeechAudioSender: @unchecked Sendable {
+    private let condition = NSCondition()
+    private let capacity: Int
+    private let sendChunk: @Sendable (Data) async -> Void
+    private var queue: [Data] = []
+    private var acceptsChunks = true
+    private var workWaiter: CheckedContinuation<Void, Never>?
+    private var worker: Task<Void, Never>?
+    private var observedMaximum = 0
+
+    init(
+        capacity: Int = 32,
+        sendChunk: @escaping @Sendable (Data) async -> Void
+    ) {
+        precondition(capacity > 0)
+        self.capacity = capacity
+        self.sendChunk = sendChunk
+        worker = Task { [weak self] in
+            await self?.run()
+        }
+    }
+
+    @discardableResult
+    func enqueue(_ chunk: Data) -> Bool {
+        condition.lock()
+        while acceptsChunks, queue.count >= capacity {
+            condition.wait()
+        }
+        guard acceptsChunks else {
+            condition.unlock()
+            return false
+        }
+        queue.append(chunk)
+        observedMaximum = max(observedMaximum, queue.count)
+        let waiter = workWaiter
+        workWaiter = nil
+        condition.unlock()
+        waiter?.resume()
+        return true
+    }
+
+    func finishAndDrain() async {
+        let waiter = stopAccepting()
+        waiter?.resume()
+        if let worker {
+            await worker.value
+        }
+    }
+
+    var maximumBufferedCount: Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return observedMaximum
+    }
+
+    private func run() async {
+        while let chunk = await nextChunk() {
+            await sendChunk(chunk)
+        }
+    }
+
+    private func nextChunk() async -> Data? {
+        while true {
+            switch dequeue() {
+            case .chunk(let chunk):
+                return chunk
+            case .finished:
+                return nil
+            case .wait:
+                await withCheckedContinuation { continuation in
+                    registerWaiter(continuation)
+                }
+            }
+        }
+    }
+
+    private enum DequeueResult {
+        case chunk(Data)
+        case finished
+        case wait
+    }
+
+    private func stopAccepting() -> CheckedContinuation<Void, Never>? {
+        condition.lock()
+        defer { condition.unlock() }
+        acceptsChunks = false
+        let waiter = workWaiter
+        workWaiter = nil
+        condition.broadcast()
+        return waiter
+    }
+
+    private func dequeue() -> DequeueResult {
+        condition.lock()
+        defer { condition.unlock() }
+        if !queue.isEmpty {
+            let chunk = queue.removeFirst()
+            condition.broadcast()
+            return .chunk(chunk)
+        }
+        return acceptsChunks ? .wait : .finished
+    }
+
+    private func registerWaiter(_ continuation: CheckedContinuation<Void, Never>) {
+        condition.lock()
+        if !queue.isEmpty || !acceptsChunks {
+            condition.unlock()
+            continuation.resume()
+        } else {
+            workWaiter = continuation
+            condition.unlock()
+        }
+    }
+}

--- a/OpenCodeClient/OpenCodeClient/Views/Car/CarModeView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Car/CarModeView.swift
@@ -2,14 +2,45 @@ import SwiftUI
 import os
 import VoiceFlowKit
 
+enum PendingCarAudio {
+    case file(URL, strategy: VoiceFlowRecordingStrategy)
+    case preserved(VoiceFlowPreservedAudio)
+
+    var strategy: VoiceFlowRecordingStrategy {
+        switch self {
+        case .file(_, let strategy): strategy
+        case .preserved(let audio): audio.strategy
+        }
+    }
+}
+
+private enum CarFailureRetry {
+    case transcription
+    case request
+}
+
+enum CarSpeechAttemptGate {
+    static func accepts(
+        _ attemptID: UUID,
+        activeAttemptID: UUID?,
+        generation: UUID,
+        currentGeneration: UUID
+    ) -> Bool {
+        attemptID == activeAttemptID && generation == currentGeneration
+    }
+}
+
 struct CarModeView: View {
     @Bindable var state: AppState
     @State private var microphone = VoiceFlowMicrophone()
     @State private var speechSession: VoiceFlowSession?
+    @State private var audioSender: OrderedSpeechAudioSender?
+    @State private var speechGeneration = UUID()
     @State private var recordingStartID: UUID?
+    @State private var activeRecordingGeneration: UUID?
     @State private var activeRecordingStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
-    @State private var pendingRecordingURL: URL?
-    @State private var pendingRecordingStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
+    @State private var pendingAudio: PendingCarAudio?
+    @State private var failureRetry: CarFailureRetry?
     @State private var heartbeatTask: Task<Void, Never>?
     @State private var audioLevelTask: Task<Void, Never>?
     @State private var audioLevel: Float = 0
@@ -95,7 +126,7 @@ struct CarModeView: View {
             }
             .confirmationDialog(L10n.t(.carNewSessionPrompt), isPresented: $showNewSessionConfirmation) {
                 Button(L10n.t(.carNewSession), role: .destructive) {
-                    Task { await state.startNewCarSession() }
+                    Task { await startNewCarSession() }
                 }
                 Button(L10n.t(.commonCancel), role: .cancel) {}
             }
@@ -236,19 +267,87 @@ struct CarModeView: View {
         }
     }
 
+    private func finishAudioSender() async {
+        let sender = audioSender
+        audioSender = nil
+        await sender?.finishAndDrain()
+    }
+
+    private func replacePendingAudio(_ audio: PendingCarAudio) {
+        discardPendingRecording()
+        pendingAudio = audio
+    }
+
+    private func startNewCarSession() async {
+        speechGeneration = UUID()
+        await cancelLocalCarSpeech(preserveAudio: false)
+        await state.startNewCarSession()
+    }
+
+    private func cancelLocalCarSpeech(preserveAudio: Bool) async {
+        let strategy = activeRecordingStrategy
+        let hadLocalSpeech = isStartingRecording
+            || speechSession != nil
+            || state.carPhase == .recording
+            || state.carPhase == .finalizing
+        recordingStartID = nil
+        speechFinalizationID = nil
+        isStartingRecording = false
+        stopHeartbeat()
+        stopAudioLevelConsumer()
+        let audioURL = try? await microphone.stop()
+        microphone.discard()
+        await finishAudioSender()
+
+        let session = speechSession
+        speechSession = nil
+        activeRecordingGeneration = nil
+
+        if preserveAudio, hadLocalSpeech {
+            if strategy.usesRealtimeTransport {
+                if let audioURL { try? FileManager.default.removeItem(at: audioURL) }
+                if let session, let preserved = await preserve(session) {
+                    replacePendingAudio(.preserved(preserved))
+                }
+            } else if let audioURL {
+                replacePendingAudio(.file(audioURL, strategy: strategy))
+            }
+        } else {
+            if let audioURL { try? FileManager.default.removeItem(at: audioURL) }
+            if let session { await terminate(session) }
+            if !preserveAudio { discardPendingRecording() }
+        }
+
+        await state.cancelCarInteraction()
+        if preserveAudio, pendingAudio != nil {
+            failureRetry = .transcription
+            state.carPhase = .failed
+        } else {
+            failureRetry = nil
+        }
+    }
+
     private func handlePrimaryAction() async {
         switch displayPhase {
         case .recording:
             await stopRecordingAndSubmit()
         case .finalizing, .waitingReply, .speaking:
-            speechFinalizationID = nil
-            discardPendingRecording()
-            await state.cancelCarInteraction()
+            await cancelLocalCarSpeech(preserveAudio: true)
         case .failed:
-            if pendingRecordingURL != nil {
-                await retryPendingRecording()
-            } else {
+            switch failureRetry {
+            case .transcription:
+                if pendingAudio != nil {
+                    await retryPendingRecording()
+                } else {
+                    await startRecording()
+                }
+            case .request:
                 await state.submitCarTurn(state.carLastTranscript)
+                if state.carPhase != .failed {
+                    failureRetry = nil
+                }
+            case nil:
+                await startRecording()
             }
         case .idle, .awaitingConfirmation:
             await startRecording()
@@ -268,52 +367,92 @@ struct CarModeView: View {
             state.carPhase = .failed
             return
         }
+        let strategy = state.aiBuilderRecordingStrategy
+        let generation = speechGeneration
         let startID = UUID()
         recordingStartID = startID
+        activeRecordingGeneration = generation
         isStartingRecording = true
         guard await ChatTabView.requestMicrophonePermissionForRecording() else {
-            guard recordingStartID == startID else { return }
+            guard CarSpeechAttemptGate.accepts(
+                startID,
+                activeAttemptID: recordingStartID,
+                generation: generation,
+                currentGeneration: speechGeneration
+            ) else { return }
             recordingStartID = nil
+            activeRecordingGeneration = nil
             isStartingRecording = false
             state.carError = L10n.t(.chatMicrophoneDenied)
             state.carPhase = .failed
             return
         }
 
-        guard recordingStartID == startID else { return }
+        guard CarSpeechAttemptGate.accepts(
+            startID,
+            activeAttemptID: recordingStartID,
+            generation: generation,
+            currentGeneration: speechGeneration
+        ) else { return }
         speechFinalizationID = nil
         discardPendingRecording()
+        failureRetry = nil
         state.carSpeechOutput.stop()
         let startingMicrophone = VoiceFlowMicrophone()
         microphone = startingMicrophone
         var startedSession: VoiceFlowSession?
         do {
-            let strategy = state.aiBuilderRecordingStrategy
             activeRecordingStrategy = strategy
             if strategy.usesRealtimeTransport {
-                let session = try await state.startRealtimeSpeechSession()
+                let session = try await state.startRealtimeSpeechSession(strategy: strategy, surface: .car)
                 startedSession = session
-                guard recordingStartID == startID else {
+                guard CarSpeechAttemptGate.accepts(
+                    startID,
+                    activeAttemptID: recordingStartID,
+                    generation: generation,
+                    currentGeneration: speechGeneration
+                ) else {
                     await terminate(session)
                     return
                 }
                 speechSession = session
+                let sender = OrderedSpeechAudioSender { chunk in
+                    await session.sendAudioChunk(chunk)
+                }
+                audioSender = sender
                 try await startingMicrophone.start(strategy: strategy) { chunk in
-                    Task { await session.sendAudioChunk(chunk) }
+                    sender.enqueue(chunk)
                 }
             } else {
                 speechSession = nil
                 try await startingMicrophone.start(strategy: strategy)
             }
-            guard recordingStartID == startID else {
-                if let audioURL = try? await startingMicrophone.stop() {
-                    try? FileManager.default.removeItem(at: audioURL)
-                }
+            guard CarSpeechAttemptGate.accepts(
+                startID,
+                activeAttemptID: recordingStartID,
+                generation: generation,
+                currentGeneration: speechGeneration
+            ) else {
+                let audioURL = try? await startingMicrophone.stop()
                 startingMicrophone.discard()
-                if let startedSession {
-                    await terminate(startedSession)
-                    if speechSession === startedSession {
+                await finishAudioSender()
+                if strategy.usesRealtimeTransport {
+                    if let audioURL { try? FileManager.default.removeItem(at: audioURL) }
+                    if let startedSession, speechSession === startedSession {
                         speechSession = nil
+                        if generation == speechGeneration {
+                            if let preserved = await preserve(startedSession) {
+                                replacePendingAudio(.preserved(preserved))
+                            }
+                        } else {
+                            await terminate(startedSession)
+                        }
+                    }
+                } else if let audioURL {
+                    if generation == speechGeneration {
+                        replacePendingAudio(.file(audioURL, strategy: strategy))
+                    } else {
+                        try? FileManager.default.removeItem(at: audioURL)
                     }
                 }
                 return
@@ -325,27 +464,52 @@ struct CarModeView: View {
             state.carPhase = .recording
             startAudioLevelConsumer()
         } catch {
-            if let audioURL = try? await startingMicrophone.stop() {
-                try? FileManager.default.removeItem(at: audioURL)
-            }
+            let audioURL = try? await startingMicrophone.stop()
             startingMicrophone.discard()
-            if let startedSession {
-                await terminate(startedSession)
-                if speechSession === startedSession {
+            await finishAudioSender()
+            if strategy.usesRealtimeTransport {
+                if let audioURL { try? FileManager.default.removeItem(at: audioURL) }
+                if let startedSession, speechSession === startedSession {
                     speechSession = nil
+                    if generation == speechGeneration {
+                        if let preserved = await preserve(startedSession) {
+                            replacePendingAudio(.preserved(preserved))
+                        }
+                    } else {
+                        await terminate(startedSession)
+                    }
+                }
+            } else if let audioURL {
+                if generation == speechGeneration {
+                    replacePendingAudio(.file(audioURL, strategy: strategy))
+                } else {
+                    try? FileManager.default.removeItem(at: audioURL)
                 }
             }
-            guard recordingStartID == startID else { return }
+            guard CarSpeechAttemptGate.accepts(
+                startID,
+                activeAttemptID: recordingStartID,
+                generation: generation,
+                currentGeneration: speechGeneration
+            ) else { return }
+            activeRecordingGeneration = nil
+            if pendingAudio != nil { failureRetry = .transcription }
             state.carError = error.localizedDescription
             state.carPhase = .failed
         }
-        if recordingStartID == startID {
+        if CarSpeechAttemptGate.accepts(
+            startID,
+            activeAttemptID: recordingStartID,
+            generation: generation,
+            currentGeneration: speechGeneration
+        ) {
             recordingStartID = nil
             isStartingRecording = false
         }
     }
 
     private func stopRecordingAndSubmit() async {
+        guard let generation = activeRecordingGeneration else { return }
         let finalizationID = UUID()
         speechFinalizationID = finalizationID
         let stoppingMicrophone = microphone
@@ -353,9 +517,19 @@ struct CarModeView: View {
         stopAudioLevelConsumer()
         let audioURL = try? await stoppingMicrophone.stop()
         stoppingMicrophone.discard()
-        guard speechFinalizationID == finalizationID else {
+        await finishAudioSender()
+        guard CarSpeechAttemptGate.accepts(
+            finalizationID,
+            activeAttemptID: speechFinalizationID,
+            generation: generation,
+            currentGeneration: speechGeneration
+        ) else {
             if let audioURL {
-                try? FileManager.default.removeItem(at: audioURL)
+                if activeRecordingStrategy.usesRealtimeTransport || generation != speechGeneration {
+                    try? FileManager.default.removeItem(at: audioURL)
+                } else {
+                    replacePendingAudio(.file(audioURL, strategy: activeRecordingStrategy))
+                }
             }
             return
         }
@@ -365,13 +539,14 @@ struct CarModeView: View {
         if !strategy.usesRealtimeTransport {
             guard let audioURL else {
                 speechFinalizationID = nil
+                activeRecordingGeneration = nil
+                failureRetry = .transcription
                 state.carError = L10n.t(.carTranscriptionFailed)
                 state.carPhase = .failed
                 return
             }
-            pendingRecordingURL = audioURL
-            pendingRecordingStrategy = strategy
-            await transcribePendingRecording(finalizationID: finalizationID)
+            replacePendingAudio(.file(audioURL, strategy: strategy))
+            await transcribePendingRecording(finalizationID: finalizationID, generation: generation)
             return
         }
 
@@ -380,83 +555,151 @@ struct CarModeView: View {
         }
         guard let session = speechSession else {
             speechFinalizationID = nil
+            activeRecordingGeneration = nil
+            failureRetry = .transcription
             state.carError = L10n.t(.carTranscriptionFailed)
             state.carPhase = .failed
             return
         }
-        speechSession = nil
 
+        let partialTranscriptBuffer = SpeechPartialTranscriptBuffer()
         do {
-            let transcript = try await session.commitAndStop()
-            await terminate(session)
+            let transcript = try await session.commitAndStop { partial in
+                partialTranscriptBuffer.update(partial)
+            }
+            partialTranscriptBuffer.close()
             let cleaned = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !cleaned.isEmpty else { throw CarModeError.invalidResponse }
-            guard speechFinalizationID == finalizationID else { return }
+            guard CarSpeechAttemptGate.accepts(
+                finalizationID,
+                activeAttemptID: speechFinalizationID,
+                generation: generation,
+                currentGeneration: speechGeneration
+            ),
+                  speechSession === session else {
+                await terminate(session)
+                return
+            }
+            await terminate(session)
+            guard CarSpeechAttemptGate.accepts(
+                finalizationID,
+                activeAttemptID: speechFinalizationID,
+                generation: generation,
+                currentGeneration: speechGeneration
+            ),
+                  speechSession === session else { return }
+            speechSession = nil
+            activeRecordingGeneration = nil
             speechFinalizationID = nil
             discardPendingRecording()
+            failureRetry = .request
             await state.submitCarTurn(cleaned)
+            if state.carPhase != .failed {
+                failureRetry = nil
+            }
         } catch {
-            await terminate(session)
-            guard speechFinalizationID == finalizationID else { return }
+            partialTranscriptBuffer.close()
+            guard CarSpeechAttemptGate.accepts(
+                finalizationID,
+                activeAttemptID: speechFinalizationID,
+                generation: generation,
+                currentGeneration: speechGeneration
+            ), speechSession === session else { return }
+            speechSession = nil
+            let preserved = await preserve(session)
+            guard generation == speechGeneration else {
+                if let preserved { state.discardPreservedAudio(preserved) }
+                return
+            }
+            if let preserved {
+                replacePendingAudio(.preserved(preserved))
+            }
+            guard CarSpeechAttemptGate.accepts(
+                finalizationID,
+                activeAttemptID: speechFinalizationID,
+                generation: generation,
+                currentGeneration: speechGeneration
+            ) else { return }
+            activeRecordingGeneration = nil
             speechFinalizationID = nil
+            let partial = partialTranscriptBuffer.current().trimmingCharacters(in: .whitespacesAndNewlines)
+            if !partial.isEmpty {
+                state.carLastTranscript = partial
+            }
+            failureRetry = .transcription
             state.carError = error.localizedDescription
             state.carPhase = .failed
         }
     }
 
     private func stopForBackground() async {
-        recordingStartID = nil
-        isStartingRecording = false
-        speechFinalizationID = nil
-        stopHeartbeat()
-        stopAudioLevelConsumer()
-        if let audioURL = try? await microphone.stop() {
-            try? FileManager.default.removeItem(at: audioURL)
-        }
-        microphone.discard()
-        if let session = speechSession {
-            speechSession = nil
-            await terminate(session)
-        }
-        await state.cancelCarInteraction()
-        discardPendingRecording()
+        await cancelLocalCarSpeech(preserveAudio: true)
     }
 
     private func retryPendingRecording() async {
-        guard pendingRecordingURL != nil else { return }
+        guard pendingAudio != nil else { return }
         state.carPhase = .finalizing
+        let generation = speechGeneration
         let finalizationID = UUID()
         speechFinalizationID = finalizationID
-        await transcribePendingRecording(finalizationID: finalizationID)
+        await transcribePendingRecording(finalizationID: finalizationID, generation: generation)
     }
 
-    private func transcribePendingRecording(finalizationID: UUID) async {
-        guard let audioURL = pendingRecordingURL else { return }
+    private func transcribePendingRecording(finalizationID: UUID, generation: UUID) async {
+        guard let pendingAudio else { return }
         do {
-            let transcript = try await state.transcribeAudio(
-                audioFileURL: audioURL,
-                strategy: pendingRecordingStrategy
-            )
+            let transcript: String
+            switch pendingAudio {
+            case .file(let audioURL, let strategy):
+                transcript = try await state.transcribeAudio(
+                    audioFileURL: audioURL,
+                    strategy: strategy,
+                    surface: .car
+                )
+            case .preserved(let preserved):
+                transcript = try await state.transcribePreservedAudio(preserved, surface: .car)
+            }
             let cleaned = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !cleaned.isEmpty else { throw CarModeError.invalidResponse }
-            guard speechFinalizationID == finalizationID else { return }
+            guard CarSpeechAttemptGate.accepts(
+                finalizationID,
+                activeAttemptID: speechFinalizationID,
+                generation: generation,
+                currentGeneration: speechGeneration
+            ) else { return }
             speechFinalizationID = nil
+            activeRecordingGeneration = nil
             discardPendingRecording()
+            failureRetry = .request
             await state.submitCarTurn(cleaned)
+            if state.carPhase != .failed {
+                failureRetry = nil
+            }
         } catch {
-            guard speechFinalizationID == finalizationID else { return }
+            guard CarSpeechAttemptGate.accepts(
+                finalizationID,
+                activeAttemptID: speechFinalizationID,
+                generation: generation,
+                currentGeneration: speechGeneration
+            ) else { return }
             speechFinalizationID = nil
+            activeRecordingGeneration = nil
+            failureRetry = .transcription
             state.carError = error.localizedDescription
             state.carPhase = .failed
         }
     }
 
     private func discardPendingRecording() {
-        if let pendingRecordingURL {
-            try? FileManager.default.removeItem(at: pendingRecordingURL)
+        switch pendingAudio {
+        case .file(let audioURL, _):
+            try? FileManager.default.removeItem(at: audioURL)
+        case .preserved(let preserved):
+            state.discardPreservedAudio(preserved)
+        case nil:
+            break
         }
-        pendingRecordingURL = nil
-        pendingRecordingStrategy = .openAIRealtime
+        pendingAudio = nil
     }
 
     private func terminate(_ session: VoiceFlowSession) async {
@@ -466,6 +709,15 @@ struct CarModeView: View {
             }
         } catch {
             AppState.logger.error("Car speech session termination failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func preserve(_ session: VoiceFlowSession) async -> VoiceFlowPreservedAudio? {
+        do {
+            return try await session.abortPreservingAudio()
+        } catch {
+            AppState.logger.error("Car speech audio preservation failed: \(error.localizedDescription, privacy: .public)")
+            return nil
         }
     }
 

--- a/OpenCodeClient/OpenCodeClient/Views/Car/CarModeView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Car/CarModeView.swift
@@ -38,7 +38,7 @@ struct CarModeView: View {
     @State private var speechGeneration = UUID()
     @State private var recordingStartID: UUID?
     @State private var activeRecordingGeneration: UUID?
-    @State private var activeRecordingStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
+    @State private var activeRecordingStrategy: VoiceFlowRecordingStrategy = .gptLiveTranscribe
     @State private var pendingAudio: PendingCarAudio?
     @State private var failureRetry: CarFailureRetry?
     @State private var heartbeatTask: Task<Void, Never>?

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
@@ -15,10 +15,8 @@ import VoiceFlowKit
 /// SwiftUI requires `@State` on the containing struct — and this
 /// extension hosts the lifecycle methods.
 ///
-/// The chat composer intentionally suppresses mid-recording
-/// `.partialTranscript` events: OpenCode's UX shows transcript text
-/// only after stop. VoiceFlow's recorder shows live partials; see
-/// `AppState+LiveSession.swift` in the VoiceFlowKit repo for that flow.
+/// GPT Live accumulated snapshots render in the composer while recording.
+/// GPT Realtime remains finalize-only.
 
 /// Thread-safe buffer for the latest partial transcript. Used to recover
 /// a salvageable string when `commitAndStop` fails after partials
@@ -82,6 +80,15 @@ extension ChatTabView {
 
     static func speechFailureInput(prefix: String, lastPartialTranscript: String) -> String {
         mergedSpeechInput(prefix: prefix, transcript: lastPartialTranscript)
+    }
+
+    static func liveSpeechInput(
+        strategy: VoiceFlowRecordingStrategy,
+        prefix: String,
+        transcript: String
+    ) -> String? {
+        guard strategy == .gptLiveTranscribe else { return nil }
+        return mergedSpeechInput(prefix: prefix, transcript: transcript)
     }
 
     static func requestMicrophonePermissionForRecording() async -> Bool {
@@ -224,12 +231,16 @@ extension ChatTabView {
                             speechRecoveryActive = false
                         }
                     }
-                case .partialTranscript:
-                    // Mid-recording partial transcripts are intentionally
-                    // suppressed in OpenCode's chat composer — the user only
-                    // sees text after stop. (See VoiceFlow's recording flow
-                    // for the opposite UX.)
-                    continue
+                case .partialTranscript(let transcript):
+                    await MainActor.run {
+                        guard isCurrentSpeechSession(session),
+                              let liveInput = Self.liveSpeechInput(
+                                  strategy: activeSpeechStrategy,
+                                  prefix: recordingInputPrefix,
+                                  transcript: transcript
+                              ) else { return }
+                        inputText = liveInput
+                    }
                 }
             }
         }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView+VoiceInput.swift
@@ -24,14 +24,52 @@ import VoiceFlowKit
 /// a salvageable string when `commitAndStop` fails after partials
 /// already streamed in.
 final class SpeechPartialTranscriptBuffer: Sendable {
-    private let storage = OSAllocatedUnfairLock(initialState: "")
+    private struct State: Sendable {
+        var transcript = ""
+        var acceptsUpdates = true
+    }
 
-    nonisolated func update(_ newValue: String) {
-        storage.withLock { $0 = newValue }
+    private let storage = OSAllocatedUnfairLock(initialState: State())
+
+    @discardableResult
+    nonisolated func update(_ newValue: String) -> Bool {
+        storage.withLock {
+            guard $0.acceptsUpdates else { return false }
+            $0.transcript = newValue
+            return true
+        }
     }
 
     nonisolated func current() -> String {
-        storage.withLock { $0 }
+        storage.withLock { $0.transcript }
+    }
+
+    nonisolated func close() {
+        storage.withLock { $0.acceptsUpdates = false }
+    }
+}
+
+enum ChatSpeechOwner: Hashable {
+    case session(String)
+    case noSession
+
+    init(sessionID: String?) {
+        if let sessionID {
+            self = .session(sessionID)
+        } else {
+            self = .noSession
+        }
+    }
+}
+
+enum PendingChatSpeechAudio {
+    case file(URL, strategy: VoiceFlowRecordingStrategy, prefix: String)
+    case preserved(VoiceFlowPreservedAudio, prefix: String)
+
+    var prefix: String {
+        switch self {
+        case .file(_, _, let prefix), .preserved(_, let prefix): prefix
+        }
     }
 }
 
@@ -39,10 +77,7 @@ extension ChatTabView {
     static let speechHeartbeatIntervalSeconds: UInt64 = 12
 
     static func mergedSpeechInput(prefix: String, transcript: String) -> String {
-        let cleanedTranscript = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !cleanedTranscript.isEmpty else { return prefix }
-        guard !prefix.isEmpty else { return cleanedTranscript }
-        return prefix + " " + cleanedTranscript
+        ChatSpeechRouting.mergedInput(prefix: prefix, transcript: transcript)
     }
 
     static func speechFailureInput(prefix: String, lastPartialTranscript: String) -> String {
@@ -71,6 +106,54 @@ extension ChatTabView {
         #else
         return true
         #endif
+    }
+
+    func isCurrentSpeechSession(_ session: VoiceFlowSession) -> Bool {
+        speechSession === session && speechOriginSessionID == state.currentSessionID
+    }
+
+    func ownsSpeechSession(_ session: VoiceFlowSession, sourceSessionID: String?) -> Bool {
+        speechSession === session && speechOriginSessionID == sourceSessionID
+    }
+
+    func applySpeechDraft(prefix: String, transcript: String, sourceSessionID: String?) {
+        let route = ChatSpeechRouting.draftRoute(
+            prefix: prefix,
+            transcript: transcript,
+            sourceSessionID: sourceSessionID,
+            currentSessionID: state.currentSessionID
+        )
+        let owner = ChatSpeechOwner(sessionID: sourceSessionID)
+        if sourceSessionID != nil {
+            state.setDraftText(route.sourceDraftText, for: sourceSessionID)
+        } else {
+            completedSpeechDraftByOwner[owner] = route.sourceDraftText
+        }
+        if let currentComposerText = route.currentComposerText {
+            inputText = currentComposerText
+        }
+    }
+
+    func finishSpeechAudioSender() async {
+        let sender = speechAudioSender
+        speechAudioSender = nil
+        await sender?.finishAndDrain()
+    }
+
+    func storePendingSpeechAudio(_ pending: PendingChatSpeechAudio, owner: ChatSpeechOwner) {
+        if let existing = pendingSpeechAudioByOwner.removeValue(forKey: owner) {
+            discardPendingSpeechAudio(existing)
+        }
+        pendingSpeechAudioByOwner[owner] = pending
+    }
+
+    func discardPendingSpeechAudio(_ pending: PendingChatSpeechAudio) {
+        switch pending {
+        case .file(let audioURL, _, _):
+            try? FileManager.default.removeItem(at: audioURL)
+        case .preserved(let preserved, _):
+            state.discardPreservedAudio(preserved)
+        }
     }
 
     func startSpeechHeartbeat(for session: VoiceFlowSession) {
@@ -123,16 +206,23 @@ extension ChatTabView {
                 guard !Task.isCancelled else { return }
                 switch event {
                 case .recoveryStarted:
-                    await MainActor.run { speechRecoveryActive = true }
+                    await MainActor.run {
+                        guard isCurrentSpeechSession(session) else { return }
+                        speechRecoveryActive = true
+                    }
                 case .recoveryFailed(let message):
                     Self.logger.error("[SpeechProfile] realtime recovery failed message=\(message, privacy: .public)")
                     await MainActor.run {
+                        guard isCurrentSpeechSession(session) else { return }
                         speechRecoveryActive = false
                         speechError = L10n.t(.chatSpeechStreamDisconnected)
                     }
                 case .phaseChanged(let phase):
-                    if phase == .connected, speechRecoveryActive {
-                        await MainActor.run { speechRecoveryActive = false }
+                    if phase == .connected {
+                        await MainActor.run {
+                            guard isCurrentSpeechSession(session), speechRecoveryActive else { return }
+                            speechRecoveryActive = false
+                        }
                     }
                 case .partialTranscript:
                     // Mid-recording partial transcripts are intentionally
@@ -161,32 +251,79 @@ extension ChatTabView {
         }
     }
 
-    func stopSpeechForBackground() async {
-        let hadActiveOperation = isRecording || isStartingRecording || isTranscribing || isRetryingSpeech
+    func preserveSpeechSession(_ session: VoiceFlowSession) async -> VoiceFlowPreservedAudio? {
+        do {
+            return try await session.abortPreservingAudio()
+        } catch {
+            Self.logger.error("[SpeechProfile] realtime audio preservation failed error=\(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    func stopSpeechForNavigation() async {
+        await stopSpeechForNavigation(detachFinalizationOnSessionSwitch: true)
+    }
+
+    private func stopSpeechForNavigation(detachFinalizationOnSessionSwitch: Bool) async {
+        let disposition = ChatSpeechRouting.navigationDisposition(
+            detachFinalizationOnSessionSwitch: detachFinalizationOnSessionSwitch,
+            finalizationID: speechFinalizationID,
+            sourceSessionID: speechOriginSessionID,
+            currentSessionID: state.currentSessionID
+        )
+        if disposition == .detachFinalization {
+            speechRetryID = nil
+            speechRetrySessionID = nil
+            stopSpeechHeartbeat()
+            stopSpeechEventConsumer()
+            stopSpeechAudioLevelConsumer()
+            isRecording = false
+            isTranscribing = false
+            isStartingRecording = false
+            isRetryingSpeech = false
+            return
+        }
+
+        let originSessionID = speechOriginSessionID
+        let owner = ChatSpeechOwner(sessionID: originSessionID)
+        let prefix = recordingInputPrefix
+        let strategy = activeSpeechStrategy
+        let hadActiveCapture = isRecording || isStartingRecording || isTranscribing
         speechStartID = nil
         speechFinalizationID = nil
         speechRetryID = nil
+        speechRetrySessionID = nil
         stopSpeechHeartbeat()
         stopSpeechEventConsumer()
         stopSpeechAudioLevelConsumer()
-        if let audioURL = try? await microphone.stop() {
-            try? FileManager.default.removeItem(at: audioURL)
-        }
+        let audioURL = try? await microphone.stop()
         microphone.discard()
+        await finishSpeechAudioSender()
 
         let session = speechSession
         speechSession = nil
+        speechOriginSessionID = nil
         isRecording = false
         isTranscribing = false
         isStartingRecording = false
         isRetryingSpeech = false
 
-        if let session {
-            await terminateSpeechSession(session)
+        guard hadActiveCapture else {
+            if let audioURL { try? FileManager.default.removeItem(at: audioURL) }
+            return
         }
-        if hadActiveOperation {
-            clearPreservedSpeechAudio()
+        if strategy.usesRealtimeTransport {
+            if let audioURL { try? FileManager.default.removeItem(at: audioURL) }
+            if let session, let preserved = await preserveSpeechSession(session) {
+                storePendingSpeechAudio(.preserved(preserved, prefix: prefix), owner: owner)
+            }
+        } else if let audioURL {
+            storePendingSpeechAudio(.file(audioURL, strategy: strategy, prefix: prefix), owner: owner)
         }
+    }
+
+    func stopSpeechForBackground() async {
+        await stopSpeechForNavigation(detachFinalizationOnSessionSwitch: false)
     }
 
     func toggleRecording() async {
@@ -194,47 +331,64 @@ extension ChatTabView {
             let finalizationID = UUID()
             speechFinalizationID = finalizationID
             let stoppingMicrophone = microphone
+            let originSessionID = speechOriginSessionID
+            let owner = ChatSpeechOwner(sessionID: originSessionID)
+            let prefix = recordingInputPrefix
+            let strategy = activeSpeechStrategy
             stopSpeechHeartbeat()
             stopSpeechEventConsumer()
             stopSpeechAudioLevelConsumer()
             let stopStart = ProcessInfo.processInfo.systemUptime
             let audioURL = try? await stoppingMicrophone.stop()
             stoppingMicrophone.discard()
-            guard speechFinalizationID == finalizationID else {
-                if let audioURL {
+            await finishSpeechAudioSender()
+            guard SpeechAttemptGate.owns(finalizationID, activeAttemptID: speechFinalizationID),
+                  speechOriginSessionID == originSessionID else {
+                if let audioURL, !strategy.usesRealtimeTransport {
+                    storePendingSpeechAudio(.file(audioURL, strategy: strategy, prefix: prefix), owner: owner)
+                } else if let audioURL {
                     try? FileManager.default.removeItem(at: audioURL)
                 }
+                await stopSpeechForNavigation(detachFinalizationOnSessionSwitch: false)
                 return
             }
             isRecording = false
             Self.logger.notice("[SpeechProfile] realtime capture stopped ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - stopStart) * 1000)), privacy: .public)")
 
-            isTranscribing = true
-            let prefix = recordingInputPrefix
-            let strategy = activeSpeechStrategy
+            isTranscribing = originSessionID == state.currentSessionID
 
             if !strategy.usesRealtimeTransport {
                 guard let audioURL else {
                     isTranscribing = false
                     speechFinalizationID = nil
-                    speechError = L10n.t(.carTranscriptionFailed)
+                    speechOriginSessionID = nil
+                    if originSessionID == state.currentSessionID {
+                        speechError = L10n.t(.carTranscriptionFailed)
+                    }
                     return
                 }
-                preservedSpeechFileURL = audioURL
-                preservedSpeechStrategy = strategy
-                preservedSpeechInputPrefix = prefix
+                storePendingSpeechAudio(.file(audioURL, strategy: strategy, prefix: prefix), owner: owner)
                 do {
-                    let transcript = try await state.transcribeAudio(audioFileURL: audioURL, strategy: strategy)
-                    guard speechFinalizationID == finalizationID else { return }
-                    inputText = Self.mergedSpeechInput(prefix: prefix, transcript: transcript)
-                    clearPreservedSpeechAudio()
+                    let transcript = try await state.transcribeAudio(
+                        audioFileURL: audioURL,
+                        strategy: strategy,
+                        surface: .chat
+                    )
+                    guard SpeechAttemptGate.owns(finalizationID, activeAttemptID: speechFinalizationID),
+                          speechOriginSessionID == originSessionID else { return }
+                    applySpeechDraft(prefix: prefix, transcript: transcript, sourceSessionID: originSessionID)
+                    clearPreservedSpeechAudio(for: owner)
                 } catch {
-                    guard speechFinalizationID == finalizationID else { return }
+                    guard SpeechAttemptGate.owns(finalizationID, activeAttemptID: speechFinalizationID),
+                          speechOriginSessionID == originSessionID else { return }
                     Self.logger.error("[SpeechProfile] chat batch transcribe failed error=\(error.localizedDescription, privacy: .public)")
-                    speechError = error.localizedDescription
+                    if originSessionID == state.currentSessionID {
+                        speechError = error.localizedDescription
+                    }
                 }
                 if speechFinalizationID == finalizationID {
                     speechFinalizationID = nil
+                    speechOriginSessionID = nil
                     isTranscribing = false
                 }
                 return
@@ -246,13 +400,18 @@ extension ChatTabView {
             guard let session = speechSession else {
                 isTranscribing = false
                 speechFinalizationID = nil
+                speechOriginSessionID = nil
                 Self.logger.error("[SpeechProfile] realtime stop failed: missing session")
+                if originSessionID == state.currentSessionID {
+                    speechError = L10n.t(.carTranscriptionFailed)
+                }
                 return
             }
             defer {
                 if speechSession === session {
                     speechSession = nil
                     speechFinalizationID = nil
+                    speechOriginSessionID = nil
                     isTranscribing = false
                 }
             }
@@ -260,24 +419,52 @@ extension ChatTabView {
             let transcribeStart = ProcessInfo.processInfo.systemUptime
             do {
                 let transcript = try await session.commitAndStop { partial in
-                    partialTranscriptBuffer.update(partial)
+                    guard partialTranscriptBuffer.update(partial) else { return }
                     Task { @MainActor in
-                        guard speechFinalizationID == finalizationID else { return }
+                        guard SpeechAttemptGate.accepts(
+                            finalizationID,
+                            activeAttemptID: speechFinalizationID,
+                            originatingSessionID: originSessionID,
+                            currentSessionID: state.currentSessionID
+                        ), ownsSpeechSession(session, sourceSessionID: originSessionID) else { return }
                         inputText = Self.mergedSpeechInput(prefix: prefix, transcript: partial)
                     }
                 }
                 let cleaned = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard speechSession === session else { return }
+                partialTranscriptBuffer.close()
+                guard SpeechAttemptGate.owns(finalizationID, activeAttemptID: speechFinalizationID),
+                      ownsSpeechSession(session, sourceSessionID: originSessionID) else { return }
+                speechFinalizationID = nil
                 Self.logger.notice("[SpeechProfile] chat realtime transcribe done ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) chars=\(cleaned.count, privacy: .public)")
-                inputText = Self.mergedSpeechInput(prefix: prefix, transcript: cleaned)
-                clearPreservedSpeechAudio()
+                applySpeechDraft(prefix: prefix, transcript: cleaned, sourceSessionID: originSessionID)
+                clearPreservedSpeechAudio(for: owner)
+                speechSession = nil
+                speechOriginSessionID = nil
+                isTranscribing = false
                 await terminateSpeechSession(session)
             } catch {
-                await terminateSpeechSession(session)
-                guard speechSession === session else { return }
+                partialTranscriptBuffer.close()
+                guard SpeechAttemptGate.owns(finalizationID, activeAttemptID: speechFinalizationID),
+                      ownsSpeechSession(session, sourceSessionID: originSessionID) else { return }
+                speechSession = nil
+                let preserved = await preserveSpeechSession(session)
+                if let preserved {
+                    storePendingSpeechAudio(.preserved(preserved, prefix: prefix), owner: owner)
+                }
+                guard SpeechAttemptGate.owns(finalizationID, activeAttemptID: speechFinalizationID),
+                      speechOriginSessionID == originSessionID else { return }
+                speechFinalizationID = nil
+                speechOriginSessionID = nil
+                isTranscribing = false
                 Self.logger.error("[SpeechProfile] chat realtime transcribe failed ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - transcribeStart) * 1000)), privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-                inputText = Self.speechFailureInput(prefix: prefix, lastPartialTranscript: partialTranscriptBuffer.current())
-                speechError = error.localizedDescription
+                applySpeechDraft(
+                    prefix: prefix,
+                    transcript: partialTranscriptBuffer.current(),
+                    sourceSessionID: originSessionID
+                )
+                if originSessionID == state.currentSessionID {
+                    speechError = error.localizedDescription
+                }
             }
         } else {
             guard !isStartingRecording else { return }
@@ -300,58 +487,87 @@ extension ChatTabView {
                 return
             }
 
+            let strategy = state.aiBuilderRecordingStrategy
+            let originSessionID = state.currentSessionID
             let startID = UUID()
             speechStartID = startID
+            speechOriginSessionID = originSessionID
             isStartingRecording = true
             let permissionStart = ProcessInfo.processInfo.systemUptime
             let allowed = await Self.requestMicrophonePermissionForRecording()
             Self.logger.notice("[SpeechProfile] microphone permission allowed=\(allowed, privacy: .public) ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - permissionStart) * 1000)), privacy: .public)")
             guard allowed else {
-                guard speechStartID == startID else { return }
+                guard SpeechAttemptGate.accepts(
+                    startID,
+                    activeAttemptID: speechStartID,
+                    originatingSessionID: originSessionID,
+                    currentSessionID: state.currentSessionID
+                ) else { return }
                 speechStartID = nil
+                speechOriginSessionID = nil
                 isStartingRecording = false
                 speechError = L10n.t(.chatMicrophoneDenied)
                 return
             }
-            guard speechStartID == startID else { return }
+            guard SpeechAttemptGate.accepts(
+                startID,
+                activeAttemptID: speechStartID,
+                originatingSessionID: originSessionID,
+                currentSessionID: state.currentSessionID
+            ) else { return }
             let startRecordingStart = ProcessInfo.processInfo.systemUptime
             var startedSession: VoiceFlowSession?
             do {
                 speechRetryID = nil
-                clearPreservedSpeechAudio()
-                let strategy = state.aiBuilderRecordingStrategy
                 recordingInputPrefix = inputText
                 activeSpeechStrategy = strategy
                 startSpeechAudioLevelConsumer()
 
                 if strategy.usesRealtimeTransport {
-                    let session = try await state.startRealtimeSpeechSession()
+                    let session = try await state.startRealtimeSpeechSession(strategy: strategy, surface: .chat)
                     startedSession = session
-                    guard speechStartID == startID else {
+                    guard SpeechAttemptGate.accepts(
+                        startID,
+                        activeAttemptID: speechStartID,
+                        originatingSessionID: originSessionID,
+                        currentSessionID: state.currentSessionID
+                    ) else {
                         await terminateSpeechSession(session)
                         return
                     }
                     speechSession = session
                     startSpeechEventConsumer(for: session)
+                    let sender = OrderedSpeechAudioSender { chunk in
+                        await session.sendAudioChunk(chunk)
+                    }
+                    speechAudioSender = sender
                     try await startingMicrophone.start(strategy: strategy) { chunk in
-                        Task {
-                            await session.sendAudioChunk(chunk)
-                        }
+                        sender.enqueue(chunk)
                     }
                 } else {
                     speechSession = nil
                     try await startingMicrophone.start(strategy: strategy)
                 }
-                guard speechStartID == startID else {
-                    if let audioURL = try? await startingMicrophone.stop() {
-                        try? FileManager.default.removeItem(at: audioURL)
-                    }
+                guard SpeechAttemptGate.accepts(
+                    startID,
+                    activeAttemptID: speechStartID,
+                    originatingSessionID: originSessionID,
+                    currentSessionID: state.currentSessionID
+                ) else {
+                    let audioURL = try? await startingMicrophone.stop()
                     startingMicrophone.discard()
-                    if let startedSession {
-                        await terminateSpeechSession(startedSession)
-                        if speechSession === startedSession {
-                            self.speechSession = nil
+                    await finishSpeechAudioSender()
+                    let owner = ChatSpeechOwner(sessionID: originSessionID)
+                    if strategy.usesRealtimeTransport {
+                        if let audioURL { try? FileManager.default.removeItem(at: audioURL) }
+                        if let startedSession, speechSession === startedSession {
+                            speechSession = nil
+                            if let preserved = await preserveSpeechSession(startedSession) {
+                                storePendingSpeechAudio(.preserved(preserved, prefix: recordingInputPrefix), owner: owner)
+                            }
                         }
+                    } else if let audioURL {
+                        storePendingSpeechAudio(.file(audioURL, strategy: strategy, prefix: recordingInputPrefix), owner: owner)
                     }
                     return
                 }
@@ -363,22 +579,33 @@ extension ChatTabView {
                 isStartingRecording = false
                 Self.logger.notice("[SpeechProfile] capture started strategy=\(strategy.rawValue, privacy: .public) ms=\(max(0, Int((ProcessInfo.processInfo.systemUptime - startRecordingStart) * 1000)), privacy: .public)")
             } catch {
-                if let audioURL = try? await startingMicrophone.stop() {
-                    try? FileManager.default.removeItem(at: audioURL)
-                }
+                let audioURL = try? await startingMicrophone.stop()
                 startingMicrophone.discard()
-                if let startedSession {
-                    await terminateSpeechSession(startedSession)
-                    if speechSession === startedSession {
+                await finishSpeechAudioSender()
+                let owner = ChatSpeechOwner(sessionID: originSessionID)
+                if strategy.usesRealtimeTransport {
+                    if let audioURL { try? FileManager.default.removeItem(at: audioURL) }
+                    if let startedSession, speechSession === startedSession {
                         speechSession = nil
+                        if let preserved = await preserveSpeechSession(startedSession) {
+                            storePendingSpeechAudio(.preserved(preserved, prefix: recordingInputPrefix), owner: owner)
+                        }
                     }
+                } else if let audioURL {
+                    storePendingSpeechAudio(.file(audioURL, strategy: strategy, prefix: recordingInputPrefix), owner: owner)
                 }
-                let shouldReportError = speechStartID == startID
+                let shouldReportError = SpeechAttemptGate.accepts(
+                    startID,
+                    activeAttemptID: speechStartID,
+                    originatingSessionID: originSessionID,
+                    currentSessionID: state.currentSessionID
+                )
                 if shouldReportError {
                     stopSpeechHeartbeat()
                     stopSpeechEventConsumer()
                     stopSpeechAudioLevelConsumer()
                     speechStartID = nil
+                    speechOriginSessionID = nil
                     isStartingRecording = false
                 }
                 guard shouldReportError else { return }
@@ -389,28 +616,32 @@ extension ChatTabView {
     }
 
     func abortSpeechRecognition() async {
+        let originSessionID = speechOriginSessionID
+        let owner = ChatSpeechOwner(sessionID: originSessionID)
         speechStartID = nil
         speechFinalizationID = nil
         speechRetryID = nil
+        speechRetrySessionID = nil
         stopSpeechHeartbeat()
         stopSpeechEventConsumer()
         stopSpeechAudioLevelConsumer()
         let audioURL = try? await microphone.stop()
+        microphone.discard()
+        await finishSpeechAudioSender()
 
         let session = speechSession
         let prefix = recordingInputPrefix
         let strategy = activeSpeechStrategy
         speechSession = nil
+        speechOriginSessionID = nil
         isRecording = false
         isTranscribing = false
         isStartingRecording = false
+        isRetryingSpeech = false
 
         if !strategy.usesRealtimeTransport {
             if let audioURL {
-                clearPreservedSpeechAudio()
-                preservedSpeechFileURL = audioURL
-                preservedSpeechStrategy = strategy
-                preservedSpeechInputPrefix = prefix
+                storePendingSpeechAudio(.file(audioURL, strategy: strategy, prefix: prefix), owner: owner)
             }
             return
         }
@@ -420,9 +651,7 @@ extension ChatTabView {
         guard let session else { return }
         do {
             if let preserved = try await session.abortPreservingAudio() {
-                clearPreservedSpeechAudio()
-                preservedSpeechInputPrefix = prefix
-                preservedSpeechAudio = preserved
+                storePendingSpeechAudio(.preserved(preserved, prefix: prefix), owner: owner)
                 Self.logger.notice("[SpeechProfile] realtime speech aborted with preserved bytes=\(preserved.byteCount, privacy: .public)")
             }
         } catch {
@@ -432,55 +661,78 @@ extension ChatTabView {
     }
 
     func retryPreservedSpeechAudio() async {
-        guard preservedSpeechAudio != nil || preservedSpeechFileURL != nil else { return }
+        let retrySessionID = state.currentSessionID
+        let owner = ChatSpeechOwner(sessionID: retrySessionID)
+        guard let pending = pendingSpeechAudioByOwner[owner] else { return }
         let retryID = UUID()
         speechRetryID = retryID
+        speechRetrySessionID = retrySessionID
         isRetryingSpeech = true
         defer {
             if speechRetryID == retryID {
                 speechRetryID = nil
+                speechRetrySessionID = nil
                 isRetryingSpeech = false
             }
         }
 
-        let prefix = preservedSpeechInputPrefix
+        let prefix = pending.prefix
+        let partialTranscriptBuffer = SpeechPartialTranscriptBuffer()
         do {
             let transcript: String
-            if let audioURL = preservedSpeechFileURL {
+            switch pending {
+            case .file(let audioURL, let strategy, _):
                 transcript = try await state.transcribeAudio(
                     audioFileURL: audioURL,
-                    strategy: preservedSpeechStrategy
+                    strategy: strategy,
+                    surface: .chat
                 )
-            } else if let preserved = preservedSpeechAudio {
-                transcript = try await state.transcribePreservedAudio(preserved) { partial in
+            case .preserved(let preserved, _):
+                transcript = try await state.transcribePreservedAudio(preserved, surface: .chat) { partial in
+                    guard partialTranscriptBuffer.update(partial) else { return }
                     Task { @MainActor in
-                        guard speechRetryID == retryID else { return }
+                        guard SpeechAttemptGate.accepts(
+                            retryID,
+                            activeAttemptID: speechRetryID,
+                            originatingSessionID: retrySessionID,
+                            currentSessionID: state.currentSessionID
+                        ), speechRetrySessionID == retrySessionID else { return }
                         inputText = Self.mergedSpeechInput(prefix: prefix, transcript: partial)
                     }
                 }
-            } else {
-                return
             }
-            guard speechRetryID == retryID else { return }
+            partialTranscriptBuffer.close()
+            guard SpeechAttemptGate.accepts(
+                retryID,
+                activeAttemptID: speechRetryID,
+                originatingSessionID: retrySessionID,
+                currentSessionID: state.currentSessionID
+            ), speechRetrySessionID == retrySessionID else { return }
+            speechRetryID = nil
+            speechRetrySessionID = nil
+            isRetryingSpeech = false
             inputText = Self.mergedSpeechInput(prefix: prefix, transcript: transcript)
-            clearPreservedSpeechAudio()
+            clearPreservedSpeechAudio(for: owner)
         } catch {
-            guard speechRetryID == retryID else { return }
+            partialTranscriptBuffer.close()
+            guard SpeechAttemptGate.accepts(
+                retryID,
+                activeAttemptID: speechRetryID,
+                originatingSessionID: retrySessionID,
+                currentSessionID: state.currentSessionID
+            ), speechRetrySessionID == retrySessionID else { return }
             Self.logger.error("[SpeechProfile] preserved speech retry failed error=\(error.localizedDescription, privacy: .public)")
             speechError = error.localizedDescription
         }
     }
 
     func clearPreservedSpeechAudio() {
-        if let preservedSpeechAudio {
-            state.discardPreservedAudio(preservedSpeechAudio)
+        clearPreservedSpeechAudio(for: ChatSpeechOwner(sessionID: state.currentSessionID))
+    }
+
+    func clearPreservedSpeechAudio(for owner: ChatSpeechOwner) {
+        if let pending = pendingSpeechAudioByOwner.removeValue(forKey: owner) {
+            discardPendingSpeechAudio(pending)
         }
-        preservedSpeechAudio = nil
-        if let preservedSpeechFileURL {
-            try? FileManager.default.removeItem(at: preservedSpeechFileURL)
-        }
-        preservedSpeechFileURL = nil
-        preservedSpeechStrategy = .openAIRealtime
-        preservedSpeechInputPrefix = ""
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -66,7 +66,7 @@ struct ChatTabView: View {
     @State var speechAudioSender: OrderedSpeechAudioSender?
     @State var speechStartID: UUID?
     @State var speechOriginSessionID: String?
-    @State var activeSpeechStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
+    @State var activeSpeechStrategy: VoiceFlowRecordingStrategy = .gptLiveTranscribe
     @State var speechFinalizationID: UUID?
     @State var speechRetryID: UUID?
     @State var speechRetrySessionID: String?

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -63,17 +63,18 @@ struct ChatTabView: View {
     @State private var renameText = ""
     @State var microphone = VoiceFlowMicrophone()
     @State var speechSession: VoiceFlowSession?
+    @State var speechAudioSender: OrderedSpeechAudioSender?
     @State var speechStartID: UUID?
+    @State var speechOriginSessionID: String?
     @State var activeSpeechStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
     @State var speechFinalizationID: UUID?
     @State var speechRetryID: UUID?
+    @State var speechRetrySessionID: String?
     @State var speechHeartbeatTask: Task<Void, Never>?
     @State var speechEventTask: Task<Void, Never>?
     @State var recordingInputPrefix = ""
-    @State var preservedSpeechInputPrefix = ""
-    @State var preservedSpeechAudio: VoiceFlowPreservedAudio?
-    @State var preservedSpeechFileURL: URL?
-    @State var preservedSpeechStrategy: VoiceFlowRecordingStrategy = .openAIRealtime
+    @State var pendingSpeechAudioByOwner: [ChatSpeechOwner: PendingChatSpeechAudio] = [:]
+    @State var completedSpeechDraftByOwner: [ChatSpeechOwner: String] = [:]
     @State var isRecording = false
     @State var isStartingRecording = false
     @State var isTranscribing = false
@@ -108,7 +109,8 @@ struct ChatTabView: View {
     }
 
     private var hasPreservedSpeechAudioForUI: Bool {
-        preservedSpeechAudio != nil || preservedSpeechFileURL != nil || Self.hasUITestF3RetryFixture
+        pendingSpeechAudioByOwner[ChatSpeechOwner(sessionID: state.currentSessionID)] != nil
+            || Self.hasUITestF3RetryFixture
     }
 
     private var composerPlaceholderText: String {
@@ -850,21 +852,24 @@ struct ChatTabView: View {
             }
             .onChange(of: state.currentSessionID) { oldID, newID in
                 let draftText = inputText
+                state.setDraftText(draftText, for: oldID)
+                syncDraftFromState(sessionID: newID)
+                isNearBottom = true
+                pendingBottomVisibilityTask?.cancel()
+                pendingBottomVisibilityTask = nil
                 Task { @MainActor in
-                    await Task.yield()
-                    state.setDraftText(draftText, for: oldID)
-                    syncDraftFromState(sessionID: newID)
-                    isNearBottom = true
-                    pendingBottomVisibilityTask?.cancel()
-                    pendingBottomVisibilityTask = nil
+                    await stopSpeechForNavigation()
                 }
             }
             .onChange(of: inputText) { _, newValue in
                 guard !isSyncingDraft else { return }
+                let draftSessionID = state.currentSessionID
                 Task { @MainActor in
                     await Task.yield()
-                    guard !isSyncingDraft, inputText == newValue else { return }
-                    state.setDraftText(newValue, for: state.currentSessionID)
+                    guard !isSyncingDraft,
+                          state.currentSessionID == draftSessionID,
+                          inputText == newValue else { return }
+                    state.setDraftText(newValue, for: draftSessionID)
                 }
             }
             .onChange(of: selectedPhotoItems) { _, newItems in
@@ -882,7 +887,12 @@ struct ChatTabView: View {
 
     private func syncDraftFromState(sessionID: String?) {
         isSyncingDraft = true
-        inputText = state.draftText(for: sessionID)
+        if sessionID == nil,
+           let completedDraft = completedSpeechDraftByOwner[ChatSpeechOwner(sessionID: nil)] {
+            inputText = completedDraft
+        } else {
+            inputText = state.draftText(for: sessionID)
+        }
         isSyncingDraft = false
     }
 

--- a/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
@@ -174,9 +174,10 @@ struct SettingsTabView: View {
                 Section(L10n.t(.settingsSpeechRecognition)) {
                     Picker(L10n.t(.settingsRecordingStrategy), selection: $state.aiBuilderRecordingStrategy) {
                         Text(L10n.t(.settingsOpenAIRealtime)).tag(VoiceFlowRecordingStrategy.openAIRealtime)
+                        Text(L10n.t(.settingsGPTLiveTranscribe)).tag(VoiceFlowRecordingStrategy.gptLiveTranscribe)
                         Text(L10n.t(.settingsGrokBatch)).tag(VoiceFlowRecordingStrategy.grokBatch)
                     }
-                    .pickerStyle(.segmented)
+                    .pickerStyle(.menu)
                     .accessibilityIdentifier("settings-recording-strategy")
 
                     HStack(spacing: 6) {
@@ -214,9 +215,10 @@ struct SettingsTabView: View {
                     SecureField(L10n.t(.settingsAiBuilderToken), text: $state.aiBuilderToken)
                         .textContentType(.password)
 
-                    if state.aiBuilderRecordingStrategy == .openAIRealtime {
+                    if state.aiBuilderRecordingStrategy.usesRealtimeTransport {
                         TextField(L10n.t(.settingsCustomPrompt), text: $state.aiBuilderCustomPrompt, axis: .vertical)
                             .lineLimit(3...6)
+                            .accessibilityIdentifier("settings-custom-prompt")
                     }
 
                     TextField(L10n.t(.settingsTerminology), text: $state.aiBuilderTerminology)
@@ -250,6 +252,10 @@ struct SettingsTabView: View {
                                 .foregroundStyle(.red)
                         }
                     }
+
+                    Text(L10n.t(.settingsTestConnectionScope))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
                 Section(L10n.t(.settingsAbout)) {
                     if let version = state.serverVersion {

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -12,6 +12,36 @@ import Testing
 import VoiceFlowKit
 @testable import OpenCodeClient
 
+private actor SpeechSenderTestLatch {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        for waiter in pendingWaiters {
+            waiter.resume()
+        }
+    }
+}
+
+private actor SpeechSenderTestRecorder {
+    private(set) var values: [UInt8] = []
+
+    func append(_ value: UInt8) {
+        values.append(value)
+    }
+}
+
 // MARK: - Existing Tests
 
 struct OpenCodeClientTests {
@@ -1359,6 +1389,7 @@ struct LayoutConstantsTests {
 
 // MARK: - Speech Recognition Defaults
 
+@Suite(.serialized)
 struct SpeechRecognitionDefaultsTests {
 
     @Test @MainActor func speechRecognitionDefaultPromptAndTerminology() async {
@@ -1383,19 +1414,30 @@ struct SpeechRecognitionDefaultsTests {
     }
 
     @Test @MainActor func recordingStrategyPersistsAndDefaultsToRealtime() async {
+        let oldValue = UserDefaults.standard.string(forKey: AppState.aiBuilderRecordingStrategyKey)
         UserDefaults.standard.removeObject(forKey: AppState.aiBuilderRecordingStrategyKey)
+        defer {
+            if let oldValue {
+                UserDefaults.standard.set(oldValue, forKey: AppState.aiBuilderRecordingStrategyKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: AppState.aiBuilderRecordingStrategyKey)
+            }
+        }
         let defaultState = AppState()
         #expect(defaultState.aiBuilderRecordingStrategy == .openAIRealtime)
 
-        defaultState.aiBuilderRecordingStrategy = .grokBatch
-        let restoredState = AppState()
-        #expect(restoredState.aiBuilderRecordingStrategy == .grokBatch)
-
-        UserDefaults.standard.removeObject(forKey: AppState.aiBuilderRecordingStrategyKey)
+        for strategy in VoiceFlowRecordingStrategy.allCases {
+            defaultState.aiBuilderRecordingStrategy = strategy
+            #expect(AppState().aiBuilderRecordingStrategy == strategy)
+        }
     }
 
-    @Test func onlyOpenAIRecordingUsesRealtimeTransport() {
+    @Test func strategyRawValuesAndRealtimeCapabilityRemainStable() {
+        #expect(VoiceFlowRecordingStrategy.openAIRealtime.rawValue == "openAIRealtime")
+        #expect(VoiceFlowRecordingStrategy.gptLiveTranscribe.rawValue == "gptLiveTranscribe")
+        #expect(VoiceFlowRecordingStrategy.grokBatch.rawValue == "grokBatch")
         #expect(VoiceFlowRecordingStrategy.openAIRealtime.usesRealtimeTransport)
+        #expect(VoiceFlowRecordingStrategy.gptLiveTranscribe.usesRealtimeTransport)
         #expect(!VoiceFlowRecordingStrategy.grokBatch.usesRealtimeTransport)
     }
 }
@@ -1417,6 +1459,193 @@ struct ChatComposerSpeechTests {
 
     @Test func speechFailureInputFallsBackToPrefixWithoutPartialTranscript() {
         #expect(ChatTabView.speechFailureInput(prefix: "Existing draft", lastPartialTranscript: "   ") == "Existing draft")
+    }
+
+    @Test func finalSpeechResultReplacesPartialWithoutDuplicatingPrefix() {
+        let prefix = "Existing draft"
+        let partial = ChatTabView.mergedSpeechInput(prefix: prefix, transcript: "partial")
+        let final = ChatTabView.mergedSpeechInput(prefix: prefix, transcript: "final result")
+        #expect(partial == "Existing draft partial")
+        #expect(final == "Existing draft final result")
+    }
+
+    @Test func speechAttemptGateRejectsStaleAndCompletedAttempts() {
+        let current = UUID()
+        #expect(SpeechAttemptGate.accepts(
+            current,
+            activeAttemptID: current,
+            originatingSessionID: "session-1",
+            currentSessionID: "session-1"
+        ))
+        #expect(!SpeechAttemptGate.accepts(
+            UUID(),
+            activeAttemptID: current,
+            originatingSessionID: "session-1",
+            currentSessionID: "session-1"
+        ))
+        #expect(!SpeechAttemptGate.accepts(
+            current,
+            activeAttemptID: nil,
+            originatingSessionID: "session-1",
+            currentSessionID: "session-1"
+        ))
+        #expect(!SpeechAttemptGate.accepts(
+            current,
+            activeAttemptID: current,
+            originatingSessionID: "session-1",
+            currentSessionID: "session-2"
+        ))
+
+        var activeAttemptID: UUID? = current
+        var acceptedCallbacks = 0
+        for _ in 0..<2 where SpeechAttemptGate.accepts(
+            current,
+            activeAttemptID: activeAttemptID,
+            originatingSessionID: "session-1",
+            currentSessionID: "session-1"
+        ) {
+            activeAttemptID = nil
+            acceptedCallbacks += 1
+        }
+        #expect(acceptedCallbacks == 1)
+    }
+
+    @Test func chatSpeechOwnersKeepPendingAudioSessionScoped() {
+        #expect(ChatSpeechOwner(sessionID: "session-1") == .session("session-1"))
+        #expect(ChatSpeechOwner(sessionID: "session-1") != ChatSpeechOwner(sessionID: "session-2"))
+        #expect(ChatSpeechOwner(sessionID: nil) == .noSession)
+    }
+
+    @Test @MainActor func completedSpeechAfterSwitchUpdatesOnlySourceDraft() {
+        let sourceSessionID = "speech-source"
+        let destinationSessionID = "speech-destination"
+        let state = AppState()
+        defer {
+            state.setDraftText("", for: sourceSessionID)
+            state.setDraftText("", for: destinationSessionID)
+        }
+        state.setDraftText("destination draft", for: destinationSessionID)
+
+        // Navigation snapshots the old composer before asynchronous cleanup starts.
+        state.setDraftText("source prefix", for: sourceSessionID)
+        let route = ChatSpeechRouting.draftRoute(
+            prefix: "source prefix",
+            transcript: "completed utterance",
+            sourceSessionID: sourceSessionID,
+            currentSessionID: destinationSessionID
+        )
+        state.setDraftText(route.sourceDraftText, for: route.sourceSessionID)
+
+        #expect(route.currentComposerText == nil)
+        #expect(state.draftText(for: sourceSessionID) == "source prefix completed utterance")
+        #expect(state.draftText(for: destinationSessionID) == "destination draft")
+    }
+
+    @Test @MainActor func sessionSwitchDetachesFinalizationWithoutRevokingOwnership() {
+        let finalizationID = UUID()
+        #expect(ChatSpeechRouting.navigationDisposition(
+            detachFinalizationOnSessionSwitch: true,
+            finalizationID: finalizationID,
+            sourceSessionID: "speech-source",
+            currentSessionID: "speech-destination"
+        ) == .detachFinalization)
+        #expect(SpeechAttemptGate.owns(finalizationID, activeAttemptID: finalizationID))
+        #expect(!SpeechAttemptGate.accepts(
+            finalizationID,
+            activeAttemptID: finalizationID,
+            originatingSessionID: "speech-source",
+            currentSessionID: "speech-destination"
+        ))
+
+        #expect(ChatSpeechRouting.navigationDisposition(
+            detachFinalizationOnSessionSwitch: false,
+            finalizationID: finalizationID,
+            sourceSessionID: "speech-source",
+            currentSessionID: "speech-destination"
+        ) == .cancelAndPreserve)
+        #expect(ChatSpeechRouting.navigationDisposition(
+            detachFinalizationOnSessionSwitch: true,
+            finalizationID: nil,
+            sourceSessionID: "speech-source",
+            currentSessionID: "speech-destination"
+        ) == .cancelAndPreserve)
+    }
+
+    @Test @MainActor func completedSpeechWithoutSwitchStillTargetsCurrentComposer() {
+        let route = ChatSpeechRouting.draftRoute(
+            prefix: "source prefix",
+            transcript: "completed utterance",
+            sourceSessionID: "speech-source",
+            currentSessionID: "speech-source"
+        )
+        #expect(route.sourceDraftText == "source prefix completed utterance")
+        #expect(route.currentComposerText == route.sourceDraftText)
+    }
+
+    @Test func carSpeechAttemptGateRejectsOldGenerations() {
+        let current = UUID()
+        let generation = UUID()
+        #expect(CarSpeechAttemptGate.accepts(
+            current,
+            activeAttemptID: current,
+            generation: generation,
+            currentGeneration: generation
+        ))
+        #expect(!CarSpeechAttemptGate.accepts(
+            current,
+            activeAttemptID: current,
+            generation: UUID(),
+            currentGeneration: generation
+        ))
+        #expect(!CarSpeechAttemptGate.accepts(
+            UUID(),
+            activeAttemptID: current,
+            generation: generation,
+            currentGeneration: generation
+        ))
+    }
+
+    @Test func orderedSpeechAudioSenderPreservesOrderBoundsAndDrain() async {
+        let firstSendStarted = SpeechSenderTestLatch()
+        let releaseFirstSend = SpeechSenderTestLatch()
+        let capacityReached = SpeechSenderTestLatch()
+        let recorder = SpeechSenderTestRecorder()
+        let sender = OrderedSpeechAudioSender(capacity: 2) { chunk in
+            guard let value = chunk.first else { return }
+            await recorder.append(value)
+            if value == 0 {
+                await firstSendStarted.open()
+                await releaseFirstSend.wait()
+            }
+        }
+
+        #expect(sender.enqueue(Data([0])))
+        await firstSendStarted.wait()
+
+        let producer = Task.detached {
+            guard sender.enqueue(Data([1])), sender.enqueue(Data([2])) else { return false }
+            await capacityReached.open()
+            return sender.enqueue(Data([3]))
+        }
+        await capacityReached.wait()
+        #expect(sender.maximumBufferedCount == 2)
+
+        await releaseFirstSend.open()
+        let producerFinished = await producer.value
+        #expect(producerFinished)
+        await sender.finishAndDrain()
+
+        let sentValues = await recorder.values
+        #expect(sentValues == [0, 1, 2, 3])
+        #expect(!sender.enqueue(Data([4])))
+    }
+
+    @Test func closedPartialBufferRejectsLateCallbacks() {
+        let buffer = SpeechPartialTranscriptBuffer()
+        #expect(buffer.update("partial"))
+        buffer.close()
+        #expect(!buffer.update("stale"))
+        #expect(buffer.current() == "partial")
     }
 
     @Test func speechTranscriptAutoScrollsOnlyDuringGeneratedUpdates() {
@@ -3126,6 +3355,12 @@ final class MockCarSpeechOutput: CarSpeechOutputProviding {
 
 @Suite(.serialized)
 struct CarModeFlowTests {
+    @Test func pendingCarFileKeepsOriginatingStrategy() {
+        let url = URL(fileURLWithPath: "/tmp/gpt-live.wav")
+        let pending = PendingCarAudio.file(url, strategy: .gptLiveTranscribe)
+        #expect(pending.strategy == .gptLiveTranscribe)
+    }
+
     @Test @MainActor func submitCarTurnReusesScopedSessionAndSpeaksOnce() async throws {
         let defaultsKey = AppState.carSessionsByContextKey
         let oldValue = UserDefaults.standard.data(forKey: defaultsKey)
@@ -4219,7 +4454,11 @@ struct VoiceFlowKitIntegrationTests {
         let state = AppState()
         state.aiBuilderToken = "   "
         await #expect(throws: VoiceFlowError.missingToken) {
-            _ = try await state.transcribeAudio(audioFileURL: URL(fileURLWithPath: "/tmp/does-not-exist.wav"))
+            _ = try await state.transcribeAudio(
+                audioFileURL: URL(fileURLWithPath: "/tmp/does-not-exist.wav"),
+                strategy: .gptLiveTranscribe,
+                surface: .chat
+            )
         }
     }
 
@@ -4227,7 +4466,7 @@ struct VoiceFlowKitIntegrationTests {
         let state = AppState()
         state.aiBuilderToken = ""
         await #expect(throws: VoiceFlowError.missingToken) {
-            _ = try await state.startRealtimeSpeechSession()
+            _ = try await state.startRealtimeSpeechSession(strategy: .gptLiveTranscribe, surface: .car)
         }
     }
 }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1413,7 +1413,7 @@ struct SpeechRecognitionDefaultsTests {
         UserDefaults.standard.removeObject(forKey: "aiBuilderTerminology")
     }
 
-    @Test @MainActor func recordingStrategyPersistsAndDefaultsToRealtime() async {
+    @Test @MainActor func recordingStrategyPersistsAndDefaultsToGPTLive() async {
         let oldValue = UserDefaults.standard.string(forKey: AppState.aiBuilderRecordingStrategyKey)
         UserDefaults.standard.removeObject(forKey: AppState.aiBuilderRecordingStrategyKey)
         defer {
@@ -1424,7 +1424,7 @@ struct SpeechRecognitionDefaultsTests {
             }
         }
         let defaultState = AppState()
-        #expect(defaultState.aiBuilderRecordingStrategy == .openAIRealtime)
+        #expect(defaultState.aiBuilderRecordingStrategy == .gptLiveTranscribe)
 
         for strategy in VoiceFlowRecordingStrategy.allCases {
             defaultState.aiBuilderRecordingStrategy = strategy
@@ -1450,6 +1450,19 @@ struct ChatComposerSpeechTests {
 
     @Test func mergedSpeechInputKeepsSeparatorForExistingInput() {
         #expect(ChatTabView.mergedSpeechInput(prefix: "Existing draft", transcript: "partial") == "Existing draft partial")
+    }
+
+    @Test func liveSpeechInputOnlyRendersGPTLiveSnapshots() {
+        #expect(ChatTabView.liveSpeechInput(
+            strategy: .gptLiveTranscribe,
+            prefix: "Existing draft",
+            transcript: "live words"
+        ) == "Existing draft live words")
+        #expect(ChatTabView.liveSpeechInput(
+            strategy: .openAIRealtime,
+            prefix: "Existing draft",
+            transcript: "hidden words"
+        ) == nil)
     }
 
     @Test func speechFailureInputPreservesLastPartialTranscript() {

--- a/OpenCodeClient/OpenCodeClientUITests/OpenCodeClientUITests.swift
+++ b/OpenCodeClient/OpenCodeClientUITests/OpenCodeClientUITests.swift
@@ -38,6 +38,30 @@ final class OpenCodeClientUITests: XCTestCase {
     }
 
     @MainActor
+    func testSettingsShowsThreeSpeechStrategiesAndRealtimePrompt() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 8))
+        XCTAssertGreaterThan(tabBar.buttons.count, 0)
+        tabBar.buttons.element(boundBy: tabBar.buttons.count - 1).tap()
+
+        let picker = app.descendants(matching: .any)["settings-recording-strategy"]
+        for _ in 0..<5 where !picker.exists {
+            app.swipeUp()
+        }
+        XCTAssertTrue(picker.waitForExistence(timeout: 4))
+        picker.tap()
+        XCTAssertTrue(app.buttons["GPT Realtime"].exists)
+        XCTAssertTrue(app.buttons["GPT Live Transcribe"].exists)
+        XCTAssertTrue(app.buttons["Grok STT"].exists)
+
+        app.buttons["GPT Live Transcribe"].tap()
+        XCTAssertTrue(app.descendants(matching: .any)["settings-custom-prompt"].exists)
+    }
+
+    @MainActor
     func testChatComposerLongInputRemainsScrollable() throws {
         let app = XCUIApplication()
         app.launch()

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,10 +4,19 @@
 
 ## 当前状态
 
-- **最后更新**：2026-07-30
-- **分支**：`feat/dual-recording-strategies`
-- **编译/测试**：iPhone 16 build 通过；OpenCodeClientTests 中 speech/strategy 相关测试通过；已知无关失败：`LayoutConstantsTests.splitViewFractions`、`CarModeFlowTests.carSessionContextSeparatesHostsAndWorkspaces`
-- **Phase**：OpenAI Realtime / Grok Batch 双录音策略 + VoiceFlowKit exact `0.3.0`
+- **最后更新**：2026-07-31
+- **分支**：`feat/gpt-live-transcribe`
+- **编译/测试**：GPT Live host changes are implemented and VoiceFlowKit is pinned to feature commit `2be5dfa2925c451102aa9797bd35be757c9205bf`; full build and tests are the next gate. Existing unrelated failures remain `LayoutConstantsTests.splitViewFractions` and `CarModeFlowTests.carSessionContextSeparatesHostsAndWorkspaces`.
+- **Phase**：GPT Realtime / GPT Live Transcribe / Grok STT host integration; pinned to VoiceFlowKit PR 1 commit, awaiting exact `0.4.0` before merge
+
+### 2026-07-31 — GPT Live Transcribe host integration
+
+- Settings now persists and displays the third `gptLiveTranscribe` strategy in a menu. Both GPT strategies use realtime transport and expose the custom prompt; the default and existing raw values remain unchanged.
+- Chat and Car snapshot strategy at Start and pass it into strategy-aware Kit sessions. Preserved retries route through the handle's originating strategy, while file retries keep their captured strategy.
+- Realtime audio chunks now pass through one bounded ordered sender per capture; Stop/Cancel drains that worker before commit or preservation. Realtime finalization failures retain recoverable audio.
+- Chat pending audio is keyed by its originating OpenCode session, and every start/finalization/retry callback is gated by attempt plus session ownership. A session switch now detaches an in-flight finalization without revoking ownership: success persists the completed transcript to the source session draft while leaving the destination composer unchanged, and failure preserves source-owned audio. The navigation snapshot is synchronous so it cannot overwrite a just-completed source transcript; background/explicit cancellation still aborts and preserves. Car uses a generation gate so New Session invalidates old permission, microphone, transcript, and request continuations without carrying old audio into the new session.
+- Car retry state now distinguishes transcription retry from OpenCode request retry, so a transcription failure cannot resend the previous `carLastTranscript`.
+- Validation: strict Swift 6 standalone runtime checks pass for source/destination draft routing, session-switch detach versus cancellation preservation, and ordered sender order/capacity/drain. Deterministic app tests cover switch-at-finalize completion and destination-draft isolation. The Xcode package reference now pins VoiceFlowKit PR 1 commit `2be5dfa2925c451102aa9797bd35be757c9205bf`. Follow-up: replace that revision with exact `0.4.0` after Kit release and rerun build, focused speech/Car tests, full tests, UI tests, and visionOS build sequentially.
 
 ### 2026-07-30 — Pin VoiceFlowKit 0.3.0
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -6,12 +6,13 @@
 
 - **最后更新**：2026-07-31
 - **分支**：`feat/gpt-live-transcribe`
-- **编译/测试**：GPT Live host changes are implemented and VoiceFlowKit is pinned to feature commit `2be5dfa2925c451102aa9797bd35be757c9205bf`; full build and tests are the next gate. Existing unrelated failures remain `LayoutConstantsTests.splitViewFractions` and `CarModeFlowTests.carSessionContextSeparatesHostsAndWorkspaces`.
+- **编译/测试**：VoiceFlowKit is pinned to feature commit `1f4859913773020504d6fe237168b32a8e4eaa5d`. iOS Simulator build passed; the two speech suites passed 26/26. The full suite still has unrelated `LayoutConstantsTests.splitViewFractions` and `ToolCardsUITests.testToolCardsFixtureRendersFileCardsAndMergedToolCalls` failures.
 - **Phase**：GPT Realtime / GPT Live Transcribe / Grok STT host integration; pinned to VoiceFlowKit PR 1 commit, awaiting exact `0.4.0` before merge
 
 ### 2026-07-31 — GPT Live Transcribe host integration
 
-- Settings now persists and displays the third `gptLiveTranscribe` strategy in a menu. Both GPT strategies use realtime transport and expose the custom prompt; the default and existing raw values remain unchanged.
+- New installations default to GPT Live Transcribe without overwriting a valid saved strategy. Chat now renders the Kit's accumulated GPT Live snapshots directly in the composer during recording; GPT Realtime remains finalize-only. The Kit pin advances to `1f4859913773020504d6fe237168b32a8e4eaa5d` for the recording-time snapshot contract.
+- Settings now persists and displays the third `gptLiveTranscribe` strategy in a menu. Both GPT strategies use realtime transport and expose the custom prompt; existing valid saved values remain unchanged.
 - Chat and Car snapshot strategy at Start and pass it into strategy-aware Kit sessions. Preserved retries route through the handle's originating strategy, while file retries keep their captured strategy.
 - Realtime audio chunks now pass through one bounded ordered sender per capture; Stop/Cancel drains that worker before commit or preservation. Realtime finalization failures retain recoverable audio.
 - Chat pending audio is keyed by its originating OpenCode session, and every start/finalization/retry callback is gated by attempt plus session ownership. A session switch now detaches an in-flight finalization without revoking ownership: success persists the completed transcript to the source session draft while leaving the destination composer unchanged, and failure preserves source-owned audio. The navigation snapshot is synchronous so it cannot overwrite a just-completed source transcript; background/explicit cancellation still aborts and preserves. Car uses a generation gate so New Session invalidates old permission, microphone, transcript, and request continuations without carrying old audio into the new session.


### PR DESCRIPTION
## Summary
- add GPT Live Transcribe to Speech Recognition settings while keeping GPT Realtime as the default
- use ordered bounded PCM delivery and drain before commit in Chat and Car Mode
- preserve source-session ownership, recoverable audio, and originating strategy across navigation/retry
- prevent stale Chat writes and duplicate Car submissions
- pin VoiceFlowKit feature commit `2be5dfa2925c451102aa9797bd35be757c9205bf`

## Dependency
Depends on grapeot/voiceflow#66. Replace the commit pin with exact VoiceFlowKit `0.4.0` after that PR is reviewed and released, before merging this PR.

## Tests
- iOS Simulator build succeeded
- full `OpenCodeClientTests` ran 370 tests; all new speech/Car tests passed
- existing unrelated failures remain in `LayoutConstantsTests.splitViewFractions` and the live `ReadToolCardIntegrationTests` fixture

## Remaining gates
- UI test pass
- physical-device microphone/TTS route validation
- visionOS build

This PR should remain unmerged for now.