### PR TITLE
test: run test targets non-parallelizable

### DIFF
--- a/OpenCodeClient/OpenCodeClient.xcodeproj/xcshareddata/xcschemes/OpenCodeClient.xcscheme
+++ b/OpenCodeClient/OpenCodeClient.xcodeproj/xcshareddata/xcschemes/OpenCodeClient.xcscheme
@@ -32,7 +32,7 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3B4F440E2F3E642600A4CD74"
@@ -43,7 +43,7 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3B4F44182F3E642600A4CD74"


### PR DESCRIPTION
Follow-up to #159: Tier 3 integration tests hit the same live server from parallel simulator clones, which caused cross-clone interference. Mark both test targets non-parallelizable in the shared scheme. This change was written on top of the PR branch but landed outside the squash, so it needs its own PR.