### PR TITLE
fix: make SSH device key fail-closed (#161)

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+HostProfiles.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+HostProfiles.swift
@@ -20,7 +20,7 @@ extension AppState {
         if !_username.isEmpty || !_password.isEmpty {
             let passwordID = Self.passwordKeychainID(for: profile.id)
             if !_password.isEmpty {
-                KeychainHelper.save(_password, forKey: passwordID)
+                try? KeychainHelper.save(_password, forKey: passwordID)
             }
             profile.basicAuth = BasicAuthConfig(username: _username, keychainPasswordID: passwordID)
         }
@@ -64,7 +64,7 @@ extension AppState {
         _serverURL = profile.serverURL
         _username = profile.basicAuth?.username ?? ""
         if let passwordID = profile.basicAuth?.keychainPasswordID {
-            _password = KeychainHelper.load(forKey: passwordID) ?? ""
+            _password = (try? KeychainHelper.load(forKey: passwordID)) ?? ""
         } else {
             _password = ""
         }
@@ -73,9 +73,9 @@ extension AppState {
             defaults.set(_serverURL, forKey: Self.serverURLKey)
             defaults.set(_username, forKey: Self.usernameKey)
             if _password.isEmpty {
-                KeychainHelper.delete(Self.passwordKeychainKey)
+                try? KeychainHelper.delete(Self.passwordKeychainKey)
             } else {
-                KeychainHelper.save(_password, forKey: Self.passwordKeychainKey)
+                try? KeychainHelper.save(_password, forKey: Self.passwordKeychainKey)
             }
         }
 
@@ -102,15 +102,15 @@ extension AppState {
 
         if username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && password.isEmpty {
             if let oldID = profile.basicAuth?.keychainPasswordID {
-                KeychainHelper.delete(oldID)
+                try? KeychainHelper.delete(oldID)
             }
             profile.basicAuth = nil
         } else {
             let passwordID = profile.basicAuth?.keychainPasswordID ?? Self.passwordKeychainID(for: profile.id)
             if password.isEmpty {
-                KeychainHelper.delete(passwordID)
+                try? KeychainHelper.delete(passwordID)
             } else {
-                KeychainHelper.save(password, forKey: passwordID)
+                try? KeychainHelper.save(password, forKey: passwordID)
             }
             profile.basicAuth = BasicAuthConfig(username: username, keychainPasswordID: passwordID)
         }
@@ -140,9 +140,9 @@ extension AppState {
             } else {
                 let passwordID = profile.basicAuth?.keychainPasswordID ?? Self.passwordKeychainID(for: profile.id)
                 if password.isEmpty {
-                    KeychainHelper.delete(passwordID)
+                    try? KeychainHelper.delete(passwordID)
                 } else {
-                    KeychainHelper.save(password, forKey: passwordID)
+                    try? KeychainHelper.save(password, forKey: passwordID)
                 }
                 saved.basicAuth = BasicAuthConfig(username: username, keychainPasswordID: passwordID)
             }
@@ -182,7 +182,7 @@ extension AppState {
         guard hostProfiles.count > 1 else { throw HostProfileError.cannotDeleteOnlyHost }
         let wasCurrent = profile.id == currentHostProfileID
         if let passwordID = profile.basicAuth?.keychainPasswordID {
-            KeychainHelper.delete(passwordID)
+            try? KeychainHelper.delete(passwordID)
         }
         hostProfiles.removeAll { $0.id == profile.id }
         if wasCurrent, let first = hostProfiles.first {
@@ -200,8 +200,8 @@ extension AppState {
         copy.lastUsedAt = nil
         if let auth = profile.basicAuth {
             let newPasswordID = Self.passwordKeychainID(for: copy.id)
-            if let password = KeychainHelper.load(forKey: auth.keychainPasswordID) {
-                KeychainHelper.save(password, forKey: newPasswordID)
+            if let password = try? KeychainHelper.load(forKey: auth.keychainPasswordID) {
+                try? KeychainHelper.save(password, forKey: newPasswordID)
             }
             copy.basicAuth = BasicAuthConfig(username: auth.username, keychainPasswordID: newPasswordID)
         }

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -152,9 +152,9 @@ final class AppState {
         set {
             _password = newValue
             if newValue.isEmpty {
-                KeychainHelper.delete(Self.passwordKeychainKey)
+                try? KeychainHelper.delete(Self.passwordKeychainKey)
             } else {
-                KeychainHelper.save(newValue, forKey: Self.passwordKeychainKey)
+                try? KeychainHelper.save(newValue, forKey: Self.passwordKeychainKey)
             }
         }
     }
@@ -222,12 +222,12 @@ final class AppState {
             _serverURL = APIClient.defaultServer
         }
         _username = defaults.string(forKey: Self.usernameKey) ?? ""
-        _password = KeychainHelper.load(forKey: Self.passwordKeychainKey) ?? ""
+        _password = (try? KeychainHelper.load(forKey: Self.passwordKeychainKey)) ?? ""
         loadHostProfilesFromStorageOrLegacy()
         applyCurrentHostProfileToRuntime(persistLegacy: false)
 
         _aiBuilderBaseURL = defaults.string(forKey: Self.aiBuilderBaseURLKey) ?? "https://space.ai-builders.com/backend"
-        _aiBuilderToken = KeychainHelper.load(forKey: Self.aiBuilderTokenKeychainKey) ?? ""
+        _aiBuilderToken = (try? KeychainHelper.load(forKey: Self.aiBuilderTokenKeychainKey)) ?? ""
         _aiBuilderCustomPrompt = defaults.string(forKey: Self.aiBuilderCustomPromptKey) ?? Self.defaultAIBuilderCustomPrompt
         _aiBuilderTerminology = defaults.string(forKey: Self.aiBuilderTerminologyKey) ?? Self.defaultAIBuilderTerminology
         _aiBuilderRecordingStrategy = VoiceFlowRecordingStrategy(
@@ -326,9 +326,9 @@ final class AppState {
         set {
             _aiBuilderToken = newValue
             if newValue.isEmpty {
-                KeychainHelper.delete(Self.aiBuilderTokenKeychainKey)
+                try? KeychainHelper.delete(Self.aiBuilderTokenKeychainKey)
             } else {
-                KeychainHelper.save(newValue, forKey: Self.aiBuilderTokenKeychainKey)
+                try? KeychainHelper.save(newValue, forKey: Self.aiBuilderTokenKeychainKey)
             }
             aiBuilderConnectionOK = false
             aiBuilderConnectionError = nil

--- a/OpenCodeClient/OpenCodeClient/Services/SSHKeyManager.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/SSHKeyManager.swift
@@ -14,7 +14,7 @@ enum SSHKeyManager {
     private static let privateKeyKeychainKey = "sshPrivateKey.ed25519"
     private static let publicKeyUserDefaultsKey = "sshPublicKey.ed25519"
     private static let keyComment = "opencode-ios"
-    
+
     static func generateKeyPair() throws -> (privateKey: Data, publicKey: String) {
         let privateKey = Curve25519.Signing.PrivateKey()
 
@@ -25,18 +25,18 @@ enum SSHKeyManager {
         return (privateKeyData, publicKeyLine)
     }
 
-    static func savePrivateKey(_ key: Data) {
-        KeychainHelper.save(key, forKey: privateKeyKeychainKey)
+    static func savePrivateKey(_ key: Data) throws {
+        try KeychainHelper.save(key, forKey: privateKeyKeychainKey)
     }
-    
-    static func loadPrivateKey() -> Data? {
-        KeychainHelper.loadData(forKey: privateKeyKeychainKey)
+
+    static func loadPrivateKey() throws -> Data? {
+        try KeychainHelper.loadData(forKey: privateKeyKeychainKey)
     }
-    
+
     static func savePublicKey(_ publicKey: String) {
         UserDefaults.standard.set(publicKey, forKey: publicKeyUserDefaultsKey)
     }
-    
+
     static func getPublicKey() -> String? {
         guard let raw = UserDefaults.standard.string(forKey: publicKeyUserDefaultsKey) else {
             return nil
@@ -44,36 +44,69 @@ enum SSHKeyManager {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
-    
+
     static func deleteKeyPair() {
-        KeychainHelper.delete(privateKeyKeychainKey)
+        try? KeychainHelper.delete(privateKeyKeychainKey)
         UserDefaults.standard.removeObject(forKey: publicKeyUserDefaultsKey)
     }
-    
+
     static func hasKeyPair() -> Bool {
-        loadPrivateKey() != nil && getPublicKey() != nil
+        (try? loadPrivateKey())?.isEmpty == false && getPublicKey() != nil
     }
 
+    /// Read-only: never generates. Returns the cached public key after
+    /// verifying it derives from the stored private key. Throws
+    /// `SSHError.keyUnavailable` when the Keychain is transiently unreadable
+    /// and `SSHError.keyNotFound` when no private key exists.
+    static func getKeyPair() throws -> String {
+        let privateKeyData: Data?
+        do {
+            privateKeyData = try loadPrivateKey()
+        } catch {
+            throw SSHError.keyUnavailable
+        }
+        guard let privateKeyData else {
+            throw SSHError.keyNotFound
+        }
+        let derivedPublicKey = try publicKeyLine(fromPrivateKeyData: privateKeyData)
+        if let cached = getPublicKey(), cached == derivedPublicKey {
+            return cached
+        }
+        savePublicKey(derivedPublicKey)
+        return derivedPublicKey
+    }
+
+    /// Generate authority is restricted to bootstrap: only generates when the
+    /// private-key item is truly absent (`loadPrivateKey()` returns nil, i.e.
+    /// `errSecItemNotFound`). Any other Keychain failure throws
+    /// `SSHError.keyUnavailable` without touching stored keys.
     static func ensureKeyPair() throws -> String {
-        if let existing = getPublicKey(), loadPrivateKey() != nil {
-            return existing
+        let privateKeyData: Data?
+        do {
+            privateKeyData = try loadPrivateKey()
+        } catch {
+            throw SSHError.keyUnavailable
         }
 
-        if let privateKeyData = loadPrivateKey() {
-            let repairedPublicKey = try publicKeyLine(fromPrivateKeyData: privateKeyData)
-            savePublicKey(repairedPublicKey)
-            return repairedPublicKey
+        if let privateKeyData {
+            let derivedPublicKey = try publicKeyLine(fromPrivateKeyData: privateKeyData)
+            if getPublicKey() != derivedPublicKey {
+                savePublicKey(derivedPublicKey)
+            }
+            return derivedPublicKey
         }
-        
-        let (privateKey, publicKey) = try generateKeyPair()
-        savePrivateKey(privateKey)
+
+        let (newPrivateKey, publicKey) = try generateKeyPair()
+        try savePrivateKey(newPrivateKey)
         savePublicKey(publicKey)
         return publicKey
     }
-    
+
     static func rotateKey() throws -> String {
-        deleteKeyPair()
-        return try ensureKeyPair()
+        let (newPrivateKey, newPublicKey) = try generateKeyPair()
+        try savePrivateKey(newPrivateKey)
+        savePublicKey(newPublicKey)
+        return newPublicKey
     }
 
     // OpenSSH public key format (base64 of SSH wire encoding):

--- a/OpenCodeClient/OpenCodeClient/Services/SSHTunnelManager.swift
+++ b/OpenCodeClient/OpenCodeClient/Services/SSHTunnelManager.swift
@@ -221,8 +221,8 @@ final class SSHTunnelManager: ObservableObject {
         SSHKeyManager.getPublicKey()
     }
 
-    func generateOrGetPublicKey() throws -> String {
-        try SSHKeyManager.ensureKeyPair()
+    func readPublicKey() throws -> String {
+        try SSHKeyManager.getKeyPair()
     }
 
     func rotateKey() throws -> String {
@@ -285,11 +285,23 @@ final class SSHTunnelManager: ObservableObject {
             return
         }
 
-        // Ensure key pair exists (first run auto-generates).
-        _ = try? SSHKeyManager.ensureKeyPair()
+        do {
+            _ = try SSHKeyManager.ensureKeyPair()
+        } catch {
+            disconnect()
+            status = .error(error.localizedDescription)
+            return
+        }
 
-        guard let privateKeyData = SSHKeyManager.loadPrivateKey() else {
-            status = .error(L10n.t(.sshErrorKeyNotFound))
+        let privateKeyData: Data
+        do {
+            guard let data = try SSHKeyManager.loadPrivateKey() else {
+                throw SSHError.keyNotFound
+            }
+            privateKeyData = data
+        } catch {
+            disconnect()
+            status = .error(error.localizedDescription)
             return
         }
         
@@ -474,10 +486,10 @@ final class SSHTunnelManager: ObservableObject {
         SSHKeyManager.getPublicKey()
     }
     
-    func generateOrGetPublicKey() throws -> String {
-        try SSHKeyManager.ensureKeyPair()
+    func readPublicKey() throws -> String {
+        try SSHKeyManager.getKeyPair()
     }
-    
+
     func rotateKey() throws -> String {
         try SSHKeyManager.rotateKey()
     }
@@ -552,10 +564,11 @@ enum SSHError: LocalizedError {
     case connectionFailed(String)
     case authenticationFailed
     case keyNotFound
+    case keyUnavailable
     case invalidKeyFormat
     case tunnelFailed(String)
     case hostKeyMismatch(expected: String, got: String, presentedOpenSSHKey: String)
-    
+
     var errorDescription: String? {
         switch self {
         case .connectionFailed(let reason):
@@ -564,6 +577,8 @@ enum SSHError: LocalizedError {
             return L10n.t(.sshErrorAuthenticationFailed)
         case .keyNotFound:
             return L10n.t(.sshErrorKeyNotFound)
+        case .keyUnavailable:
+            return L10n.t(.sshErrorKeyUnavailable)
         case .invalidKeyFormat:
             return L10n.t(.sshErrorInvalidKeyFormat)
         case .tunnelFailed(let reason):

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -220,6 +220,8 @@ enum L10n {
         case sshErrorInvalidKeyFormat
         case sshErrorTunnelFailed
         case sshErrorHostKeyMismatch
+        case sshErrorKeyUnavailable
+        case keychainErrorUnhandledStatus
 
         case connectionPhaseIdle
         case connectionPhaseSSHGateway
@@ -650,6 +652,8 @@ enum L10n {
         Key.sshErrorInvalidKeyFormat.rawValue: "Invalid SSH key format.",
         Key.sshErrorTunnelFailed.rawValue: "Tunnel failed: %@",
         Key.sshErrorHostKeyMismatch.rawValue: "Host key mismatch. Expected %@, got %@. This may be a MITM attack or a reinstalled server. Reset trusted host and verify fingerprint before reconnecting.",
+        Key.sshErrorKeyUnavailable.rawValue: "SSH key is unavailable right now. Unlock the device and try again.",
+        Key.keychainErrorUnhandledStatus.rawValue: "Keychain operation failed (OSStatus %d).",
 
         Key.connectionPhaseIdle.rawValue: "Idle",
         Key.connectionPhaseSSHGateway.rawValue: "Connecting to SSH gateway",
@@ -1084,6 +1088,8 @@ enum L10n {
         Key.sshErrorInvalidKeyFormat.rawValue: "SSH 密钥格式无效。",
         Key.sshErrorTunnelFailed.rawValue: "隧道失败：%@",
         Key.sshErrorHostKeyMismatch.rawValue: "Host key 不匹配。预期 %@，实际 %@。这可能是中间人攻击，也可能是服务器重装。请重置信任主机，并核对 fingerprint 后再连接。",
+        Key.sshErrorKeyUnavailable.rawValue: "SSH 密钥暂时不可用。请解锁设备后重试。",
+        Key.keychainErrorUnhandledStatus.rawValue: "Keychain 操作失败（OSStatus %d）。",
 
         Key.connectionPhaseIdle.rawValue: "空闲",
         Key.connectionPhaseSSHGateway.rawValue: "正在连接 SSH 网关",

--- a/OpenCodeClient/OpenCodeClient/Utils/KeychainHelper.swift
+++ b/OpenCodeClient/OpenCodeClient/Utils/KeychainHelper.swift
@@ -8,53 +8,90 @@ import Security
 
 /// Minimal Keychain helper for storing sensitive credentials (e.g. password).
 /// Uses kSecClassGenericPassword with service = bundle ID, account = key.
+enum KeychainError: LocalizedError {
+    case unhandledStatus(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .unhandledStatus(let status):
+            return L10n.t(.keychainErrorUnhandledStatus, Int32(status))
+        }
+    }
+}
+
 enum KeychainHelper {
     private static var service: String {
         Bundle.main.bundleIdentifier ?? "com.opencode.client"
     }
 
-    static func save(_ value: String, forKey key: String) {
-        guard let data = value.data(using: .utf8) else { return }
-        save(data, forKey: key)
-    }
-
-    static func save(_ data: Data, forKey key: String) {
-        delete(key)
-        let query: [String: Any] = [
+    private static var baseQuery: [String: Any] {
+        [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-            kSecValueData as String: data,
         ]
-        SecItemAdd(query as CFDictionary, nil)
     }
 
-    static func load(forKey key: String) -> String? {
-        guard let data = loadData(forKey: key) else { return nil }
+    static func save(_ value: String, forKey key: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.unhandledStatus(errSecInvalidData)
+        }
+        try save(data, forKey: key)
+    }
+
+    static func save(_ data: Data, forKey key: String) throws {
+        var query = baseQuery
+        query[kSecAttrAccount as String] = key
+        let update: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+        guard updateStatus == errSecSuccess || updateStatus == errSecItemNotFound else {
+            throw KeychainError.unhandledStatus(updateStatus)
+        }
+        if updateStatus == errSecItemNotFound {
+            query[kSecValueData as String] = data
+            query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            let status = SecItemAdd(query as CFDictionary, nil)
+            guard status == errSecSuccess else {
+                throw KeychainError.unhandledStatus(status)
+            }
+        }
+    }
+
+    static func load(forKey key: String) throws -> String? {
+        guard let data = try loadData(forKey: key) else { return nil }
         return String(data: data, encoding: .utf8)
     }
 
-    static func loadData(forKey key: String) -> Data? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
+    /// Returns nil only when the item is truly absent (`errSecItemNotFound`);
+    /// throws on any other Keychain failure (e.g. `errSecInteractionNotAllowed`).
+    static func loadData(forKey key: String) throws -> Data? {
+        var query = baseQuery
+        query[kSecAttrAccount as String] = key
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess,
-              let data = result as? Data else { return nil }
-        return data
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data else {
+                throw KeychainError.unhandledStatus(errSecInvalidData)
+            }
+            return data
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError.unhandledStatus(status)
+        }
     }
 
-    static func delete(_ key: String) {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-        ]
-        SecItemDelete(query as CFDictionary)
+    static func delete(_ key: String) throws {
+        var query = baseQuery
+        query[kSecAttrAccount as String] = key
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unhandledStatus(status)
+        }
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Views/HostProfilesView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/HostProfilesView.swift
@@ -170,7 +170,7 @@ struct HostProfilesView: View {
     private func copyPublicKey() {
         #if !os(visionOS)
         do {
-            let key = try state.sshTunnelManager.generateOrGetPublicKey()
+            let key = try state.sshTunnelManager.readPublicKey()
             UIPasteboard.general.string = key
             publicKeyCopied = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { publicKeyCopied = false }
@@ -417,7 +417,7 @@ private struct HostProfileDetailView: View {
     private func copyPublicKey() {
         #if !os(visionOS)
         do {
-            UIPasteboard.general.string = try state.sshTunnelManager.generateOrGetPublicKey()
+            UIPasteboard.general.string = try state.sshTunnelManager.readPublicKey()
             copiedPublicKey = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { copiedPublicKey = false }
         } catch {
@@ -479,7 +479,7 @@ struct HostProfileEditorView: View {
             initial = profile
         }
         _profile = State(initialValue: initial)
-        _password = State(initialValue: initial.basicAuth.flatMap { KeychainHelper.load(forKey: $0.keychainPasswordID) } ?? "")
+        _password = State(initialValue: initial.basicAuth.flatMap { try? KeychainHelper.load(forKey: $0.keychainPasswordID) } ?? "")
         _importText = State(initialValue: Self.uiTestImportJSON)
     }
 
@@ -704,7 +704,7 @@ struct HostProfileEditorView: View {
     private func copyPublicKey() {
         #if !os(visionOS)
         do {
-            let key = try state.sshTunnelManager.generateOrGetPublicKey()
+            let key = try state.sshTunnelManager.readPublicKey()
             UIPasteboard.general.string = key
             publicKeyCopied = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { publicKeyCopied = false }

--- a/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/SettingsTabView.swift
@@ -290,7 +290,7 @@ struct SettingsTabView: View {
             .navigationTitle(L10n.t(.settingsTitle))
             .onAppear {
                 #if !os(visionOS)
-                _ = try? state.sshTunnelManager.generateOrGetPublicKey()
+                _ = try? state.sshTunnelManager.readPublicKey()
                 #endif
                 pulseModelShortlistIfNeeded(proxy: proxy)
             }
@@ -314,7 +314,7 @@ struct SettingsTabView: View {
                         UIPasteboard.general.string = newKey
                         copiedPublicKey = true
                     } catch {
-                        // Error handled by manager
+                        publicKeyLoadError = error.localizedDescription
                     }
                 }
             } message: {
@@ -405,10 +405,7 @@ struct SettingsTabView: View {
 
     private func loadPublicKeyForSheet() {
         do {
-            let key = try state.sshTunnelManager.generateOrGetPublicKey().trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !key.isEmpty else {
-                throw SSHError.keyNotFound
-            }
+            let key = try state.sshTunnelManager.readPublicKey()
             publicKeyForSheet = key
             showPublicKeySheet = true
         } catch {

--- a/OpenCodeClient/OpenCodeClientTests/ConnectionTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/ConnectionTests.swift
@@ -348,6 +348,7 @@ struct SSHTunnelTests {
 
 // MARK: - SSH Key Manager Tests
 
+@Suite(.serialized)
 struct SSHKeyManagerTests {
 
     @Test func sshKeyGenerationProducesValidKeys() throws {
@@ -364,7 +365,7 @@ struct SSHKeyManagerTests {
         defer { SSHKeyManager.deleteKeyPair() }
 
         let (privateKey, _) = try SSHKeyManager.generateKeyPair()
-        SSHKeyManager.savePrivateKey(privateKey)
+        try SSHKeyManager.savePrivateKey(privateKey)
         SSHKeyManager.savePublicKey("   ")
 
         let repaired = try SSHKeyManager.ensureKeyPair()
@@ -372,6 +373,93 @@ struct SSHKeyManagerTests {
         #expect(!repaired.isEmpty)
         #expect(repaired.hasPrefix("ssh-ed25519 "))
         #expect(SSHKeyManager.getPublicKey() == repaired)
+    }
+
+    @Test func getKeyPairNeverGeneratesWhenKeyMissing() throws {
+        SSHKeyManager.deleteKeyPair()
+        defer { SSHKeyManager.deleteKeyPair() }
+
+        do {
+            _ = try SSHKeyManager.getKeyPair()
+            Issue.record("getKeyPair() should throw SSHError.keyNotFound when no key exists")
+        } catch {
+            guard case SSHError.keyNotFound = error else {
+                Issue.record("unexpected error: \(error)")
+                return
+            }
+        }
+
+        #expect(try SSHKeyManager.loadPrivateKey() == nil)
+        #expect(SSHKeyManager.getPublicKey() == nil)
+    }
+
+    @Test func ensureKeyPairBootstrapsOnceAndIsIdempotent() throws {
+        SSHKeyManager.deleteKeyPair()
+        defer { SSHKeyManager.deleteKeyPair() }
+
+        let first = try SSHKeyManager.ensureKeyPair()
+        #expect(first.hasPrefix("ssh-ed25519 "))
+        guard let privateKeyAfterFirst = try SSHKeyManager.loadPrivateKey() else {
+            Issue.record("private key should exist after ensureKeyPair()")
+            return
+        }
+        #expect(!privateKeyAfterFirst.isEmpty)
+
+        let second = try SSHKeyManager.ensureKeyPair()
+        guard let privateKeyAfterSecond = try SSHKeyManager.loadPrivateKey() else {
+            Issue.record("private key should exist after second ensureKeyPair()")
+            return
+        }
+
+        #expect(second == first)
+        #expect(privateKeyAfterSecond == privateKeyAfterFirst)
+    }
+
+    @Test func getKeyPairDerivesPublicKeyAndRepairsStaleCache() throws {
+        SSHKeyManager.deleteKeyPair()
+        defer { SSHKeyManager.deleteKeyPair() }
+
+        let (_, stalePublicKey) = try SSHKeyManager.generateKeyPair()
+        let (privateKey, _) = try SSHKeyManager.generateKeyPair()
+        try SSHKeyManager.savePrivateKey(privateKey)
+        SSHKeyManager.savePublicKey(stalePublicKey)
+        #expect(SSHKeyManager.getPublicKey() == stalePublicKey)
+
+        let returned = try SSHKeyManager.getKeyPair()
+
+        #expect(returned.hasPrefix("ssh-ed25519 "))
+        #expect(returned != stalePublicKey)
+        #expect(SSHKeyManager.getPublicKey() == returned)
+        #expect(SSHKeyManager.getPublicKey() != stalePublicKey)
+    }
+
+    @Test func keychainHelperSaveUpdatesInPlaceAndDeleteRemoves() throws {
+        let key = "unitTest.keychainHelper"
+        defer { try? KeychainHelper.delete(key) }
+
+        try KeychainHelper.save("first-value", forKey: key)
+        #expect(try KeychainHelper.load(forKey: key) == "first-value")
+
+        try KeychainHelper.save("second-value", forKey: key)
+        #expect(try KeychainHelper.load(forKey: key) == "second-value")
+
+        try KeychainHelper.delete(key)
+        #expect(try KeychainHelper.loadData(forKey: key) == nil)
+    }
+
+    @Test func hasKeyPairReflectsPairLifecycle() throws {
+        SSHKeyManager.deleteKeyPair()
+        defer { SSHKeyManager.deleteKeyPair() }
+
+        #expect(SSHKeyManager.hasKeyPair() == false)
+
+        let (privateKey, publicKey) = try SSHKeyManager.generateKeyPair()
+        try SSHKeyManager.savePrivateKey(privateKey)
+        SSHKeyManager.savePublicKey(publicKey)
+        #expect(SSHKeyManager.hasKeyPair() == true)
+
+        SSHKeyManager.deleteKeyPair()
+        #expect(SSHKeyManager.hasKeyPair() == false)
     }
 
 }

--- a/docs/OpenCode_iOS_Client_PRD.md
+++ b/docs/OpenCode_iOS_Client_PRD.md
@@ -477,7 +477,8 @@ iOS App → SSH Gateway (:8006) → Assigned Remote Port (:19001) → OpenCode (
 **密钥管理规范**：
 
 - App 在首次使用时自动生成 Ed25519 密钥对
-- 私钥安全存放在 iOS Keychain（设置访问控制属性为 `kSecAttrAccessibleWhenUnlocked`）
+- 私钥安全存放在 iOS Keychain（设置访问控制属性为 `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`）
+- 密钥对为长期设备身份：仅在首次使用（Keychain 条目确实缺失）或用户显式轮换时生成；Keychain 暂不可读（如设备锁定期间）时报错提示解锁设备重试，不静默重新生成
 - 公钥展示在 Settings 界面中，支持一键复制到剪贴板
 - 提供密钥轮换入口（支持重新生成全新密钥对）
 

--- a/docs/OpenCode_iOS_Client_RFC.md
+++ b/docs/OpenCode_iOS_Client_RFC.md
@@ -217,7 +217,7 @@ struct BasicAuthConfig: Codable, Equatable {
 **持久化边界**：
 
 - `HostProfile` 列表保存在 UserDefaults 或轻量 JSON store 中；敏感密码仅存储 Keychain 引用标识（Keychain reference），不直接写入 JSON 数据。
-- SSH 私钥（private key）默认采用设备级密钥（device-level key），由现有的 `SSHKeyManager` 统一管理，多个 SSH profile 共享同一个公钥。未来若需要更高安全隔离级别，可在此基础上增加针对单 profile 的 key override 配置。
+- SSH 私钥（private key）默认采用设备级密钥（device-level key），由现有的 `SSHKeyManager` 统一管理，多个 SSH profile 共享同一个公钥。私钥为长期设备身份：仅首次引导（Keychain 条目确实缺失时）与用户显式 Rotate 才生成；读取路径 fail-closed，Keychain 暂不可读时报错而不重新生成，公钥缓存由私钥派生校验。未来若需要更高安全隔离级别，可在此基础上增加针对单 profile 的 key override 配置。
 - TOFU（Trust On First Use）的 known host 记录依然严格按 SSH gateway 的 `host:port` 进行绑定，而非绑定到 profile 名称。当多个 profile 指向同一个 gateway 时，它们将共享同一份受信任的 host 指纹信息。
 
 **切换流程**：
@@ -332,21 +332,29 @@ enum SSHKeyManager {
     // 生成 Ed25519 密钥对
     static func generateKeyPair() throws -> (privateKey: Data, publicKey: String)
     
-    // 私钥存 Keychain
-    static func savePrivateKey(_ key: Data)
-    static func loadPrivateKey() -> Data?
+    // 私钥存 Keychain（读写均传播 OSStatus；loadData 仅在 errSecItemNotFound 时返回 nil）
+    static func savePrivateKey(_ key: Data) throws
+    static func loadPrivateKey() throws -> Data?
     
-    // 公钥用于显示/复制
+    // 公钥用于显示/复制（只读，不生成；先做一致性校验）
     static func getPublicKey() -> String?
     
-    // 密钥轮换
+    // 只读获取：校验缓存公钥确由私钥派生，不匹配时以私钥为准修复缓存；
+    // Keychain 暂不可读抛 SSHError.keyUnavailable，私钥不存在抛 SSHError.keyNotFound
+    static func getKeyPair() throws -> String
+
+    // 引导：仅当私钥条目确实缺失（errSecItemNotFound）时生成新密钥对；
+    // 其他 Keychain 错误抛 SSHError.keyUnavailable，不触碰已存密钥
+    static func ensureKeyPair() throws -> String
+
+    // 密钥轮换（唯一由用户显式触发的生成路径）
     static func rotateKey() throws -> String  // 返回新公钥
 }
 ```
 
 **安全考虑**：
 
-1. **私钥保护**：采用 `kSecAttrAccessibleWhenUnlocked` 策略存储，确保仅在设备处于解锁状态时才允许访问私钥
+1. **私钥保护**：采用 `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` 策略存储，首次解锁后（含锁屏状态）即可读取，支持重启后的后台连接，且不随 iCloud Keychain 迁移到其他设备；`KeychainHelper` 的 save/load 传播 OSStatus，写失败不再被静默吞掉
 2. **公钥传输**：采用用户手动复制粘贴的方式，App 不会通过任何网络接口主动上传公钥
 3. **TOFU**：首次连接自动信任并保存服务器指纹（按 host:port 绑定），后续 mismatch 直接失败并提示 reset trusted host
 4. **超时**：连接超时 30 秒，自动断开并提示
@@ -358,6 +366,7 @@ enum SSHKeyManager {
 | 密钥未授权 | 公钥未添加到 VPS | "请先添加公钥到服务器的 authorized_keys" |
 | 连接超时 | 网络问题或地址错误 | "连接超时，请检查网络和服务器地址" |
 | 认证失败 | 私钥不匹配 | "认证失败，请确认公钥已正确添加" |
+| 密钥暂不可用 | Keychain 暂不可读（如设备锁定期间） | "SSH 密钥暂时不可用。请解锁设备后重试" |
 
 **SSH UX 补充**：
 - 在 Settings 页面内提供配置引导（setup guide）：指导用户将设备公钥复制给管理员，并填入管理员返回的 assigned remote port

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -9,6 +9,16 @@
 - **编译/测试**：build 通过；shortlist 单测与 `ModelShortlistUITests` 通过
 - **Phase**：聊天栏模型选择改为设备本地 shortlist（Settings → Models）
 
+### 2026-09-07 — SSH 密钥 fail-closed（issue #161）
+
+- **背景**：issue #161 报告设备 Ed25519 密钥对会被静默重新生成：私钥 Keychain 读取瞬时失败（设备未解锁时的 `errSecInteractionNotAllowed`）会让 `ensureKeyPair()` fail-open，烧掉旧身份并覆盖公钥缓存，服务端 authorized_keys 随之失效；加剧因素包括 `KeychainHelper` 未设 `kSecAttrAccessible`（默认 WhenUnlocked）、save/load 忽略 OSStatus、连接与视图热路径调用会生成的函数。
+- **修复（read/create 分离）**：新增只读 `getKeyPair()`——永不生成，先从私钥派生公钥校验缓存一致性（不匹配以私钥为准修复缓存），Keychain 暂不可读抛新错误 `SSHError.keyUnavailable`，私钥确实不存在抛 `.keyNotFound`；`ensureKeyPair()` 收窄为仅引导使用，仅在 Keychain 返回 `errSecItemNotFound`（条目真正缺失）时生成，其余错误抛 `.keyUnavailable` 且不触碰已存密钥；`rotateKey()` 保留生成权限（用户显式触发）。
+- **调用点改写**：`connect()` 的 `_ = try? ensureKeyPair()` 改为 do/catch 显式传播，密钥错误时 disconnect 并进入 `.error`（fail closed）；视图侧 `generateOrGetPublicKey()` 更名为 `readPublicKey()` 并改走 `getKeyPair()`（Settings onAppear 预取、公钥 sheet、三处 Copy 公钥），瞬时失败复用既有错误 UI 提示解锁设备。
+- **Keychain 加固**：Keychain 条目统一设置 `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`（私钥与密码/token 共用同一写入路径；首次解锁后锁屏也可读，支持重启后后台连接，且不随 iCloud Keychain 迁移）；`KeychainHelper.save/load/delete` 全部传播 OSStatus，`loadData` 仅在 `errSecItemNotFound` 时返回 nil（区分"不存在"与"读取失败"）；`save` 改为 update-then-add 且仅在私钥写入校验通过后才写 UserDefaults 公钥缓存。
+- **Rotate 加固（review 后补充）**：`rotateKey()` 不再先删后生成，改为先生成新密钥并用 update-then-add `savePrivateKey` 原地覆盖，保存成功后才更新公钥缓存——保存失败时旧身份保持不变；Settings Rotate 回调的错误改为写入 `publicKeyLoadError` 提示用户，不再静默吞掉。
+- **测试隔离**：`SSHKeyManagerTests` 标注 `@Suite(.serialized)`（与同文件 `HostProfileTests` 一致），避免多条测试并发修改共享 Keychain/UserDefaults 状态造成 flake。
+- **验证**：build 通过（xcodebuild build，指定 simulator destination）；`SSHKeyManagerTests` 定向 7/7 通过（2 既有 + 5 新增：getKeyPair 不铸造、bootstrap 幂等、派生修复过期缓存、KeychainHelper update-in-place/delete、hasKeyPair 生命周期）；全量 451 个测试 443 通过 / 4 失败 / 4 跳过，失败全部为 UI fixture 测试（CarMode/AIUsageQuota/SpeechStrategies/ToolCards），在干净基线上复跑同样失败，属本机环境预存 flake，与本次改动无关。注意：本机跑 Keychain 相关测试必须去掉 `CODE_SIGNING_ALLOWED=NO`（未签名宿主 app 无 Keychain entitlement，报 -34018）。
+
 ### 2026-08-24 — 本地 model shortlist（PR #149，related #99 / #144）
 
 - 官方 picker 的可见性在桌面 persist，`/provider` 与 `/config/providers` 都是完整目录。iOS 在本机做 shortlist：Settings → Models 从已连接 chat-capable catalog 搜索添加，左滑删除，左边手柄排序，点行改 toolbar short name。

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -68,6 +68,7 @@ Tier 1 专注于纯逻辑与数据契约测试，既不需要依赖真实 server
 - URL 修正、scheme 补全、路径规范化、文件路径提取。
 - Client capability action/callback decoding、Pending/Outbox expiration 与幂等、权限和原 session continuation。
 - `ToolCardClassifier`：哪些 part 进入 file-card grid，哪些折叠进 merged tool calls row；目录 read 的识别和 entries parsing。
+- `SSHKeyManager` 密钥生命周期：read/create 分离（`getKeyPair()` 只读不生成）、仅条目缺失（`errSecItemNotFound`）时引导生成、Keychain 暂不可读 fail-closed 抛 `keyUnavailable` 而非重新生成、缓存公钥由私钥派生一致性校验与修复。
 
 这一层主要验证 client 针对已知输入格式与纯规则的处理是否正确。但它并不能证明真实 server 当前仍在发送符合该契约的数据格式；这一问题交由 Tier 3 验证。
 


### PR DESCRIPTION
## Problem (issue #161)

The device Ed25519 key pair silently regenerated whenever the Keychain private-key read transiently failed (e.g. device locked → `errSecInteractionNotAllowed`). `ensureKeyPair()` fail-opened on any unreadable key: it minted a brand-new pair, overwrote the cached public key, and permanently broke server-side `authorized_keys` auth.

## Fix

**Read/create split**
- New read-only `SSHKeyManager.getKeyPair()` — never generates; derives the public key from the stored private key and repairs the cache on mismatch; throws the new `SSHError.keyUnavailable` on transient Keychain failures, `keyNotFound` when the item is truly absent.
- `ensureKeyPair()` now generates only when the Keychain reports `errSecItemNotFound`; any other status fails closed without touching stored keys.
- `connect()` (both visionOS and non-visionOS branches) and all view call sites (Settings onAppear / public key sheet, three Copy Public Key actions) switched to read-only paths with explicit error surfacing ("unlock the device and try again").
- `generateOrGetPublicKey()` renamed to `readPublicKey()`.

**Keychain hardening**
- `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` on new/updated items (supports post-reboot background connect; no iCloud Keychain sync).
- `KeychainHelper.save/load/delete` propagate OSStatus; `loadData` returns nil only for `errSecItemNotFound`.
- `save` is update-then-add (`SecItemUpdate` first, `SecItemAdd` only on `itemNotFound`) — no more delete-then-add window that could destroy a value on failed write.

**Rotate safety (from review)**
- `rotateKey()` no longer deletes first. It generates a new pair, overwrites the private key in place via update-then-add, and only then updates the cached public key — a failed save preserves the old identity.
- Settings rotate error now surfaces via `publicKeyLoadError` instead of being swallowed.

## Tests

- 5 new `SSHKeyManagerTests` cases pinning the regression (read-only never mints, bootstrap idempotence with unchanged private bytes, stale-cache repair, KeychainHelper update-in-place/delete, lifecycle); suite marked `@Suite(.serialized)`.
- Targeted suite 7/7 passed; full run 451 tests: 443 passed, 4 pre-existing UI fixture failures (CarMode / AIUsageQuota / SpeechStrategies / ToolCards — reproduce on clean baseline, environment flake), 4 skipped.
- Note: on this machine Keychain-backed tests require running without `CODE_SIGNING_ALLOWED=NO` (unsigned host app lacks Keychain entitlement → -34018).

## Docs

RFC / PRD / tests.md updated to the new key contract; WORKING.md changelog entry added.

Fixes #161