### PR TITLE
fix(sessions): align SSE updates with project scope

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
@@ -84,9 +84,12 @@ extension AppState {
                JSONSerialization.isValidJSONObject(infoObj),
                let data = try? JSONSerialization.data(withJSONObject: infoObj),
                let session = try? JSONDecoder().decode(Session.self, from: data) {
-                let dir = effectiveProjectDirectory
+                let dir = effectiveProjectDirectory ?? serverCurrentProjectWorktree
                 let isCurrent = (session.id == currentSessionID)
-                let matchesProject = dir == nil || session.directory == dir
+                let isKnown = sessions.contains(where: { $0.id == session.id })
+                // REST treats a missing directory as the server's current project,
+                // while /global/event carries updates from every project.
+                let matchesProject = dir.map { session.directory == $0 } ?? isKnown
                 let shouldApply = matchesProject || isCurrent
                 if shouldApply {
                     if sessions.first(where: { $0.id == session.id }) == session { return }

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -3885,6 +3885,34 @@ struct AppStateFlowTests {
         #expect(state.sessions.first?.title == "Current")
     }
 
+    @Test @MainActor func sessionUpdatedUsesServerDefaultProjectScope() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.selectedProjectWorktree = nil
+        state.serverCurrentProjectWorktree = "/project/a"
+        state.sessions = [Self.makeSession(id: "s-current", updated: 10, directory: "/project/a", title: "Current")]
+
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"session.updated","properties":{"session":{"id":"s-other","slug":"s-other","projectID":"p1","directory":"/project/b","parentID":null,"title":"Other","version":"1","time":{"created":0,"updated":20},"share":null,"summary":null}}}}
+        """))
+
+        #expect(state.sessions.map(\.id) == ["s-current"])
+    }
+
+    @Test @MainActor func sessionUpdatedDoesNotInsertUnknownProjectBeforeDefaultLoads() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.selectedProjectWorktree = nil
+        state.serverCurrentProjectWorktree = nil
+        state.sessions = [Self.makeSession(id: "s-known", updated: 10, directory: "/project/a", title: "Known")]
+
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"session.updated","properties":{"session":{"id":"s-other","slug":"s-other","projectID":"p1","directory":"/project/b","parentID":null,"title":"Other","version":"1","time":{"created":0,"updated":20},"share":null,"summary":null}}}}
+        """))
+
+        #expect(state.sessions.map(\.id) == ["s-known"])
+    }
+
     @Test @MainActor func sessionUpdatedStillAppliesToCurrentSessionAcrossProjectMismatch() async {
         let apiClient = MockAPIClient()
         let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())


### PR DESCRIPTION
## Summary
- align global SSE `session.updated` filtering with the project scope used by the REST session list
- use the server's current worktree when the UI selects Server default
- avoid inserting unknown-project sessions before `/project/current` finishes loading

## Root Cause
`GET /session` without a directory returns only the server-default project, while `/global/event` emits updates for every project. The client treated a nil selected directory as all projects, so foreign sessions appeared through SSE and disappeared on the next REST refresh.

## Verification
- generic iOS Simulator build succeeded
- both new session-scope regression tests passed
- full test run reached two unrelated shared-state failures; both passed on focused rerun alongside the new tests
- `git diff --check`
