### PR TITLE
Keep GPT Live recording across previews and tabs

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -879,9 +879,6 @@ struct ChatTabView: View {
                 guard newPhase == .background else { return }
                 Task { await stopSpeechForBackground() }
             }
-            .onDisappear {
-                Task { await stopSpeechForBackground() }
-            }
         }
     }
 

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -1352,9 +1352,9 @@ struct LocalizationTests {
 struct LayoutConstantsTests {
     
     @Test func splitViewFractions() {
-        #expect(LayoutConstants.SplitView.sidebarWidthFraction == 1.0 / 6.0)
-        #expect(LayoutConstants.SplitView.previewWidthFraction == 5.0 / 12.0)
-        #expect(LayoutConstants.SplitView.chatWidthFraction == 5.0 / 12.0)
+        #expect(LayoutConstants.SplitView.sidebarWidthFraction == CGFloat(1) / CGFloat(6))
+        #expect(LayoutConstants.SplitView.previewWidthFraction == CGFloat(5) / CGFloat(12))
+        #expect(LayoutConstants.SplitView.chatWidthFraction == CGFloat(5) / CGFloat(12))
     }
     
     @Test func splitViewFractionsSum() {


### PR DESCRIPTION
## Summary
- keep chat speech capture alive when the Chat tab temporarily disappears behind file previews or another tab
- continue stopping capture when the app enters the iOS background
- fix the split-view fraction assertions to compare native CGFloat values

## Validation
- iPhone 16 / iOS 18.4 simulator build passed
- 372 deterministic unit tests passed (live-server ReadToolCardIntegrationTests excluded)
- the live-server read-card test was run separately and is currently nondeterministic against the active server