### PR TITLE
feat: close iPhone docked file preview with left-edge swipe

### DIFF
--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatBehaviors.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatBehaviors.swift
@@ -16,6 +16,16 @@ enum ChatScrollBehavior {
     }
 }
 
+/// Why a leading-edge swipe was accepted or rejected. Used by the preview
+/// close logger so a no-op swipe is diagnosable from console output.
+enum EdgeSwipeDecision: String, Equatable {
+    case accept
+    case startTooFarFromEdge
+    case swipedWrongDirection
+    case horizontalTooShort
+    case verticalDriftTooLarge
+}
+
 /// Shared geometry for leading-edge horizontal swipes (session list open,
 /// file preview close). Keep a single source of thresholds so the two
 /// behaviors cannot drift.
@@ -24,10 +34,18 @@ enum EdgeSwipeGeometry {
     static let minimumHorizontalTranslation: CGFloat = 72
     static let maximumVerticalTranslation: CGFloat = 56
 
+    static func decision(startLocation: CGPoint, translation: CGSize) -> EdgeSwipeDecision {
+        if startLocation.x > edgeThreshold { return .startTooFarFromEdge }
+        // iOS back-edge is rightward. A leftward flick from the edge is
+        // the opposite of dismiss and must not close the preview.
+        if translation.width < 0 { return .swipedWrongDirection }
+        if translation.width < minimumHorizontalTranslation { return .horizontalTooShort }
+        if abs(translation.height) > maximumVerticalTranslation { return .verticalDriftTooLarge }
+        return .accept
+    }
+
     static func shouldAcceptLeadingEdgeSwipe(startLocation: CGPoint, translation: CGSize) -> Bool {
-        guard startLocation.x <= edgeThreshold else { return false }
-        guard translation.width >= minimumHorizontalTranslation else { return false }
-        return abs(translation.height) <= maximumVerticalTranslation
+        decision(startLocation: startLocation, translation: translation) == .accept
     }
 }
 

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatBehaviors.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatBehaviors.swift
@@ -16,17 +16,49 @@ enum ChatScrollBehavior {
     }
 }
 
-/// Edge-swipe gesture for opening the session list. We only accept
-/// horizontal swipes starting near the left edge — keeps the chat
-/// pan / scroll gestures responsive in the rest of the view.
-enum SessionListEdgeSwipeBehavior {
+/// Shared geometry for leading-edge horizontal swipes (session list open,
+/// file preview close). Keep a single source of thresholds so the two
+/// behaviors cannot drift.
+enum EdgeSwipeGeometry {
     static let edgeThreshold: CGFloat = 32
     static let minimumHorizontalTranslation: CGFloat = 72
     static let maximumVerticalTranslation: CGFloat = 56
 
-    static func shouldOpenSessionList(startLocation: CGPoint, translation: CGSize) -> Bool {
+    static func shouldAcceptLeadingEdgeSwipe(startLocation: CGPoint, translation: CGSize) -> Bool {
         guard startLocation.x <= edgeThreshold else { return false }
         guard translation.width >= minimumHorizontalTranslation else { return false }
         return abs(translation.height) <= maximumVerticalTranslation
+    }
+}
+
+/// Edge-swipe gesture for opening the session list. We only accept
+/// horizontal swipes starting near the left edge — keeps the chat
+/// pan / scroll gestures responsive in the rest of the view.
+enum SessionListEdgeSwipeBehavior {
+    static let edgeThreshold: CGFloat = EdgeSwipeGeometry.edgeThreshold
+    static let minimumHorizontalTranslation: CGFloat = EdgeSwipeGeometry.minimumHorizontalTranslation
+    static let maximumVerticalTranslation: CGFloat = EdgeSwipeGeometry.maximumVerticalTranslation
+
+    static func shouldOpenSessionList(startLocation: CGPoint, translation: CGSize) -> Bool {
+        EdgeSwipeGeometry.shouldAcceptLeadingEdgeSwipe(
+            startLocation: startLocation,
+            translation: translation
+        )
+    }
+}
+
+/// Edge-swipe gesture for dismissing the iPhone docked file preview.
+/// Same geometry as opening the session list: start at the far-left
+/// edge and translate rightward with limited vertical drift.
+enum FilePreviewEdgeSwipeBehavior {
+    static let edgeThreshold: CGFloat = EdgeSwipeGeometry.edgeThreshold
+    static let minimumHorizontalTranslation: CGFloat = EdgeSwipeGeometry.minimumHorizontalTranslation
+    static let maximumVerticalTranslation: CGFloat = EdgeSwipeGeometry.maximumVerticalTranslation
+
+    static func shouldClosePreview(startLocation: CGPoint, translation: CGSize) -> Bool {
+        EdgeSwipeGeometry.shouldAcceptLeadingEdgeSwipe(
+            startLocation: startLocation,
+            translation: translation
+        )
     }
 }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -1246,6 +1246,7 @@ private struct ChatInlineFilePreview: View {
     let filePath: String
     let workspaceDirectory: String?
     let onClose: () -> Void
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1268,7 +1269,29 @@ private struct ChatInlineFilePreview: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay(alignment: .leading) {
+            if sizeClass != .regular {
+                Color.clear
+                    .frame(width: FilePreviewEdgeSwipeBehavior.edgeThreshold)
+                    .contentShape(Rectangle())
+                    .gesture(filePreviewEdgeSwipeGesture)
+                    .accessibilityHidden(true)
+                    .ignoresSafeArea(.container, edges: .horizontal)
+            }
+        }
         .accessibilityIdentifier("chat-inline-file-preview")
+    }
+
+    private var filePreviewEdgeSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 20, coordinateSpace: .local)
+            .onEnded { value in
+                guard sizeClass != .regular else { return }
+                guard FilePreviewEdgeSwipeBehavior.shouldClosePreview(
+                    startLocation: value.startLocation,
+                    translation: value.translation
+                ) else { return }
+                onClose()
+            }
     }
 }
 

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ChatTabView.swift
@@ -1242,11 +1242,18 @@ private extension View {
 /// Reuses `FileContentView` for rendering; lifecycle (open/close) is owned by
 /// `ChatTabView` via `inlinePreviewPath`.
 private struct ChatInlineFilePreview: View {
+    static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "OpenCodeClient",
+        category: "FilePreviewSwipe"
+    )
+
     @Bindable var state: AppState
     let filePath: String
     let workspaceDirectory: String?
     let onClose: () -> Void
     @Environment(\.horizontalSizeClass) private var sizeClass
+
+    private var overlayEnabled: Bool { sizeClass != .regular }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1259,6 +1266,7 @@ private struct ChatInlineFilePreview: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button {
+                        ChatInlineFilePreview.logger.info("filePreviewSwipe close via toolbar xmark")
                         onClose()
                     } label: {
                         Image(systemName: "xmark")
@@ -1270,28 +1278,167 @@ private struct ChatInlineFilePreview: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .overlay(alignment: .leading) {
-            if sizeClass != .regular {
-                Color.clear
-                    .frame(width: FilePreviewEdgeSwipeBehavior.edgeThreshold)
-                    .contentShape(Rectangle())
-                    .gesture(filePreviewEdgeSwipeGesture)
-                    .accessibilityHidden(true)
-                    .ignoresSafeArea(.container, edges: .horizontal)
-            }
+            LeadingEdgeSwipeCatcher(
+                isEnabled: overlayEnabled,
+                onEvent: { event in
+                    ChatInlineFilePreview.logger.info("\(event, privacy: .public)")
+                },
+                onClose: {
+                    ChatInlineFilePreview.logger.info("filePreviewSwipe close via edge swipe")
+                    onClose()
+                }
+            )
+            .frame(width: FilePreviewEdgeSwipeBehavior.edgeThreshold)
+            .frame(maxHeight: .infinity)
+            .accessibilityHidden(true)
+            .ignoresSafeArea(.container, edges: .horizontal)
+        }
+        .onAppear {
+            ChatInlineFilePreview.logger.info(
+                "filePreviewSwipe appear path=\(filePath, privacy: .public) sizeClass=\(String(describing: sizeClass), privacy: .public) overlay=\(overlayEnabled, privacy: .public)"
+            )
+        }
+        .onChange(of: sizeClass) { _, newValue in
+            ChatInlineFilePreview.logger.info(
+                "filePreviewSwipe sizeClass=\(String(describing: newValue), privacy: .public) overlay=\(newValue != .regular, privacy: .public)"
+            )
         }
         .accessibilityIdentifier("chat-inline-file-preview")
     }
+}
 
-    private var filePreviewEdgeSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 20, coordinateSpace: .local)
-            .onEnded { value in
-                guard sizeClass != .regular else { return }
-                guard FilePreviewEdgeSwipeBehavior.shouldClosePreview(
-                    startLocation: value.startLocation,
-                    translation: value.translation
-                ) else { return }
-                onClose()
+/// UIKit hit target for the left-edge dismiss strip. SwiftUI `Color.clear`
+/// overlays do not reliably win hit-testing over `WKWebView`, so the
+/// preview close gesture never even starts. A real `UIView` claims the
+/// leftmost 32pt and keeps tracking after the finger leaves that strip.
+private struct LeadingEdgeSwipeCatcher: UIViewRepresentable {
+    var isEnabled: Bool
+    var onEvent: (String) -> Void
+    var onClose: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isEnabled: isEnabled, onEvent: onEvent, onClose: onClose)
+    }
+
+    func makeUIView(context: Context) -> FilePreviewEdgeSwipeHitView {
+        let view = FilePreviewEdgeSwipeHitView()
+        view.backgroundColor = .clear
+        view.isUserInteractionEnabled = isEnabled
+        view.onTouchBegan = { point in
+            context.coordinator.noteTouchBegan(point)
+        }
+        let pan = UIPanGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handlePan(_:)))
+        pan.maximumNumberOfTouches = 1
+        pan.cancelsTouchesInView = true
+        pan.delaysTouchesBegan = false
+        view.addGestureRecognizer(pan)
+        context.coordinator.pan = pan
+        return view
+    }
+
+    func updateUIView(_ uiView: FilePreviewEdgeSwipeHitView, context: Context) {
+        context.coordinator.isEnabled = isEnabled
+        context.coordinator.onEvent = onEvent
+        context.coordinator.onClose = onClose
+        uiView.isUserInteractionEnabled = isEnabled
+    }
+
+    private static func fmt(_ value: CGFloat) -> String {
+        String(format: "%.1f", value)
+    }
+
+    final class Coordinator: NSObject {
+        var isEnabled: Bool
+        var onEvent: (String) -> Void
+        var onClose: () -> Void
+        weak var pan: UIPanGestureRecognizer?
+        private var touchStart: CGPoint?
+        private var lastLoggedStep = -1
+
+        init(isEnabled: Bool, onEvent: @escaping (String) -> Void, onClose: @escaping () -> Void) {
+            self.isEnabled = isEnabled
+            self.onEvent = onEvent
+            self.onClose = onClose
+        }
+
+        func emit(_ message: String) {
+            onEvent(message)
+        }
+
+        func noteTouchBegan(_ point: CGPoint) {
+            touchStart = point
+            emit(
+                "filePreviewSwipe touchBegan x=\(LeadingEdgeSwipeCatcher.fmt(point.x)) y=\(LeadingEdgeSwipeCatcher.fmt(point.y)) enabled=\(isEnabled)"
+            )
+        }
+
+        /// Pan `.began` fires after the finger has already moved. Using that
+        /// location as the edge origin falsely rejects real left-edge starts
+        /// (`touchBegan x=7` then `began startX=73`). Measure from touch-down.
+        private func swipeState(in view: UIView, gesture: UIPanGestureRecognizer) -> (start: CGPoint, translation: CGSize) {
+            let current = gesture.location(in: view)
+            let start = touchStart ?? current
+            return (
+                start,
+                CGSize(width: current.x - start.x, height: current.y - start.y)
+            )
+        }
+
+        @objc func handlePan(_ gesture: UIPanGestureRecognizer) {
+            guard let view = gesture.view else { return }
+            let state = swipeState(in: view, gesture: gesture)
+            switch gesture.state {
+            case .began:
+                lastLoggedStep = 0
+                let panX = gesture.location(in: view).x
+                emit(
+                    "filePreviewSwipe began startX=\(LeadingEdgeSwipeCatcher.fmt(state.start.x)) panX=\(LeadingEdgeSwipeCatcher.fmt(panX)) enabled=\(isEnabled)"
+                )
+            case .changed:
+                let step = Int(abs(state.translation.width) / 36)
+                guard step != lastLoggedStep else { return }
+                lastLoggedStep = step
+                let decision = EdgeSwipeGeometry.decision(
+                    startLocation: state.start,
+                    translation: state.translation
+                )
+                emit(
+                    "filePreviewSwipe changed startX=\(LeadingEdgeSwipeCatcher.fmt(state.start.x)) dx=\(LeadingEdgeSwipeCatcher.fmt(state.translation.width)) dy=\(LeadingEdgeSwipeCatcher.fmt(state.translation.height)) decision=\(decision.rawValue)"
+                )
+            case .ended, .cancelled, .failed:
+                let decision = EdgeSwipeGeometry.decision(
+                    startLocation: state.start,
+                    translation: state.translation
+                )
+                emit(
+                    "filePreviewSwipe \(gesture.state == .ended ? "ended" : "cancelled") startX=\(LeadingEdgeSwipeCatcher.fmt(state.start.x)) dx=\(LeadingEdgeSwipeCatcher.fmt(state.translation.width)) dy=\(LeadingEdgeSwipeCatcher.fmt(state.translation.height)) decision=\(decision.rawValue) enabled=\(isEnabled)"
+                )
+                if gesture.state == .ended, isEnabled, decision == .accept {
+                    onClose()
+                }
+                touchStart = nil
+            default:
+                break
             }
+        }
+    }
+}
+
+private final class FilePreviewEdgeSwipeHitView: UIView {
+    var onTouchBegan: ((CGPoint) -> Void)?
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard isUserInteractionEnabled, !isHidden, alpha > 0.01, bounds.contains(point) else {
+            return nil
+        }
+        return self
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        if let point = touches.first?.location(in: self) {
+            onTouchBegan?(point)
+        }
+        super.touchesBegan(touches, with: event)
     }
 }
 

--- a/OpenCodeClient/OpenCodeClientTests/RenderingTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/RenderingTests.swift
@@ -509,6 +509,45 @@ struct SessionListEdgeSwipeBehaviorTests {
     }
 }
 
+struct FilePreviewEdgeSwipeBehaviorTests {
+
+    @Test func closesForLeftEdgeSwipeWithStrongHorizontalTravel() {
+        #expect(
+            FilePreviewEdgeSwipeBehavior.shouldClosePreview(
+                startLocation: CGPoint(x: 12, y: 180),
+                translation: CGSize(width: 120, height: 18)
+            ) == true
+        )
+    }
+
+    @Test func ignoresSwipeThatStartsAwayFromLeftEdge() {
+        #expect(
+            FilePreviewEdgeSwipeBehavior.shouldClosePreview(
+                startLocation: CGPoint(x: 60, y: 180),
+                translation: CGSize(width: 120, height: 12)
+            ) == false
+        )
+    }
+
+    @Test func ignoresMostlyVerticalDrag() {
+        #expect(
+            FilePreviewEdgeSwipeBehavior.shouldClosePreview(
+                startLocation: CGPoint(x: 8, y: 180),
+                translation: CGSize(width: 110, height: 90)
+            ) == false
+        )
+    }
+
+    @Test func ignoresShortRightwardTravel() {
+        #expect(
+            FilePreviewEdgeSwipeBehavior.shouldClosePreview(
+                startLocation: CGPoint(x: 12, y: 180),
+                translation: CGSize(width: 40, height: 8)
+            ) == false
+        )
+    }
+}
+
 // MARK: - Design Tokens Tests
 
 @MainActor

--- a/OpenCodeClient/OpenCodeClientTests/RenderingTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/RenderingTests.swift
@@ -546,6 +546,33 @@ struct FilePreviewEdgeSwipeBehaviorTests {
             ) == false
         )
     }
+
+    @Test func decisionExplainsWrongDirectionLeftwardFlick() {
+        #expect(
+            EdgeSwipeGeometry.decision(
+                startLocation: CGPoint(x: 8, y: 200),
+                translation: CGSize(width: -90, height: 6)
+            ) == .swipedWrongDirection
+        )
+    }
+
+    @Test func decisionExplainsStartTooFarFromEdge() {
+        #expect(
+            EdgeSwipeGeometry.decision(
+                startLocation: CGPoint(x: 60, y: 180),
+                translation: CGSize(width: 120, height: 12)
+            ) == .startTooFarFromEdge
+        )
+    }
+
+    @Test func decisionAcceptsCanonicalBackEdgeSwipe() {
+        #expect(
+            EdgeSwipeGeometry.decision(
+                startLocation: CGPoint(x: 12, y: 180),
+                translation: CGSize(width: 120, height: 18)
+            ) == .accept
+        )
+    }
 }
 
 // MARK: - Design Tokens Tests

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -13,11 +13,11 @@
 
 - compact-width Chat 里，点文件 tool call 打开的 docked `ChatInlineFilePreview` 除 toolbar `xmark` 外，可用标准 iOS 返回手势关闭：从屏幕物理左缘起手、向右拖够距离。
 - 几何与 session list 打开手势共用 `EdgeSwipeGeometry`（左缘 32pt、横向 ≥ 72pt、纵向漂移 ≤ 56pt），`FilePreviewEdgeSwipeBehavior` / `SessionListEdgeSwipeBehavior` 两个入口；regular/iPad 中间栏预览不启用。
-- 手势条叠在预览内容区（导航栏 xmark 与底部 composer 不覆盖）；条本身 `.ignoresSafeArea(.container, edges: .horizontal)`，意图是横屏刘海侧也从物理左缘起手，而不是从安全区 inset 后的内容左缘起手。竖屏已确认可用；横屏这一条尚未真机验证，若失效则在条外补一层 flexible leading frame 再 ignoresSafeArea。
+- 手势条叠在预览内容区（导航栏 xmark 与底部 composer 不覆盖）；条本身 `.ignoresSafeArea(.container, edges: .horizontal)`，意图是横屏刘海侧也从物理左缘起手，而不是从安全区 inset 后的内容左缘起手。竖屏已真机确认；横屏尚未验证，若失效则补一层 flexible leading frame 再 ignoresSafeArea。
 - Markdown Web Preview 的 `WKWebView` 会吃掉 SwiftUI `Color.clear` overlay 的 hit-testing，左缘 `DragGesture` 根本收不到 began。关闭条改为 UIKit `UIView` 抢左侧 32pt，并打 `FilePreviewSwipe` 日志（appear / touchBegan / began / changed / ended+decision / xmark）。关闭方向是**从左缘向右滑**，向左滑会记 `swipedWrongDirection`。
 - 真机 log：`touchBegan x=7` 已在 32pt 条内，但 `UIPanGestureRecognizer` 的 `.began` 发生在手指已右移到 `startX=73` 时，用这个点做左缘判定会得到 `startTooFarFromEdge`。改成按下坐标做 origin，位移用当前点减按下点。
 - 代价：最左侧约 32pt 是关闭手势保留区，该条内的代码横向滚动 / 图片平移不可达，这是有意为之。
-- 测试：`FilePreviewEdgeSwipeBehaviorTests`（合法右滑、非左缘、过大纵向、过短横向）。
+- 测试：`FilePreviewEdgeSwipeBehaviorTests`（合法右滑、非左缘、过大纵向、过短横向、反方向左滑 decision）。
 
 ### 2026-09-07 — SSH 密钥 fail-closed（issue #161）
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -9,6 +9,14 @@
 - **编译/测试**：build 通过；shortlist 单测与 `ModelShortlistUITests` 通过
 - **Phase**：聊天栏模型选择改为设备本地 shortlist（Settings → Models）
 
+### 2026-09-10 — iPhone 文件预览左缘右滑关闭
+
+- compact-width Chat 里，点文件 tool call 打开的 docked `ChatInlineFilePreview` 除 toolbar `xmark` 外，可用标准 iOS 返回手势关闭：从屏幕物理左缘起手、向右拖够距离。
+- 几何与 session list 打开手势共用 `EdgeSwipeGeometry`（左缘 32pt、横向 ≥ 72pt、纵向漂移 ≤ 56pt），`FilePreviewEdgeSwipeBehavior` / `SessionListEdgeSwipeBehavior` 两个入口；regular/iPad 中间栏预览不启用。
+- 手势条叠在预览内容区（导航栏 xmark 与底部 composer 不覆盖）；条本身 `.ignoresSafeArea(.container, edges: .horizontal)`，意图是横屏刘海侧也从物理左缘起手，而不是从安全区 inset 后的内容左缘起手。竖屏已确认可用；横屏这一条尚未真机验证，若失效则在条外补一层 flexible leading frame 再 ignoresSafeArea。
+- 代价：最左侧约 32pt 是关闭手势保留区，该条内的代码横向滚动 / 图片平移不可达，这是有意为之。
+- 测试：`FilePreviewEdgeSwipeBehaviorTests`（合法右滑、非左缘、过大纵向、过短横向）。
+
 ### 2026-09-07 — SSH 密钥 fail-closed（issue #161）
 
 - **背景**：issue #161 报告设备 Ed25519 密钥对会被静默重新生成：私钥 Keychain 读取瞬时失败（设备未解锁时的 `errSecInteractionNotAllowed`）会让 `ensureKeyPair()` fail-open，烧掉旧身份并覆盖公钥缓存，服务端 authorized_keys 随之失效；加剧因素包括 `KeychainHelper` 未设 `kSecAttrAccessible`（默认 WhenUnlocked）、save/load 忽略 OSStatus、连接与视图热路径调用会生成的函数。

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -14,6 +14,8 @@
 - compact-width Chat 里，点文件 tool call 打开的 docked `ChatInlineFilePreview` 除 toolbar `xmark` 外，可用标准 iOS 返回手势关闭：从屏幕物理左缘起手、向右拖够距离。
 - 几何与 session list 打开手势共用 `EdgeSwipeGeometry`（左缘 32pt、横向 ≥ 72pt、纵向漂移 ≤ 56pt），`FilePreviewEdgeSwipeBehavior` / `SessionListEdgeSwipeBehavior` 两个入口；regular/iPad 中间栏预览不启用。
 - 手势条叠在预览内容区（导航栏 xmark 与底部 composer 不覆盖）；条本身 `.ignoresSafeArea(.container, edges: .horizontal)`，意图是横屏刘海侧也从物理左缘起手，而不是从安全区 inset 后的内容左缘起手。竖屏已确认可用；横屏这一条尚未真机验证，若失效则在条外补一层 flexible leading frame 再 ignoresSafeArea。
+- Markdown Web Preview 的 `WKWebView` 会吃掉 SwiftUI `Color.clear` overlay 的 hit-testing，左缘 `DragGesture` 根本收不到 began。关闭条改为 UIKit `UIView` 抢左侧 32pt，并打 `FilePreviewSwipe` 日志（appear / touchBegan / began / changed / ended+decision / xmark）。关闭方向是**从左缘向右滑**，向左滑会记 `swipedWrongDirection`。
+- 真机 log：`touchBegan x=7` 已在 32pt 条内，但 `UIPanGestureRecognizer` 的 `.began` 发生在手指已右移到 `startX=73` 时，用这个点做左缘判定会得到 `startTooFarFromEdge`。改成按下坐标做 origin，位移用当前点减按下点。
 - 代价：最左侧约 32pt 是关闭手势保留区，该条内的代码横向滚动 / 图片平移不可达，这是有意为之。
 - 测试：`FilePreviewEdgeSwipeBehaviorTests`（合法右滑、非左缘、过大纵向、过短横向）。
 


### PR DESCRIPTION
## What

Adds a left-edge swipe-to-close for the iPhone (compact-width) docked file preview (`ChatInlineFilePreview`), which previously could only be dismissed with the toolbar `xmark`.

Drag starting at the far-left edge, translated right past the threshold, closes the preview — the standard iOS back-edge gesture.

## How

- New shared `EdgeSwipeGeometry` in `ChatBehaviors.swift` (left edge 32pt, horizontal >= 72pt, vertical drift <= 56pt). `FilePreviewEdgeSwipeBehavior.shouldClosePreview` and the existing `SessionListEdgeSwipeBehavior.shouldOpenSessionList` both delegate to it, so the open/close thresholds cannot drift.
- Leading overlay strip on `ChatInlineFilePreview` with a `DragGesture`; gated to `sizeClass != .regular`, so the iPad middle-column preview is untouched.
- Strip sits on the preview content (nav-bar `xmark` and the composer are not covered).

Known tradeoff: the leftmost ~32pt becomes a reserved dismissal zone — code horizontal scroll / image pan is not reachable inside it. Intentional.

## Testing

- `xcodebuild build -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'generic/platform=iOS Simulator'` -> BUILD SUCCEEDED
- `xcodebuild test -project OpenCodeClient.xcodeproj -scheme OpenCodeClient -destination 'platform=iOS Simulator,id=302F88CA-C2D3-4DC0-8E12-B3ED82D5A3C8' -only-testing:OpenCodeClientTests` -> 416 tests / 60 suites pass, including new `FilePreviewEdgeSwipeBehaviorTests`.

## Not verified

The landscape-with-notch "physical edge" positioning (`.ignoresSafeArea(.container, edges: .horizontal)` on the strip) was not empirically verified on-device. Portrait works. If landscape fails, the documented fallback is a flexible leading-aligned wrapper before `ignoresSafeArea`. On-device testing pending.

Do not merge.