### PR TITLE
fix: empty picker UI test flake

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Support/UITestFixtures.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Support/UITestFixtures.swift
@@ -400,7 +400,9 @@ enum UITestFixtures {
             ModelPreset(displayName: "Gemini 3.5 Flash", providerID: "google", modelID: "gemini-3.5-flash"),
             ModelPreset(displayName: "Gemini 3.5 Flash Lite", providerID: "google", modelID: "gemini-3.5-flash-lite")
         ]
-        if !ProcessInfo.processInfo.arguments.contains("UITEST_MODEL_SHORTLIST_EMPTY_FIXTURE") {
+        if ProcessInfo.processInfo.arguments.contains("UITEST_MODEL_SHORTLIST_EMPTY_FIXTURE") {
+            state.modelShortlist = []
+        } else {
             state.modelShortlist = [
                 ModelShortlistItem(
                     providerID: "zai-coding-plan",

--- a/OpenCodeClient/OpenCodeClientUITests/ModelShortlistUITests.swift
+++ b/OpenCodeClient/OpenCodeClientUITests/ModelShortlistUITests.swift
@@ -54,10 +54,12 @@ final class ModelShortlistUITests: XCTestCase {
         chip.tap()
 
         let empty = app.descendants(matching: .any)["configure-empty-shortlist"]
-        XCTAssertTrue(empty.waitForExistence(timeout: 6))
+        XCTAssertTrue(empty.waitForExistence(timeout: 6), "empty shortlist should show the Settings jump row")
         empty.tap()
+        XCTAssertTrue(empty.waitForNonExistence(timeout: 4), "model sheet should dismiss after jump")
 
-        XCTAssertTrue(app.descendants(matching: .any)["settings-model-shortlist"].waitForExistence(timeout: 8))
+        let modelsRow = app.descendants(matching: .any)["settings-model-shortlist"]
+        XCTAssertTrue(modelsRow.waitForExistence(timeout: 8), "Settings → Models row should be visible after jump")
     }
 
     private func openSettings(in app: XCUIApplication) {


### PR DESCRIPTION
`UITEST_MODEL_SHORTLIST_EMPTY_FIXTURE` 现在会把 shortlist 写成空数组，不再沿用上次 UI 测试写进 UserDefaults 的名单。`ModelShortlistUITests` 两轮通过。