### PR TITLE
refactor: unify session-scoped caches behind one reset path

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+Drafts.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+Drafts.swift
@@ -4,6 +4,16 @@ import Foundation
 /// State fields (`draftInputsBySessionID`, `selectedModelIDBySessionID`)
 /// stay on `AppState` so SwiftUI observation works; only behavior moves.
 extension AppState {
+    func persistDraftInputs() {
+        if draftInputsBySessionID.isEmpty {
+            UserDefaults.standard.removeObject(forKey: Self.draftInputsBySessionKey)
+            return
+        }
+        if let data = try? JSONEncoder().encode(draftInputsBySessionID) {
+            UserDefaults.standard.set(data, forKey: Self.draftInputsBySessionKey)
+        }
+    }
+
     func persistSelectedModelMap() {
         if selectedModelIDBySessionID.isEmpty {
             UserDefaults.standard.removeObject(forKey: Self.selectedModelBySessionKey)
@@ -27,13 +37,6 @@ extension AppState {
         } else {
             draftInputsBySessionID[sessionID] = cleaned
         }
-
-        if draftInputsBySessionID.isEmpty {
-            UserDefaults.standard.removeObject(forKey: Self.draftInputsBySessionKey)
-            return
-        }
-        if let data = try? JSONEncoder().encode(draftInputsBySessionID) {
-            UserDefaults.standard.set(data, forKey: Self.draftInputsBySessionKey)
-        }
+        persistDraftInputs()
     }
 }

--- a/OpenCodeClient/OpenCodeClient/AppState+HostProfiles.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+HostProfiles.swift
@@ -310,9 +310,11 @@ extension AppState {
         partsByMessage = [:]
         sessionDiffs = []
         fileTreeRoot = []
-        pendingPermissions = []
         sessionStatuses = [:]
         sessionTodos = [:]
+        sessionScope.resetAll()
+        persistDraftInputs()
+        persistSelectedModelMap()
     }
 
     nonisolated static func passwordKeychainID(for profileID: UUID) -> String {

--- a/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
@@ -311,28 +311,13 @@ extension AppState {
     func clearSessionScopedCaches(sessionID: String) {
         sessionStatuses[sessionID] = nil
         sessionTodos[sessionID] = nil
-        sessionActivities[sessionID] = nil
-        sessionStatusUpdatedAt[sessionID] = nil
-        activityTextLastChangeAt[sessionID] = nil
-        activityTextPendingTask[sessionID]?.cancel()
-        activityTextPendingTask[sessionID] = nil
-        loadedMessageLimitBySessionID[sessionID] = nil
-        hasMoreHistoryBySessionID[sessionID] = nil
-        loadingOlderMessagesSessionIDs.remove(sessionID)
-        pendingPermissions.removeAll { $0.sessionID == sessionID }
+        sessionScope.remove(sessionID: sessionID)
 
         if streamingReasoningPart?.sessionID == sessionID {
             messageStore.streamingReasoningPart = nil
         }
 
-        draftInputsBySessionID[sessionID] = nil
-        if draftInputsBySessionID.isEmpty {
-            UserDefaults.standard.removeObject(forKey: Self.draftInputsBySessionKey)
-        } else if let data = try? JSONEncoder().encode(draftInputsBySessionID) {
-            UserDefaults.standard.set(data, forKey: Self.draftInputsBySessionKey)
-        }
-
-        selectedModelIDBySessionID[sessionID] = nil
+        persistDraftInputs()
         persistSelectedModelMap()
     }
 

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -270,11 +270,17 @@ final class AppState {
         }
     }
 
-    // Unsent composer drafts per session.
-    var draftInputsBySessionID: [String: String] = [:]
+    var sessionScope = SessionScopedState()
 
-    // Selected model (providerID/modelID) per session.
-    var selectedModelIDBySessionID: [String: String] = [:]
+    var draftInputsBySessionID: [String: String] {
+        get { sessionScope.draftInputs }
+        set { sessionScope.draftInputs = newValue }
+    }
+
+    var selectedModelIDBySessionID: [String: String] {
+        get { sessionScope.selectedModelIDs }
+        set { sessionScope.selectedModelIDs = newValue }
+    }
 
     var hostProfiles: [HostProfile] = [] {
         didSet { saveHostProfiles() }
@@ -395,15 +401,25 @@ final class AppState {
     var deepLinkError: String?
     var deepLinkRouteID = UUID()
 
-    // Session activity (rendered in transcript; session-scoped)
-    var sessionActivities: [String: SessionActivity] = [:]
+    var sessionActivities: [String: SessionActivity] {
+        get { sessionScope.activities }
+        set { sessionScope.activities = newValue }
+    }
 
-    // Track when a session status was last updated via SSE.
-    var sessionStatusUpdatedAt: [String: Date] = [:]
+    var sessionStatusUpdatedAt: [String: Date] {
+        get { sessionScope.statusUpdatedAt }
+        set { sessionScope.statusUpdatedAt = newValue }
+    }
 
-    // Debounce session activity text changes (avoid rapid flipping).
-    var activityTextLastChangeAt: [String: Date] = [:]
-    var activityTextPendingTask: [String: Task<Void, Never>] = [:]
+    var activityTextLastChangeAt: [String: Date] {
+        get { sessionScope.activityTextLastChangeAt }
+        set { sessionScope.activityTextLastChangeAt = newValue }
+    }
+
+    var activityTextPendingTask: [String: Task<Void, Never>] {
+        get { sessionScope.activityTextPendingTask }
+        set { sessionScope.activityTextPendingTask = newValue }
+    }
 
     var currentSessionActivity: SessionActivity? {
         guard let sid = currentSessionID else { return nil }
@@ -579,8 +595,15 @@ final class AppState {
     /// Sentinel value when user selects "Custom path" option
     static let customProjectSentinel = "__custom__"
 
-    var pendingPermissions: [PendingPermission] = []
-    var pendingQuestions: [QuestionRequest] = []
+    var pendingPermissions: [PendingPermission] {
+        get { sessionScope.pendingPermissions }
+        set { sessionScope.pendingPermissions = newValue }
+    }
+
+    var pendingQuestions: [QuestionRequest] {
+        get { sessionScope.pendingQuestions }
+        set { sessionScope.pendingQuestions = newValue }
+    }
 
     var themePreference: String = "auto"  // "auto" | "light" | "dark"
     var _languagePreference: L10n.LanguagePreference = .system
@@ -689,9 +712,20 @@ final class AppState {
 
     // WAN optimization: page message history in fixed-size message batches.
     nonisolated private static let messagePageSize = 20
-    var loadedMessageLimitBySessionID: [String: Int] = [:]
-    var hasMoreHistoryBySessionID: [String: Bool] = [:]
-    var loadingOlderMessagesSessionIDs: Set<String> = []
+    var loadedMessageLimitBySessionID: [String: Int] {
+        get { sessionScope.loadedMessageLimit }
+        set { sessionScope.loadedMessageLimit = newValue }
+    }
+
+    var hasMoreHistoryBySessionID: [String: Bool] {
+        get { sessionScope.hasMoreHistory }
+        set { sessionScope.hasMoreHistory = newValue }
+    }
+
+    var loadingOlderMessagesSessionIDs: Set<String> {
+        get { sessionScope.loadingOlderMessages }
+        set { sessionScope.loadingOlderMessages = newValue }
+    }
 
     var selectedModel: ModelPreset? {
         pickerModelPresets.indices.contains(selectedModelIndex) ? pickerModelPresets[selectedModelIndex] : nil

--- a/OpenCodeClient/OpenCodeClient/Stores/SessionScopedState.swift
+++ b/OpenCodeClient/OpenCodeClient/Stores/SessionScopedState.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct SessionScopedState {
+    var activities: [String: SessionActivity] = [:]
+    var statusUpdatedAt: [String: Date] = [:]
+    var activityTextLastChangeAt: [String: Date] = [:]
+    var activityTextPendingTask: [String: Task<Void, Never>] = [:]
+    var loadedMessageLimit: [String: Int] = [:]
+    var hasMoreHistory: [String: Bool] = [:]
+    var loadingOlderMessages: Set<String> = []
+    var draftInputs: [String: String] = [:]
+    var selectedModelIDs: [String: String] = [:]
+    var pendingPermissions: [PendingPermission] = []
+    var pendingQuestions: [QuestionRequest] = []
+
+    mutating func remove(sessionID: String) {
+        activities[sessionID] = nil
+        statusUpdatedAt[sessionID] = nil
+        activityTextLastChangeAt[sessionID] = nil
+        activityTextPendingTask[sessionID]?.cancel()
+        activityTextPendingTask[sessionID] = nil
+        loadedMessageLimit[sessionID] = nil
+        hasMoreHistory[sessionID] = nil
+        loadingOlderMessages.remove(sessionID)
+        draftInputs[sessionID] = nil
+        selectedModelIDs[sessionID] = nil
+        pendingPermissions.removeAll { $0.sessionID == sessionID }
+        pendingQuestions.removeAll { $0.sessionID == sessionID }
+    }
+
+    mutating func resetAll() {
+        activityTextPendingTask.values.forEach { $0.cancel() }
+        self = SessionScopedState()
+    }
+}

--- a/OpenCodeClient/OpenCodeClientTests/SessionScopedStateTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/SessionScopedStateTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import OpenCodeClient
+
+struct SessionScopedStateTests {
+    @Test func removeClearsEverySessionKeyedFieldIncludingQuestions() {
+        var scope = SessionScopedState()
+        scope.activities["s1"] = SessionActivity(sessionID: "s1", state: .running, text: "x", startedAt: Date())
+        scope.statusUpdatedAt["s1"] = Date()
+        scope.activityTextLastChangeAt["s1"] = Date()
+        scope.loadedMessageLimit["s1"] = 40
+        scope.hasMoreHistory["s1"] = true
+        scope.loadingOlderMessages.insert("s1")
+        scope.draftInputs["s1"] = "draft"
+        scope.selectedModelIDs["s1"] = "google/gemini-3.5-flash"
+        scope.pendingPermissions = [
+            PendingPermission(
+                sessionID: "s1",
+                permissionID: "p1",
+                permission: nil,
+                patterns: [],
+                allowAlways: false,
+                tool: nil,
+                description: "x"
+            )
+        ]
+        scope.pendingQuestions = [
+            QuestionRequest(id: "q1", sessionID: "s1", questions: [], tool: nil),
+            QuestionRequest(id: "q2", sessionID: "s2", questions: [], tool: nil)
+        ]
+        scope.activities["s2"] = SessionActivity(sessionID: "s2", state: .completed, text: "y", startedAt: Date())
+
+        scope.remove(sessionID: "s1")
+
+        #expect(scope.activities["s1"] == nil)
+        #expect(scope.activities["s2"] != nil)
+        #expect(scope.loadedMessageLimit["s1"] == nil)
+        #expect(scope.hasMoreHistory["s1"] == nil)
+        #expect(!scope.loadingOlderMessages.contains("s1"))
+        #expect(scope.draftInputs["s1"] == nil)
+        #expect(scope.selectedModelIDs["s1"] == nil)
+        #expect(scope.pendingPermissions.isEmpty)
+        #expect(scope.pendingQuestions.map(\.id) == ["q2"])
+    }
+
+    @Test func resetAllClearsHostSwitchLeftovers() {
+        var scope = SessionScopedState()
+        scope.activities["s1"] = SessionActivity(sessionID: "s1", state: .running, text: "x", startedAt: Date())
+        scope.loadedMessageLimit["s1"] = 40
+        scope.pendingQuestions = [QuestionRequest(id: "q1", sessionID: "s1", questions: [], tool: nil)]
+        scope.draftInputs["s1"] = "draft"
+        scope.resetAll()
+        #expect(scope.activities.isEmpty)
+        #expect(scope.loadedMessageLimit.isEmpty)
+        #expect(scope.pendingQuestions.isEmpty)
+        #expect(scope.draftInputs.isEmpty)
+    }
+
+    @Test @MainActor func hostSwitchResetsPreviouslyLeakedSessionCaches() {
+        let state = AppState(apiClient: MockAPIClient(), sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.sessionActivities["s1"] = SessionActivity(sessionID: "s1", state: .running, text: "x", startedAt: Date())
+        state.loadedMessageLimitBySessionID["s1"] = 40
+        state.hasMoreHistoryBySessionID["s1"] = true
+        state.pendingQuestions = [QuestionRequest(id: "q1", sessionID: "s1", questions: [], tool: nil)]
+        state.draftInputsBySessionID["s1"] = "draft"
+        state.selectedModelIDBySessionID["s1"] = "google/gemini-3.5-flash"
+
+        state.resetConnectionRuntimeForHostSwitch()
+
+        #expect(state.sessionActivities.isEmpty)
+        #expect(state.loadedMessageLimitBySessionID.isEmpty)
+        #expect(state.hasMoreHistoryBySessionID.isEmpty)
+        #expect(state.pendingQuestions.isEmpty)
+        #expect(state.pendingPermissions.isEmpty)
+        #expect(state.draftInputsBySessionID.isEmpty)
+        #expect(state.selectedModelIDBySessionID.isEmpty)
+    }
+
+    @Test @MainActor func clearSessionScopedCachesDropsQuestionsForThatSessionOnly() {
+        let state = AppState(apiClient: MockAPIClient(), sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.pendingQuestions = [
+            QuestionRequest(id: "q1", sessionID: "s1", questions: [], tool: nil),
+            QuestionRequest(id: "q2", sessionID: "s2", questions: [], tool: nil)
+        ]
+        state.sessionActivities["s1"] = SessionActivity(sessionID: "s1", state: .running, text: "x", startedAt: Date())
+        state.clearSessionScopedCaches(sessionID: "s1")
+        #expect(state.pendingQuestions.map(\.id) == ["q2"])
+        #expect(state.sessionActivities["s1"] == nil)
+    }
+}


### PR DESCRIPTION
No product UI change intended. This is the next maintainability slice after #151.

`clearSessionScopedCaches` and `resetConnectionRuntimeForHostSwitch` used to maintain two different field lists. Switching host left session activities, history pagination, pending questions, drafts, and per-session model selection in memory.

- New `SessionScopedState` owns those maps
- AppState still exposes the same property names to views
- Delete one session and switch host both go through `remove` / `resetAll`
- Pending questions for a deleted session are now cleared (they were missed before)

Please test host switching and session delete before merge.