### PR TITLE
fix(send): deterministic message ids + inline send-failure visibility

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+CarMode.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+CarMode.swift
@@ -103,7 +103,7 @@ extension AppState {
         }
 
         guard canCreateSession else { throw CarModeError.selectedProjectUnsupported }
-        let session = try await apiClient.createSession(title: "Car Mode")
+        let session = try await apiClient.createSession(title: "Car Mode", directory: nil)
         carSessionsByContext[carContextKey] = CarSessionRecord(
             sessionID: session.id,
             lastHandledAssistantMessageID: nil,

--- a/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
@@ -8,10 +8,14 @@ import os
 ///
 /// State lives on `MessageStore`; this extension only orchestrates.
 extension AppState {
-    nonisolated static func visibleMessages(_ messages: [MessageWithParts], revertMessageID: String?) -> [MessageWithParts] {
+    nonisolated static func visibleMessages(
+        _ messages: [MessageWithParts],
+        revertMessageID: String?,
+        pendingIDs: Set<String> = []
+    ) -> [MessageWithParts] {
         guard let revertMessageID else { return messages }
         return messages.filter { message in
-            message.info.id.hasPrefix("temp-") || message.info.id < revertMessageID
+            pendingIDs.contains(message.info.id) || message.info.id.hasPrefix("temp-") || message.info.id < revertMessageID
         }
     }
 
@@ -30,48 +34,13 @@ extension AppState {
             hasMoreHistoryBySessionID[sessionID] = loaded.count >= fetchLimit
 
             let loadedMessageIDs = Set(loaded.map { $0.info.id })
-            let keepPending = isBusySession(currentSessionStatus)
-            let pendingMessages: [MessageWithParts] = {
-                guard keepPending else { return [] }
-                let pending = messages.filter({ $0.info.id.hasPrefix("temp-user-") })
-                guard let lastLoadedUser = loaded.last(where: { $0.info.isUser }) else { return pending }
-
-                func normalizeEpochMs(_ raw: Int) -> Int {
-                    // Server timestamps may be seconds or milliseconds.
-                    if raw > 0 && raw < 10_000_000_000 { return raw * 1000 }
-                    return raw
-                }
-
-                func normalizeComparableText(_ raw: String) -> String {
-                    raw
-                        .components(separatedBy: .whitespacesAndNewlines)
-                        .filter { !$0.isEmpty }
-                        .joined(separator: " ")
-                }
-
-                let lastLoadedText = normalizeComparableText(
-                    lastLoadedUser.parts.first(where: { $0.isText })?.text ?? ""
-                )
-                let lastLoadedCreated = normalizeEpochMs(lastLoadedUser.info.time.created)
-
-                return pending.filter { m in
-                    guard m.info.isUser else { return true }
-                    let text = normalizeComparableText(
-                        m.parts.first(where: { $0.isText })?.text ?? ""
-                    )
-                    guard !text.isEmpty else { return true }
-                    let textMatches = text == lastLoadedText || lastLoadedText.hasSuffix(text)
-
-                    let created = normalizeEpochMs(m.info.time.created)
-                    let timestampClose: Bool = {
-                        if created == 0 || lastLoadedCreated == 0 { return true }
-                        return abs(lastLoadedCreated - created) <= 60 * 1000
-                    }()
-
-                    if textMatches || timestampClose { return false }
-                    return true
-                }
-            }()
+            // Optimistic rows carry the same deterministic msg_ id the server
+            // persists, so reconciliation is pure id membership: rows whose id
+            // has not appeared server-side yet stay visible, confirmed ids drop
+            // out of the pending set, and the merge below dedupes by id.
+            let pendingMessages = messages.filter { messageStore.isPendingOptimisticMessage($0.info.id) }
+            messageStore.untrackPendingOptimisticMessages(loadedMessageIDs)
+            messageStore.pruneSendFailures(loadedMessageIDs: loadedMessageIDs)
 
             let draftMessages = messages.filter {
                 messageStore.isStreamingDraftMessage($0.info.id) && !loadedMessageIDs.contains($0.info.id)
@@ -201,8 +170,11 @@ extension AppState {
             return true
         } catch {
             let recovered = await recoverFromMissingCurrentSessionIfNeeded(error: error, requestedSessionID: sessionID)
-            sendError = recovered ? L10n.t(.errorSessionNotFound) : error.localizedDescription
-            removeMessage(id: tempMessageID)
+            // Keep the optimistic row and surface the failure inline under it
+            // (no modal alert); the text stays available for copy & resend.
+            let reason = recovered ? L10n.t(.errorSessionNotFound) : error.localizedDescription
+            messageStore.markSendFailed(messageID: tempMessageID, reason: reason)
+            messageStore.untrackPendingOptimisticMessages([tempMessageID])
             return false
         }
     }
@@ -296,11 +268,14 @@ extension AppState {
         let row = MessageWithParts(info: message, parts: parts)
         messages.append(row)
         partsByMessage[messageID] = parts
+        messageStore.trackPendingOptimisticMessage(messageID)
         return messageID
     }
 
     func removeMessage(id: String) {
         messages.removeAll { $0.info.id == id }
         partsByMessage[id] = nil
+        messageStore.untrackPendingOptimisticMessages([id])
+        messageStore.clearSendFailure(messageID: id)
     }
 }

--- a/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Messages.swift
@@ -184,11 +184,20 @@ extension AppState {
             return false
         }
 
-        let tempMessageID = appendOptimisticUserMessage(text, attachments: attachments)
+        let messageID = Self.makeServerID(prefix: "msg")
+        let tempMessageID = appendOptimisticUserMessage(text, attachments: attachments, messageID: messageID)
         let model = selectedModel.map { Message.ModelInfo(providerID: $0.providerID, modelID: $0.modelID) }
         let agentName = selectedAgent?.name ?? "build"
         do {
-            try await apiClient.promptAsync(sessionID: sessionID, text: text, attachments: attachments, agent: agentName, model: model)
+            try await apiClient.promptAsync(
+                sessionID: sessionID,
+                messageID: messageID,
+                text: text,
+                attachments: attachments,
+                agent: agentName,
+                model: model,
+                directory: currentSession?.directory ?? effectiveProjectDirectory
+            )
             return true
         } catch {
             let recovered = await recoverFromMissingCurrentSessionIfNeeded(error: error, requestedSessionID: sessionID)
@@ -229,11 +238,15 @@ extension AppState {
             .joined(separator: "\n\n")
     }
 
+    nonisolated static func makeServerID(prefix: String) -> String {
+        "\(prefix)_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+    }
+
     @discardableResult
-    func appendOptimisticUserMessage(_ text: String, attachments: [ComposerImageAttachment] = []) -> String {
+    func appendOptimisticUserMessage(_ text: String, attachments: [ComposerImageAttachment] = [], messageID: String? = nil) -> String {
         guard let sessionID = currentSessionID else { return "" }
         let now = Int(Date().timeIntervalSince1970 * 1000)
-        let messageID = "temp-user-\(UUID().uuidString)"
+        let messageID = messageID ?? "temp-user-\(UUID().uuidString)"
         let message = Message(
             id: messageID,
             sessionID: sessionID,

--- a/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
@@ -147,9 +147,45 @@ extension AppState {
                let decoded = try? JSONDecoder().decode([TodoItem].self, from: todosData) {
                 sessionTodos[sessionID] = decoded
             }
+        case "session.error":
+            let eventSessionID = props["sessionID"]?.value as? String
+            if Self.shouldProcessMessageEvent(eventSessionID: eventSessionID, currentSessionID: currentSessionID) {
+                // prompt_async acknowledges with 204 before the turn runs, so
+                // an async failure only surfaces through this event. Mark the
+                // still-pending optimistic row as failed (inline banner, no
+                // alert) and reconcile; turns that already persisted an
+                // assistant row surface their error through that row instead.
+                let reason = Self.sessionErrorDisplayReason(properties: props)
+                if let pendingID = messageStore.pendingOptimisticMessageIDs.min() {
+                    messageStore.markSendFailed(messageID: pendingID, reason: reason)
+                    messageStore.untrackPendingOptimisticMessages([pendingID])
+                }
+                await loadMessages()
+            }
         default:
             break
         }
+    }
+
+    /// Builds a short inline-banner reason from a session.error payload
+    /// (`error: {name, data}`). Server causes can be long multi-line dumps;
+    /// keep the first meaningful line, bounded.
+    nonisolated static func sessionErrorDisplayReason(properties: [String: AnyCodable]) -> String {
+        let fallback = L10n.t(.errorOperationFailed)
+        guard let errorObject = properties["error"]?.value as? [String: Any],
+              JSONSerialization.isValidJSONObject(errorObject),
+              let jsonData = try? JSONSerialization.data(withJSONObject: errorObject),
+              let decoded = try? JSONDecoder().decode(Message.MessageError.self, from: jsonData) else {
+            return fallback
+        }
+        let raw = decoded.message ?? decoded.name
+        let firstLine = raw
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first(where: { !$0.isEmpty }) ?? raw
+        let prefix = decoded.name.isEmpty ? "" : "\(decoded.name): "
+        let text = prefix + firstLine
+        return String(text.prefix(300))
     }
 
     func updateSessionActivity(sessionID: String, previous: SessionStatus?, current: SessionStatus) {

--- a/OpenCodeClient/OpenCodeClient/AppState+Sessions.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Sessions.swift
@@ -294,7 +294,7 @@ extension AppState {
         sessionLoadingID = loadingID
 
         do {
-            let session = try await apiClient.createSession(title: nil)
+            let session = try await apiClient.createSession(title: nil, directory: effectiveProjectDirectory)
             guard sessionLoadingID == loadingID else { return }
 
             Self.logger.debug("createSession: created id=\(session.id, privacy: .public) directory=\(session.directory, privacy: .public) effectiveProjectDir=\(self.effectiveProjectDirectory ?? "nil", privacy: .public)")

--- a/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/APIClient.swift
@@ -161,10 +161,16 @@ actor APIClient {
         return try JSONDecoder().decode(MessageWithParts.self, from: responseData)
     }
 
-    func createSession(title: String? = nil) async throws -> Session {
+    func createSession(title: String? = nil, directory: String? = nil) async throws -> Session {
         let body = title.map { ["title": $0] } ?? [:]
         let data = try JSONEncoder().encode(body)
-        let (responseData, _) = try await makeRequest(path: "/session", method: "POST", body: data)
+        let queryItems = directory.map { [URLQueryItem(name: "directory", value: $0)] }
+        let (responseData, _) = try await makeRequest(
+            path: "/session",
+            method: "POST",
+            queryItems: queryItems,
+            body: data
+        )
         return try JSONDecoder().decode(Session.self, from: responseData)
     }
 
@@ -302,8 +308,17 @@ actor APIClient {
         return try? decoder.decode(type, from: data)
     }
 
-    func promptAsync(sessionID: String, text: String, attachments: [ComposerImageAttachment] = [], agent: String = "build", model: Message.ModelInfo?) async throws {
+    func promptAsync(
+        sessionID: String,
+        messageID: String,
+        text: String,
+        attachments: [ComposerImageAttachment] = [],
+        agent: String = "build",
+        model: Message.ModelInfo?,
+        directory: String?
+    ) async throws {
         struct PromptBody: Encodable {
+            let messageID: String
             let parts: [PartInput]
             let agent: String
             let model: ModelInput?
@@ -334,12 +349,19 @@ actor APIClient {
         }
         parts.append(contentsOf: attachments.map { .file($0) })
         let body = PromptBody(
+            messageID: messageID,
             parts: parts,
             agent: agent,
             model: model.map { .init(providerID: $0.providerID, modelID: $0.modelID) }
         )
         let bodyData = try JSONEncoder().encode(body)
-        let (_, response) = try await makeRequest(path: "/session/\(sessionID)/prompt_async", method: "POST", body: bodyData)
+        let queryItems = directory.map { [URLQueryItem(name: "directory", value: $0)] }
+        let (_, response) = try await makeRequest(
+            path: "/session/\(sessionID)/prompt_async",
+            method: "POST",
+            queryItems: queryItems,
+            body: bodyData
+        )
         if let http = response as? HTTPURLResponse, http.statusCode != 204 {
             throw APIError.httpError(statusCode: http.statusCode, data: Data())
         }
@@ -723,12 +745,12 @@ protocol APIClientProtocol: Actor {
     func projectCurrent() async throws -> Project?
     func sessions(directory: String?, limit: Int) async throws -> [Session]
     func session(sessionID: String) async throws -> Session
-    func createSession(title: String?) async throws -> Session
+    func createSession(title: String?, directory: String?) async throws -> Session
     func updateSession(sessionID: String, title: String) async throws -> Session
     func updateSessionArchived(sessionID: String, archived: Int) async throws -> Session
     func deleteSession(sessionID: String) async throws
     func messages(sessionID: String, limit: Int?) async throws -> [MessageWithParts]
-    func promptAsync(sessionID: String, text: String, attachments: [ComposerImageAttachment], agent: String, model: Message.ModelInfo?) async throws
+    func promptAsync(sessionID: String, messageID: String, text: String, attachments: [ComposerImageAttachment], agent: String, model: Message.ModelInfo?, directory: String?) async throws
     func promptStructured(sessionID: String, messageID: String?, text: String, system: String, format: StructuredOutputFormat, agent: String, model: Message.ModelInfo) async throws -> MessageWithParts
     func abort(sessionID: String) async throws
     func sessionStatus() async throws -> [String: SessionStatus]

--- a/OpenCodeClient/OpenCodeClient/Stores/MessageStore.swift
+++ b/OpenCodeClient/OpenCodeClient/Stores/MessageStore.swift
@@ -20,6 +20,39 @@ final class MessageStore {
     var streamingPartTexts: [String: String] = [:]
     var streamingReasoningPart: Part? = nil
     private var streamingDraftMessageIDs: Set<String> = []
+    /// Optimistic user rows whose server confirmation has not been observed yet.
+    /// Rows are keyed by the deterministic `msg_` id sent with the prompt, so
+    /// reconciliation against server data is pure id membership.
+    var pendingOptimisticMessageIDs: Set<String> = []
+    /// Send failures surfaced inline under the affected user row (no alert).
+    /// Keyed by message id; cleared when the row is confirmed or removed.
+    var failedSendReasonsByID: [String: String] = [:]
+
+    func isPendingOptimisticMessage(_ messageID: String) -> Bool {
+        pendingOptimisticMessageIDs.contains(messageID)
+    }
+
+    func trackPendingOptimisticMessage(_ messageID: String) {
+        pendingOptimisticMessageIDs.insert(messageID)
+    }
+
+    func untrackPendingOptimisticMessages(_ messageIDs: Set<String>) {
+        pendingOptimisticMessageIDs.subtract(messageIDs)
+    }
+
+    func markSendFailed(messageID: String, reason: String) {
+        failedSendReasonsByID[messageID] = reason
+    }
+
+    func clearSendFailure(messageID: String) {
+        failedSendReasonsByID.removeValue(forKey: messageID)
+    }
+
+    func pruneSendFailures(loadedMessageIDs: Set<String>) {
+        for id in failedSendReasonsByID.keys where loadedMessageIDs.contains(id) {
+            failedSendReasonsByID.removeValue(forKey: id)
+        }
+    }
 
     var hasActiveStreaming: Bool {
         streamingReasoningPart != nil || !streamingPartTexts.isEmpty || !streamingDraftMessageIDs.isEmpty

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -312,7 +312,8 @@ struct ChatTabView: View {
     private var messageGroups: [MessageGroupItem] {
         let visibleMessages = AppState.visibleMessages(
             state.messages,
-            revertMessageID: state.currentSession?.revert?.messageID
+            revertMessageID: state.currentSession?.revert?.messageID,
+            pendingIDs: state.messageStore.pendingOptimisticMessageIDs
         )
         var result: [MessageGroupItem] = []
         var i = 0

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -440,6 +440,21 @@ struct MessageRowView: View {
             .background(DesignColors.Brand.primary.opacity(DesignColors.userMessageFill(for: colorScheme)))
             .clipShape(RoundedRectangle(cornerRadius: DesignCorners.large))
 
+            // Inline send-failure banner (async session.error or failed HTTP
+            // send): subtle, non-modal, attached to the affected row. The row's
+            // text stays available for copy & manual resend.
+            if let failureReason = state.messageStore.failedSendReasonsByID[message.info.id] {
+                Text(failureReason)
+                    .font(.caption)
+                    .foregroundStyle(DesignColors.Semantic.error)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(DesignColors.Semantic.error.opacity(DesignColors.surfaceFill(for: colorScheme)))
+                    .clipShape(RoundedRectangle(cornerRadius: DesignCorners.medium))
+                    .textSelection(.enabled)
+            }
+
             HStack {
                 // User messages don't carry a model line — the model belongs to
                 // the assistant's reply, not to what the human said.

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -4028,7 +4028,7 @@ struct AppStateFlowTests {
         #expect(state.currentSessionID == "created")
     }
 
-    @Test @MainActor func sendMessageRollsBackOptimisticMessageOnFailure() async {
+    @Test @MainActor func sendMessageKeepsOptimisticRowAndMarksSendFailureInlineOnFailure() async {
         let apiClient = MockAPIClient()
         await apiClient.setPromptError(APIError.invalidURL)
         let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
@@ -4037,8 +4037,29 @@ struct AppStateFlowTests {
         let succeeded = await state.sendMessage("hello")
 
         #expect(succeeded == false)
-        #expect(state.messages.isEmpty)
-        #expect(state.sendError?.isEmpty == false)
+        // Row is retained with an inline failure banner; no modal alert.
+        #expect(state.messages.count == 1)
+        #expect(state.messages.first?.info.isUser == true)
+        #expect(state.sendError == nil)
+        let failedID = state.messages.first!.info.id
+        #expect(state.messageStore.failedSendReasonsByID[failedID]?.isEmpty == false)
+        #expect(state.messageStore.pendingOptimisticMessageIDs.contains(failedID) == false)
+    }
+
+    @Test @MainActor func sendMessageUsesDeterministicMessageIDSharedWithServer() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.currentSessionID = "s1"
+
+        _ = await state.sendMessage("hello")
+
+        let sentMessageIDs = await apiClient.promptAsyncMessageIDs
+        #expect(sentMessageIDs.count == 1)
+        #expect(sentMessageIDs[0].hasPrefix("msg_"))
+        // The optimistic row carries the exact id sent to the server, so
+        // reconciliation is pure id membership (no text/timestamp heuristics).
+        #expect(state.messages.first?.info.id == sentMessageIDs[0])
+        #expect(state.messageStore.pendingOptimisticMessageIDs == Set(sentMessageIDs))
     }
 
     @Test @MainActor func loadMessagesStoresFetchedRowsAndParts() async {
@@ -4190,38 +4211,12 @@ struct AppStateFlowTests {
         #expect(state.hasMoreHistoryBySessionID["s1"] == false)
     }
 
-    @Test @MainActor func loadMessagesDedupesOptimisticUserRowWhenPersistedTextNormalizesWhitespace() async {
+    @Test @MainActor func loadMessagesReplacesOptimisticRowWhenServerConfirmsSameMessageID() async {
         let apiClient = MockAPIClient()
         let now = Int(Date().timeIntervalSince1970 * 1000)
         await apiClient.setMessagesResult([
             Self.makeMessageRow(
-                messageID: "m-user",
-                sessionID: "s1",
-                role: "user",
-                text: "hello world",
-                created: now,
-                completed: now
-            ),
-            Self.makeMessageRow(messageID: "m-assistant", sessionID: "s1", text: "reply")
-        ])
-        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
-        state.currentSessionID = "s1"
-        state.sessionStatuses["s1"] = SessionStatus(type: "busy", attempt: nil, message: nil, next: nil)
-
-        let tempMessageID = state.appendOptimisticUserMessage("hello\n\nworld")
-        await state.loadMessages()
-
-        #expect(state.messages.map(\.info.id) == ["m-user", "m-assistant"])
-        #expect(state.messages.contains(where: { $0.info.id == tempMessageID }) == false)
-        #expect(state.partsByMessage[tempMessageID] == nil)
-    }
-
-    @Test @MainActor func loadMessagesDedupesOptimisticUserRowWhenServerPrependsPluginPrefix() async {
-        let apiClient = MockAPIClient()
-        let now = Int(Date().timeIntervalSince1970 * 1000)
-        await apiClient.setMessagesResult([
-            Self.makeMessageRow(
-                messageID: "m-user",
+                messageID: "msg_shared",
                 sessionID: "s1",
                 role: "user",
                 text: "[analyze-mode]\nANALYSIS MODE. Gather context.\n---\nhello world",
@@ -4232,40 +4227,89 @@ struct AppStateFlowTests {
         ])
         let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
         state.currentSessionID = "s1"
-        state.sessionStatuses["s1"] = SessionStatus(type: "busy", attempt: nil, message: nil, next: nil)
 
-        let tempMessageID = state.appendOptimisticUserMessage("hello world")
+        // Server-side text rewrites (plugin prefixes, whitespace) are
+        // irrelevant: the optimistic row sent msg_shared and the server
+        // persisted it under the same id.
+        _ = state.appendOptimisticUserMessage("hello world", messageID: "msg_shared")
         await state.loadMessages()
 
-        #expect(state.messages.map(\.info.id) == ["m-user", "m-assistant"])
-        #expect(state.messages.contains(where: { $0.info.id == tempMessageID }) == false)
-        #expect(state.partsByMessage[tempMessageID] == nil)
+        #expect(state.messages.map(\.info.id) == ["msg_shared", "m-assistant"])
+        #expect(state.messageStore.pendingOptimisticMessageIDs.isEmpty)
+        #expect(state.partsByMessage["msg_shared"]?.first?.text?.contains("analyze-mode") == true)
     }
 
-    @Test @MainActor func loadMessagesDedupesOptimisticUserRowByTimestampAlone() async {
+    @Test @MainActor func loadMessagesKeepsOptimisticRowUntilServerRowArrives() async {
         let apiClient = MockAPIClient()
-        let now = Int(Date().timeIntervalSince1970 * 1000)
         await apiClient.setMessagesResult([
-            Self.makeMessageRow(
-                messageID: "m-user",
-                sessionID: "s1",
-                role: "user",
-                text: "different user message",
-                created: now,
-                completed: now
-            ),
-            Self.makeMessageRow(messageID: "m-assistant", sessionID: "s1", text: "reply")
+            Self.makeMessageRow(messageID: "m-assistant", sessionID: "s1", text: "older reply")
         ])
         let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
         state.currentSessionID = "s1"
-        state.sessionStatuses["s1"] = SessionStatus(type: "busy", attempt: nil, message: nil, next: nil)
+        // Idle session: with deterministic ids the pending row survives until
+        // its id shows up server-side, regardless of session busy state.
+        state.sessionStatuses["s1"] = SessionStatus(type: "idle", attempt: nil, message: nil, next: nil)
 
-        let tempMessageID = state.appendOptimisticUserMessage("original user text")
+        _ = state.appendOptimisticUserMessage("still in flight", messageID: "msg_pending")
         await state.loadMessages()
 
-        #expect(state.messages.map(\.info.id) == ["m-user", "m-assistant"])
-        #expect(state.messages.contains(where: { $0.info.id == tempMessageID }) == false)
-        #expect(state.partsByMessage[tempMessageID] == nil)
+        #expect(state.messages.map(\.info.id) == ["m-assistant", "msg_pending"])
+        #expect(state.messageStore.pendingOptimisticMessageIDs == ["msg_pending"])
+    }
+
+    @Test @MainActor func sessionErrorMarksPendingOptimisticRowAsFailedInline() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.currentSessionID = "s1"
+
+        let pendingID = state.appendOptimisticUserMessage("hello", messageID: "msg_pending")
+
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"session.error","properties":{"sessionID":"s1","error":{"name":"UnknownError","data":{"message":"Error: boom\\nCaused by: stack trace line 2"}}}}}
+        """))
+
+        // Inline banner under the row; reason is the first meaningful line,
+        // prefixed with the error name. No modal alert, no row removal.
+        #expect(state.messageStore.failedSendReasonsByID[pendingID] == "UnknownError: Error: boom")
+        #expect(state.messageStore.pendingOptimisticMessageIDs.isEmpty)
+        #expect(state.messages.contains(where: { $0.info.id == pendingID }))
+        #expect(state.sendError == nil)
+        #expect(await apiClient.messagesCallCount == 1)
+    }
+
+    @Test @MainActor func sessionErrorIgnoresOtherSessions() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.currentSessionID = "s1"
+        let pendingID = state.appendOptimisticUserMessage("hello", messageID: "msg_pending")
+
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"session.error","properties":{"sessionID":"s2","error":{"name":"UnknownError","data":{"message":"boom"}}}}}
+        """))
+
+        #expect(state.messageStore.failedSendReasonsByID[pendingID] == nil)
+        #expect(state.messageStore.pendingOptimisticMessageIDs == [pendingID])
+        #expect(await apiClient.messagesCallCount == 0)
+    }
+
+    @Test @MainActor func sessionErrorWithoutPendingRowStillReloads() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.currentSessionID = "s1"
+
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"session.error","properties":{"sessionID":"s1","error":{"name":"APIError","data":{"message":"provider down"}}}}}
+        """))
+
+        // No optimistic row to mark; the reload surfaces assistant-row errors.
+        #expect(state.messageStore.failedSendReasonsByID.isEmpty)
+        #expect(await apiClient.messagesCallCount == 1)
+    }
+
+    @Test @MainActor func sessionErrorReasonFallsBackWhenUndecodable() async {
+        let props: [String: AnyCodable] = ["error": AnyCodable("not an object")]
+        let reason = AppState.sessionErrorDisplayReason(properties: props)
+        #expect(reason == L10n.t(.errorOperationFailed))
     }
 
     @Test @MainActor func messageUpdatedIgnoresOtherSession() async {

--- a/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/OpenCodeClientTests.swift
@@ -3330,7 +3330,8 @@ actor MockAPIClient: APIClientProtocol {
     var messageLimitRequests: [Int?] = []
     var messagesCallCount = 0
     var promptError: Error?
-    var promptAsyncCalls: [(String, String, [ComposerImageAttachment])] = []
+        var promptAsyncCalls: [(String, String, [ComposerImageAttachment])] = []
+        var promptAsyncMessageIDs: [String] = []
     var promptStructuredCalls: [(sessionID: String, messageID: String?, text: String, system: String, agent: String, providerID: String, modelID: String)] = []
     var promptStructuredResult: MessageWithParts?
     var promptStructuredDelayNanoseconds: UInt64 = 0
@@ -3437,7 +3438,7 @@ actor MockAPIClient: APIClientProtocol {
         if let sessionError { throw sessionError }
         return sessionResult ?? createSessionResult
     }
-    func createSession(title: String?) async throws -> Session { createSessionResult }
+    func createSession(title: String?, directory: String?) async throws -> Session { createSessionResult }
 
     func updateSession(sessionID: String, title: String) async throws -> Session {
         updateSessionCalls.append((sessionID, title))
@@ -3482,8 +3483,9 @@ actor MockAPIClient: APIClientProtocol {
         return messagesResult
     }
 
-    func promptAsync(sessionID: String, text: String, attachments: [ComposerImageAttachment], agent: String, model: Message.ModelInfo?) async throws {
+    func promptAsync(sessionID: String, messageID: String, text: String, attachments: [ComposerImageAttachment], agent: String, model: Message.ModelInfo?, directory: String?) async throws {
         promptAsyncCalls.append((sessionID, text, attachments))
+        promptAsyncMessageIDs.append(messageID)
         if let promptError { throw promptError }
     }
 

--- a/OpenCodeClient/OpenCodeClientTests/ReadToolCardIntegrationTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/ReadToolCardIntegrationTests.swift
@@ -30,15 +30,18 @@ struct ReadToolCardIntegrationTests {
 
         var createdSessionID: String?
         do {
-            let session = try await client.createSession(title: "ios-tier3-read-card")
+            let directory = env.nonEmpty("OPENCODE_DIRECTORY")
+            let session = try await client.createSession(title: "ios-tier3-read-card", directory: directory)
             let sessionID = await session.id
             createdSessionID = sessionID
 
             try await client.promptAsync(
                 sessionID: sessionID,
+                messageID: AppState.makeServerID(prefix: "msg"),
                 text: "Read the file AGENTS.md and reply with only its first line. Do not create, edit, or write any file.",
                 agent: agent,
-                model: model
+                model: model,
+                directory: directory
             )
 
             let messages = try await pollForReadToolPart(client: client, sessionID: sessionID)

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,10 +4,19 @@
 
 ## 当前状态
 
-- **最后更新**：2026-08-14
-- **分支**：`feat/glm-5.3`
-- **编译/测试**：pending
-- **Phase**：GLM 5.2 → 5.3; Gemini 3.6 Flash → 3.7 Flash; Grok 4.5 → 4.6; remove GPT-5.6 Sol Fast preset
+- **最后更新**：2026-08-24
+- **分支**：`fix/send-failure-visibility`
+- **编译/测试**：build 通过；全套 OpenCodeClientTests 通过（含 8 个新测试）
+- **Phase**：确定性 ID 发送对账 + 行内发送失败可见性（supersedes #89, closes #81）
+
+### 2026-08-24 — 确定性 messageID + 行内发送失败横幅（supersedes #89，closes #81）
+
+- **背景**：issue #81 报告 OpenCode 1.15 `prompt_async` 因缺 `messageID` 触发 `SQLITE_CONSTRAINT_NOTNULL` 静默失败。上游已修复（`input.messageID ?? MessageID.ascending()`，实测 1.18.16 接受旧 payload），但两个问题仍在：optimistic 消息双 ID 对账靠文本/时间戳启发式；异步失败（204 后 turn 崩掉）UI 无限等待、零反馈。
+- **cherry-pick PR #89（guyq1997）并适配**：`promptAsync` 带 `messageID` + `directory` query；`createSession` 补 `directory`；`makeServerID(prefix:)` 生成 `msg_<uuid>`。偏离原 PR：砍掉 `partID`——client 不消费 part id，且 `part_` 前缀不符合现 server `PartID` schema（要求 `prt`）。
+- **确定性 ID 对账**：optimistic 行直接用发送给 server 的真实 `msg_` id；`loadMessages` 删除文本归一化/plugin 前缀 hasSuffix/60s 时间窗/`keepPending` busy 门控（~34 行），改为 `MessageStore.pendingOptimisticMessageIDs` 纯 ID 成员对账；server 落库后 pending 自动收敛，失败行保留文本供复制重发。
+- **行内失败横幅（不弹窗）**：同步失败（HTTP 抛错）保留 optimistic 行 + 行内红字横幅，替代旧 `sendError` 弹窗路径；异步失败（SSE `session.error`，此前落入 `default: break` 静默丢弃）命中当前 session 时标记 pending 行失败并 `loadMessages` 对账，reason 取 error.name + 首个非空行（截断 300 字符）。assistant 行级错误仍走既有行内横幅（`errorMessageForDisplay`），互补不重复。
+- **端到端验证**：本地 origin/dev 临时 server 实测——带确定性 messageID 的 payload 落库 id 与 client 一致；无 API key 场景 server 发出 `session.error`（`ProviderAuthError`）且 wire 形状与解码一致。
+- **测试**：新增 8 个（ID 去重/保留、确定性 ID 发送、同步失败横幅、session.error 命中/他 session 过滤/无 pending 行/undecodable 回退）；3 个启发式时代测试改写为 ID 语义；rollback 测试改为"保留行 + 行内失败"语义。
 
 ### 2026-08-14 — GLM 5.3 + Gemini 3.7 Flash + Grok 4.6 model preset upgrade
 


### PR DESCRIPTION
## Summary

Makes sending failures visible and replaces the optimistic-message text/timestamp reconciliation heuristics with deterministic-id reconciliation.

Supersedes #89 (original idea and payload alignment by @guyq1997, cherry-picked with author credit preserved). Closes #81.

## What changed

**1. Deterministic message ids (from #89, adapted)**
- `promptAsync` now sends `messageID` (`msg_<uuid>`) in the body and a `directory` query param; `createSession` sends `directory` too.
- The optimistic user row carries the exact id sent to the server, so the server persists the message under the same id (server honors client-provided messageID: `input.messageID ?? MessageID.ascending()`).
- Divergence from #89: dropped `partID` / `parts[].id` — the client never consumes part ids, and the `part_` prefix is rejected by current server PartID schema (requires `prt`). Adapted the signature to master's `attachments:` support.

**2. Id-membership reconciliation (enabled by the above)**
- `loadMessages` drops ~34 lines of text-normalization / plugin-prefix `hasSuffix` / 60s timestamp-window heuristics and the `keepPending` busy gate. Optimistic rows reconcile by pure id membership via `MessageStore.pendingOptimisticMessageIDs`.

**3. Send-failure visibility (the surviving half of #81)**
- SSE `session.error` (previously falling into `default: break`, silently dropped) is now handled: errors for the current session mark the still-pending optimistic row as failed and trigger a reload. Assistant-row-level errors keep their existing inline banner; this covers the gap where a turn fails after `prompt_async` already returned 204 with no message row to hang an error on.
- Failed HTTP sends keep the optimistic row instead of removing it, and no longer raise a modal alert.
- Failures render as a subtle inline banner under the affected user row (same visual language as the assistant error banner). No modal, no retry button; the row text stays available for copy & manual resend.

## Context on #81

The original `SQLITE_CONSTRAINT_NOTNULL` crash was fixed server-side (verified against origin/dev @ 03bba464d: a payload without `messageID` is accepted and the server generates the id). This PR keeps the client-side alignment for older 1.15.x servers and fixes the part that never had a fix: silent indefinite waiting on async failure.

## Verification

- Build passes; full `OpenCodeClientTests` suite passes, including 8 new tests (id dedupe/keep, deterministic-id send, inline sync-failure, session.error hit/filter/no-pending-row/undecodable fallback).
- End-to-end against a local origin/dev server: payload with client `messageID` persisted under the same id; `session.error` (ProviderAuthError) emitted with the wire shape this PR decodes.
- Manual QA on simulator: async failure shows the assistant-row banner instead of waiting forever; sync failure (server down) shows the inline banner under the kept optimistic row; failed rows disappear after switching sessions (never persisted server-side).
