### PR TITLE
feat: show LLM throughput per message and in Context sheet

### DIFF
--- a/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
@@ -111,11 +111,31 @@ extension AppState {
         case "message.updated":
             let eventSessionID = props["sessionID"]?.value as? String
             if Self.shouldProcessMessageEvent(eventSessionID: eventSessionID, currentSessionID: currentSessionID) {
+                if let infoObj = props["info"]?.value as? [String: Any],
+                   infoObj["role"] as? String == "assistant",
+                   let assistantID = infoObj["id"] as? String {
+                    messageStore.recordStepStart(assistantID, sessionID: eventSessionID ?? "")
+                }
                 messageStore.resetStreaming()
                 await loadMessages()
                 await loadSessionDiff()
             }
+        case "message.part.delta":
+            if let sessionID = props["sessionID"]?.value as? String,
+               sessionID == currentSessionID,
+               props["field"]?.value as? String == "text",
+               let delta = props["delta"]?.value as? String, !delta.isEmpty,
+               let messageID = props["messageID"]?.value as? String {
+                messageStore.recordFirstText(messageID, sessionID: sessionID)
+            }
         case "message.part.updated":
+            if let partObj = props["part"]?.value as? [String: Any],
+               partObj["type"] as? String == "step-finish",
+               props["sessionID"]?.value as? String == currentSessionID,
+               let messageID = partObj["messageID"] as? String {
+                let tokensObj = partObj["tokens"] as? [String: Any]
+                messageStore.recordStepFinish(messageID, sessionID: currentSessionID ?? "", outputTokens: tokensObj?["output"] as? Int)
+            }
             switch messageStore.applyMessagePartUpdate(properties: props, currentSessionID: currentSessionID) {
             case .ignored:
                 break
@@ -303,6 +323,7 @@ extension AppState {
     func clearCurrentSessionViewState() {
         sessionLoadingID = UUID()
         messageStore.resetStreaming()
+        messageStore.stepTimings = [:]
         messages = []
         partsByMessage = [:]
         sessionDiffs = []
@@ -312,6 +333,7 @@ extension AppState {
         sessionStatuses[sessionID] = nil
         sessionTodos[sessionID] = nil
         sessionScope.remove(sessionID: sessionID)
+        messageStore.removeTimings(forSession: sessionID)
 
         if streamingReasoningPart?.sessionID == sessionID {
             messageStore.streamingReasoningPart = nil

--- a/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
@@ -113,19 +113,25 @@ extension AppState {
             if Self.shouldProcessMessageEvent(eventSessionID: eventSessionID, currentSessionID: currentSessionID) {
                 if let infoObj = props["info"]?.value as? [String: Any],
                    infoObj["role"] as? String == "assistant",
-                   let assistantID = infoObj["id"] as? String {
-                    messageStore.recordStepStart(assistantID, sessionID: eventSessionID ?? "")
+                   let assistantID = infoObj["id"] as? String,
+                   let sessionID = eventSessionID {
+                    messageStore.recordStepStart(assistantID, sessionID: sessionID)
                 }
                 messageStore.resetStreaming()
                 await loadMessages()
                 await loadSessionDiff()
             }
         case "message.part.delta":
+            // `field` is "text" for both reasoning and text parts, so it cannot
+            // discriminate; the part's `type` (tracked by partID from the
+            // `message.part.updated` that precedes each part's deltas) can.
             if let sessionID = props["sessionID"]?.value as? String,
                sessionID == currentSessionID,
                props["field"]?.value as? String == "text",
                let delta = props["delta"]?.value as? String, !delta.isEmpty,
-               let messageID = props["messageID"]?.value as? String {
+               let messageID = props["messageID"]?.value as? String,
+               let partID = props["partID"]?.value as? String,
+               messageStore.partType(for: partID, inSession: sessionID) == "text" {
                 messageStore.recordFirstText(messageID, sessionID: sessionID)
             }
         case "message.part.updated":
@@ -324,6 +330,7 @@ extension AppState {
         sessionLoadingID = UUID()
         messageStore.resetStreaming()
         messageStore.stepTimings = [:]
+        messageStore.clearPartTypes()
         messages = []
         partsByMessage = [:]
         sessionDiffs = []
@@ -334,6 +341,7 @@ extension AppState {
         sessionTodos[sessionID] = nil
         sessionScope.remove(sessionID: sessionID)
         messageStore.removeTimings(forSession: sessionID)
+        messageStore.removePartTypes(forSession: sessionID)
 
         if streamingReasoningPart?.sessionID == sessionID {
             messageStore.streamingReasoningPart = nil

--- a/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState+SSE.swift
@@ -132,15 +132,24 @@ extension AppState {
                let messageID = props["messageID"]?.value as? String,
                let partID = props["partID"]?.value as? String,
                messageStore.partType(for: partID, inSession: sessionID) == "text" {
-                messageStore.recordFirstText(messageID, sessionID: sessionID)
+                messageStore.recordVisibleToken(messageID, sessionID: sessionID)
             }
         case "message.part.updated":
-            if let partObj = props["part"]?.value as? [String: Any],
-               partObj["type"] as? String == "step-finish",
-               props["sessionID"]?.value as? String == currentSessionID,
+            if let sessionID = props["sessionID"]?.value as? String,
+               sessionID == currentSessionID,
+               let partObj = props["part"]?.value as? [String: Any],
                let messageID = partObj["messageID"] as? String {
-                let tokensObj = partObj["tokens"] as? [String: Any]
-                messageStore.recordStepFinish(messageID, sessionID: currentSessionID ?? "", outputTokens: tokensObj?["output"] as? Int)
+                // Tool-call input streams as deltas on the tool part, so it also
+                // counts as visible output; a step whose only output is a tool
+                // call would otherwise have no decoding window at all.
+                if let partType = partObj["type"] as? String, partType == "tool" || partType == "text",
+                   let delta = props["delta"]?.value as? String, !delta.isEmpty {
+                    messageStore.recordVisibleToken(messageID, sessionID: sessionID)
+                }
+                if partObj["type"] as? String == "step-finish" {
+                    let tokensObj = partObj["tokens"] as? [String: Any]
+                    messageStore.recordStepFinish(messageID, sessionID: sessionID, outputTokens: tokensObj?["output"] as? Int)
+                }
             }
             switch messageStore.applyMessagePartUpdate(properties: props, currentSessionID: currentSessionID) {
             case .ignored:

--- a/OpenCodeClient/OpenCodeClient/AppState.swift
+++ b/OpenCodeClient/OpenCodeClient/AppState.swift
@@ -492,6 +492,7 @@ final class AppState {
     var partsByMessage: [String: [Part]] { get { messageStore.partsByMessage } set { messageStore.partsByMessage = newValue } }
     var streamingPartTexts: [String: String] { get { messageStore.streamingPartTexts } set { messageStore.streamingPartTexts = newValue } }
     var streamingReasoningPart: Part? { get { messageStore.streamingReasoningPart } set { messageStore.streamingReasoningPart = newValue } }
+    var stepTimings: [String: MessageStore.StepTiming] { get { messageStore.stepTimings } set { messageStore.stepTimings = newValue } }
 
     var modelPresets: [ModelPreset] = [
         ModelPreset(displayName: "GLM-5.3", providerID: "zai-coding-plan", modelID: "glm-5.3"),

--- a/OpenCodeClient/OpenCodeClient/Models/Message.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Message.swift
@@ -193,6 +193,41 @@ nonisolated struct Message: Codable, Identifiable {
         let trimmed = error?.message?.trimmingCharacters(in: .whitespacesAndNewlines)
         return (trimmed?.isEmpty == false) ? trimmed : nil
     }
+
+    /// Tokens the model actually emitted during this step: visible `output`
+    /// plus `reasoning` (thinking). Prefill (`input`) and cache read/write are
+    /// excluded because they are not generated tokens.
+    var generatedTokens: Int {
+        (tokens?.output ?? 0) + (tokens?.reasoning ?? 0)
+    }
+
+    /// Generation throughput in tokens/second over the step's wall-clock
+    /// window (`time.created` -> `time.completed`). The window is the LLM step
+    /// only: tool execution happens between steps, so it is not counted here.
+    /// Returns nil while the step is still running (no `completed`), when the
+    /// window is zero, or when no tokens were emitted.
+    var throughput: Double? {
+        guard let completed = time.completed else { return nil }
+        let ms = completed - time.created
+        guard ms > 0 else { return nil }
+        let tokens = generatedTokens
+        guard tokens > 0 else { return nil }
+        return Double(tokens) / (Double(ms) / 1000.0)
+    }
+
+    /// Short display form of `throughput`, e.g. "146 t/s" or "8.3 t/s".
+    /// Integer when >= 10, one decimal below that; nil when unavailable.
+    var throughputLabel: String? {
+        throughput.map(Self.throughputText)
+    }
+
+    /// Shared tokens/second formatter: integer when >= 10, one decimal below
+    /// that. Used by both the per-message footer and the Context sheet so the
+    /// two can never drift.
+    static func throughputText(_ value: Double) -> String {
+        let text = value >= 10 ? String(Int(value.rounded())) : String(format: "%.1f", value)
+        return "\(text) t/s"
+    }
 }
 
 nonisolated struct MessageWithParts: Codable {

--- a/OpenCodeClient/OpenCodeClient/Models/Message.swift
+++ b/OpenCodeClient/OpenCodeClient/Models/Message.swift
@@ -201,24 +201,45 @@ nonisolated struct Message: Codable, Identifiable {
         (tokens?.output ?? 0) + (tokens?.reasoning ?? 0)
     }
 
-    /// Generation throughput in tokens/second over the step's wall-clock
-    /// window (`time.created` -> `time.completed`). The window is the LLM step
-    /// only: tool execution happens between steps, so it is not counted here.
-    /// Returns nil while the step is still running (no `completed`), when the
-    /// window is zero, or when no tokens were emitted.
-    var throughput: Double? {
+    /// Raw step wall-clock in seconds (`time.created` -> `time.completed`).
+    /// This window spans the whole step, which on live servers includes the
+    /// step's tool execution: `Step.Ended` / `step-finish` is published only
+    /// after the tools have run (`awaitToolFibers` in the V2 runner, and the
+    /// same ordering in the legacy processor). Prefer
+    /// `throughputExcludingToolSeconds` for display.
+    var stepSeconds: Double? {
         guard let completed = time.completed else { return nil }
         let ms = completed - time.created
         guard ms > 0 else { return nil }
-        let tokens = generatedTokens
-        guard tokens > 0 else { return nil }
-        return Double(tokens) / (Double(ms) / 1000.0)
+        return Double(ms) / 1000.0
     }
 
-    /// Short display form of `throughput`, e.g. "146 t/s" or "8.3 t/s".
-    /// Integer when >= 10, one decimal below that; nil when unavailable.
-    var throughputLabel: String? {
-        throughput.map(Self.throughputText)
+    /// Throughput with the step's tool execution removed from the denominator.
+    ///
+    /// The numerator is unchanged, so tool-call argument tokens stay counted;
+    /// only the wait for the tool is dropped. A write tool that ran 48s inside
+    /// a 56s step reads as 68 t/s instead of 9 t/s. Falls back to the raw
+    /// window when the server recorded no tool timing, or when subtracting the
+    /// tool time would leave nothing positive. This is the only rate the UI
+    /// shows, so the footer and the Context sheet cannot drift.
+    func throughputExcludingToolSeconds(_ toolSeconds: Double) -> Double? {
+        guard let window = stepSeconds else { return nil }
+        let adjusted = window - max(0, toolSeconds)
+        return throughput(overSeconds: adjusted > 0 ? adjusted : window)
+    }
+
+    private func throughput(overSeconds seconds: Double?) -> Double? {
+        guard let seconds, seconds > 0 else { return nil }
+        let tokens = generatedTokens
+        guard tokens > 0 else { return nil }
+        return Double(tokens) / seconds
+    }
+
+    /// Short display form of `throughputExcludingToolSeconds`, e.g. "146 t/s" or
+    /// "8.3 t/s". Integer when >= 10, one decimal below that; nil when
+    /// unavailable.
+    func throughputLabelExcludingToolSeconds(_ toolSeconds: Double) -> String? {
+        throughputExcludingToolSeconds(toolSeconds).map(Self.throughputText)
     }
 
     /// Shared tokens/second formatter: integer when >= 10, one decimal below
@@ -233,6 +254,13 @@ nonisolated struct Message: Codable, Identifiable {
 nonisolated struct MessageWithParts: Codable {
     let info: Message
     let parts: [Part]
+
+    /// Wall-clock this step spent inside its tools (sum of `state.time`). Zero
+    /// when the server recorded no tool timing, e.g. a step that called no
+    /// tools or an older payload without `state.time`.
+    var toolRunSeconds: Double {
+        parts.compactMap(\.toolRunSeconds).reduce(0, +)
+    }
 }
 
 struct ComposerImageAttachment: Identifiable, Equatable {
@@ -256,6 +284,11 @@ struct PartStateBridge: Codable {
     /// 文件路径，来自 state.input.path/file_path/filePath 或 patchText 中的 *** Add File: / *** Update File:
     let pathFromInput: String?
 
+    /// Tool execution bounds from state.time, in epoch milliseconds. Present
+    /// for running and completed tools; nil when the server did not record it.
+    let runStartMillis: Double?
+    let runEndMillis: Double?
+
     /// For todowrite: updated todo list (if present)
     let todos: [TodoItem]?
 
@@ -276,12 +309,23 @@ struct PartStateBridge: Codable {
             return try? JSONDecoder().decode([TodoItem].self, from: data)
         }
 
+        /// state.time values arrive as JSON numbers; Int and Double both occur
+        /// depending on the server's encoder.
+        func millis(_ value: Any?) -> Double? {
+            if let double = value as? Double { return double }
+            if let int = value as? Int { return Double(int) }
+            if let number = value as? NSNumber { return number.doubleValue }
+            return nil
+        }
+
         if let str = try? container.decode(String.self) {
             displayString = str
             title = nil
             inputSummary = nil
             output = nil
             pathFromInput = nil
+            runStartMillis = nil
+            runEndMillis = nil
             todos = nil
         } else if let dict = try? container.decode([String: AnyCodable].self) {
             if let status = dict["status"]?.value as? String {
@@ -357,13 +401,21 @@ struct PartStateBridge: Codable {
                 todoList = decodeTodosFromJSONText(out)
             }
 
+            let timeObj: [String: Any]? =
+                (dict["time"]?.value as? [String: Any])
+                ?? (dict["time"]?.value as? [String: AnyCodable]).map { $0.mapValues { $0.value } }
+
             pathFromInput = pathInp
             title = tit
             inputSummary = inp
             output = out
+            runStartMillis = millis(timeObj?["start"])
+            runEndMillis = millis(timeObj?["end"])
             todos = todoList
         } else {
             pathFromInput = nil
+            runStartMillis = nil
+            runEndMillis = nil
             todos = nil
             throw DecodingError.typeMismatch(PartStateBridge.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Part.state must be String or object"))
         }
@@ -404,6 +456,16 @@ nonisolated struct Part: Codable, Identifiable {
     var toolOutput: String? { state?.output }
     var toolOutputForDisplay: String? {
         toolOutput.map(DisplayTextDecoder.decodeJSONUnicodeEscapes)
+    }
+
+    /// Wall-clock this tool itself ran, from `state.time`. Nil while running or
+    /// when the server recorded no timing. Kept separate from the step window
+    /// so tool execution can be removed from throughput denominators.
+    var toolRunSeconds: Double? {
+        guard let start = state?.runStartMillis,
+              let end = state?.runEndMillis,
+              end > start else { return nil }
+        return (end - start) / 1000.0
     }
 
     var toolTodos: [TodoItem] {

--- a/OpenCodeClient/OpenCodeClient/Stores/MessageStore.swift
+++ b/OpenCodeClient/OpenCodeClient/Stores/MessageStore.swift
@@ -28,6 +28,82 @@ final class MessageStore {
     /// Keyed by message id; cleared when the row is confirmed or removed.
     var failedSendReasonsByID: [String: String] = [:]
 
+    /// Per-step timing captured from the live SSE stream, keyed by assistant
+    /// message id. Only populated while the client observed the stream for that
+    /// step (best-effort): a restart or a message loaded purely from REST has no
+    /// entry, so the footer falls back to the general (persisted) throughput.
+    /// Not cleared by `resetStreaming()` (that fires on every message update,
+    /// including the step's own start/finish); pruned on session-scoped clears.
+    var stepTimings: [String: StepTiming] = [:]
+
+    struct StepTiming {
+        let sessionID: String
+        /// Client time the step's assistant message was first seen (step start).
+        let stepStart: Date
+        /// Client time the first visible text token arrived (nil until it does).
+        var firstTextAt: Date?
+        /// Client time the step-finish part was observed.
+        var finishAt: Date?
+        /// Output tokens reported by the step-finish part.
+        var outputTokens: Int?
+
+        /// Time to first (visible text) token, in seconds, from step start.
+        var ttft: Double? {
+            guard let first = firstTextAt else { return nil }
+            let value = first.timeIntervalSince(stepStart)
+            return value > 0 ? value : nil
+        }
+
+        /// Decoding throughput: output tokens over the (first-text -> finish)
+        /// window. Excludes prefill and reasoning, which sit before first text.
+        var decode: Double? {
+            guard let first = firstTextAt, let fin = finishAt, let out = outputTokens, out > 0 else { return nil }
+            let window = fin.timeIntervalSince(first)
+            guard window > 0 else { return nil }
+            return Double(out) / window
+        }
+
+        var ttftLabel: String? {
+            ttft.map { String(format: "%.1fs", $0) }
+        }
+
+        var decodeLabel: String? {
+            guard let d = decode else { return nil }
+            let text = d >= 10 ? String(Int(d.rounded())) : String(format: "%.1f", d)
+            return "\(text) t/s decoding"
+        }
+    }
+
+    func recordStepStart(_ messageID: String, sessionID: String) {
+        guard stepTimings[messageID] == nil else { return }
+        stepTimings[messageID] = StepTiming(sessionID: sessionID, stepStart: Date())
+    }
+
+    func recordFirstText(_ messageID: String, sessionID: String) {
+        if stepTimings[messageID] == nil {
+            stepTimings[messageID] = StepTiming(sessionID: sessionID, stepStart: Date())
+        }
+        if stepTimings[messageID]?.firstTextAt == nil {
+            stepTimings[messageID]?.firstTextAt = Date()
+        }
+    }
+
+    func recordStepFinish(_ messageID: String, sessionID: String, outputTokens: Int?) {
+        if stepTimings[messageID] == nil {
+            stepTimings[messageID] = StepTiming(sessionID: sessionID, stepStart: Date())
+        }
+        stepTimings[messageID]?.finishAt = Date()
+        if let out = outputTokens {
+            stepTimings[messageID]?.outputTokens = out
+        }
+    }
+
+    func removeTimings(forSession sessionID: String) {
+        for (id, timing) in stepTimings where timing.sessionID == sessionID {
+            stepTimings[id] = nil
+        }
+    }
+
     func isPendingOptimisticMessage(_ messageID: String) -> Bool {
         pendingOptimisticMessageIDs.contains(messageID)
     }

--- a/OpenCodeClient/OpenCodeClient/Stores/MessageStore.swift
+++ b/OpenCodeClient/OpenCodeClient/Stores/MessageStore.swift
@@ -46,33 +46,28 @@ final class MessageStore {
 
     struct StepTiming {
         let sessionID: String
-        /// Client time the step's assistant message was first seen (step start).
-        let stepStart: Date
-        /// Client time the first visible text token arrived (nil until it does).
-        var firstTextAt: Date?
-        /// Client time the step-finish part was observed.
-        var finishAt: Date?
+        /// Client time the first visible output token arrived (text or a tool
+        /// call's JSON input; reasoning is excluded because `outputTokens`
+        /// excludes it too). Nil until one does.
+        var firstVisibleAt: Date?
+        /// Client time the most recent visible output token arrived. Together
+        /// with `firstVisibleAt` this forms the decoding window.
+        var lastVisibleAt: Date?
         /// Output tokens reported by the step-finish part.
         var outputTokens: Int?
 
-        /// Time to first (visible text) token, in seconds, from step start.
-        var ttft: Double? {
-            guard let first = firstTextAt else { return nil }
-            let value = first.timeIntervalSince(stepStart)
-            return value > 0 ? value : nil
-        }
-
-        /// Decoding throughput: output tokens over the (first-text -> finish)
-        /// window. Excludes prefill and reasoning, which sit before first text.
+        /// Decoding throughput: output tokens over the visible streaming window
+        /// (first token -> last token). Excludes prefill, which sits before the
+        /// first token, and tool execution, which sits after the last one (the
+        /// step-finish part only arrives once the step's tools have run, so it
+        /// is never used as a window end). Nil unless both ends were observed
+        /// and the step reported its output tokens.
         var decode: Double? {
-            guard let first = firstTextAt, let fin = finishAt, let out = outputTokens, out > 0 else { return nil }
-            let window = fin.timeIntervalSince(first)
+            guard let first = firstVisibleAt, let last = lastVisibleAt,
+                  let out = outputTokens, out > 0 else { return nil }
+            let window = last.timeIntervalSince(first)
             guard window > 0 else { return nil }
             return Double(out) / window
-        }
-
-        var ttftLabel: String? {
-            ttft.map { String(format: "%.1fs", $0) }
         }
 
         var decodeLabel: String? {
@@ -82,23 +77,28 @@ final class MessageStore {
         }
     }
 
+    /// Marks that the step's assistant message was observed before any of its
+    /// tokens arrived. Only steps with an entry get a decoding window: if the
+    /// client joined mid-step, a truncated window would fabricate a number.
     func recordStepStart(_ messageID: String, sessionID: String) {
         guard stepTimings[messageID] == nil else { return }
-        stepTimings[messageID] = StepTiming(sessionID: sessionID, stepStart: Date())
+        stepTimings[messageID] = StepTiming(sessionID: sessionID)
     }
 
-    /// Stamps the first visible text token. No-op unless the step start was
-    /// already observed: if the client joined mid-step there is no entry, so a
-    /// truncated window never yields a fabricated TTFT/decoding number.
-    func recordFirstText(_ messageID: String, sessionID: String) {
-        if stepTimings[messageID]?.firstTextAt == nil {
-            stepTimings[messageID]?.firstTextAt = Date()
+    /// Stamps one visible output token (text or tool-call input): the first
+    /// sighting opens the decoding window, every sighting moves its end. No-op
+    /// unless the step start was already observed; see `recordStepStart`.
+    func recordVisibleToken(_ messageID: String, sessionID: String) {
+        let now = Date()
+        if stepTimings[messageID]?.firstVisibleAt == nil {
+            stepTimings[messageID]?.firstVisibleAt = now
         }
+        stepTimings[messageID]?.lastVisibleAt = now
     }
 
-    /// No-op unless the step start was already observed (see `recordFirstText`).
+    /// No-op unless the step start was already observed (see
+    /// `recordVisibleToken`).
     func recordStepFinish(_ messageID: String, sessionID: String, outputTokens: Int?) {
-        stepTimings[messageID]?.finishAt = Date()
         if let out = outputTokens {
             stepTimings[messageID]?.outputTokens = out
         }

--- a/OpenCodeClient/OpenCodeClient/Stores/MessageStore.swift
+++ b/OpenCodeClient/OpenCodeClient/Stores/MessageStore.swift
@@ -36,6 +36,14 @@ final class MessageStore {
     /// including the step's own start/finish); pruned on session-scoped clears.
     var stepTimings: [String: StepTiming] = [:]
 
+    /// partID -> part type, keyed by "\(sessionID):\(partID)". Populated from
+    /// `message.part.updated` (which carries the part's `type`) before any of
+    /// that part's `message.part.delta` events arrive. The delta event carries
+    /// only `field`, which the server sets to "text" for BOTH reasoning and
+    /// text parts, so this map is what lets us stamp first-text only for
+    /// genuine text parts. First write wins: a part's type never changes.
+    private var partTypes: [String: String] = [:]
+
     struct StepTiming {
         let sessionID: String
         /// Client time the step's assistant message was first seen (step start).
@@ -79,19 +87,17 @@ final class MessageStore {
         stepTimings[messageID] = StepTiming(sessionID: sessionID, stepStart: Date())
     }
 
+    /// Stamps the first visible text token. No-op unless the step start was
+    /// already observed: if the client joined mid-step there is no entry, so a
+    /// truncated window never yields a fabricated TTFT/decoding number.
     func recordFirstText(_ messageID: String, sessionID: String) {
-        if stepTimings[messageID] == nil {
-            stepTimings[messageID] = StepTiming(sessionID: sessionID, stepStart: Date())
-        }
         if stepTimings[messageID]?.firstTextAt == nil {
             stepTimings[messageID]?.firstTextAt = Date()
         }
     }
 
+    /// No-op unless the step start was already observed (see `recordFirstText`).
     func recordStepFinish(_ messageID: String, sessionID: String, outputTokens: Int?) {
-        if stepTimings[messageID] == nil {
-            stepTimings[messageID] = StepTiming(sessionID: sessionID, stepStart: Date())
-        }
         stepTimings[messageID]?.finishAt = Date()
         if let out = outputTokens {
             stepTimings[messageID]?.outputTokens = out
@@ -102,6 +108,27 @@ final class MessageStore {
         for (id, timing) in stepTimings where timing.sessionID == sessionID {
             stepTimings[id] = nil
         }
+    }
+
+    func recordPartType(sessionID: String, partID: String, type: String) {
+        let key = "\(sessionID):\(partID)"
+        if partTypes[key] == nil {
+            partTypes[key] = type
+        }
+    }
+
+    func partType(for partID: String, inSession sessionID: String) -> String? {
+        partTypes["\(sessionID):\(partID)"]
+    }
+
+    func removePartTypes(forSession sessionID: String) {
+        for key in partTypes.keys where key.hasPrefix("\(sessionID):") {
+            partTypes[key] = nil
+        }
+    }
+
+    func clearPartTypes() {
+        partTypes = [:]
     }
 
     func isPendingOptimisticMessage(_ messageID: String) -> Bool {
@@ -252,6 +279,7 @@ final class MessageStore {
         }
 
         let partType = (partObject["type"] as? String) ?? "text"
+        recordPartType(sessionID: sessionID, partID: partID, type: partType)
 
         if let delta = properties["delta"]?.value as? String,
            !delta.isEmpty {

--- a/OpenCodeClient/OpenCodeClient/Support/L10n.swift
+++ b/OpenCodeClient/OpenCodeClient/Support/L10n.swift
@@ -354,6 +354,11 @@ enum L10n {
         case contextUsageLoadingConfig
         case contextUsageNoUsageData
         case contextUsageConfigNotLoaded
+        case contextUsageSectionThroughput
+        case contextUsageThroughputAvg
+        case contextUsageThroughputTime
+        case contextUsageThroughputTokens
+        case contextUsageThroughputNoData
         case quotaTitle
         case quotaDataSource
         case quotaNotLoaded
@@ -786,6 +791,11 @@ enum L10n {
         Key.contextUsageLoadingConfig.rawValue: "Loading provider config...",
         Key.contextUsageNoUsageData.rawValue: "No usage data",
         Key.contextUsageConfigNotLoaded.rawValue: "Provider config not loaded",
+        Key.contextUsageSectionThroughput.rawValue: "Throughput",
+        Key.contextUsageThroughputAvg.rawValue: "Avg throughput",
+        Key.contextUsageThroughputTime.rawValue: "Generation time",
+        Key.contextUsageThroughputTokens.rawValue: "Generated tokens",
+        Key.contextUsageThroughputNoData.rawValue: "No throughput data",
         Key.quotaTitle.rawValue: "Usage & Limits",
         Key.quotaDataSource.rawValue: "Data Source",
         Key.quotaNotLoaded.rawValue: "Quota data has not been loaded.",
@@ -1222,6 +1232,11 @@ enum L10n {
         Key.contextUsageLoadingConfig.rawValue: "正在加载服务商配置...",
         Key.contextUsageNoUsageData.rawValue: "无使用数据",
         Key.contextUsageConfigNotLoaded.rawValue: "未加载服务商配置",
+        Key.contextUsageSectionThroughput.rawValue: "生成速率",
+        Key.contextUsageThroughputAvg.rawValue: "平均速率",
+        Key.contextUsageThroughputTime.rawValue: "生成耗时",
+        Key.contextUsageThroughputTokens.rawValue: "生成令牌",
+        Key.contextUsageThroughputNoData.rawValue: "无速率数据",
         Key.quotaTitle.rawValue: "用量与限额",
         Key.quotaDataSource.rawValue: "数据来源",
         Key.quotaNotLoaded.rawValue: "尚未加载 quota 数据。",

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ContextUsageView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ContextUsageView.swift
@@ -15,6 +15,9 @@ struct ContextUsageSnapshot: Identifiable {
     let tokens: Message.TokenInfo
     let latestMessageCost: Double?
     let totalSessionCost: Double?
+    let totalOutputTokens: Int
+    let totalGenerationSeconds: Double?
+    let averageThroughput: Double?
 }
 
 extension AppState {
@@ -42,6 +45,24 @@ extension AppState {
         let sumCost = messages.compactMap { $0.info.cost }.reduce(0.0, +)
         let totalCost: Double? = sumCost > 0 ? sumCost : nil
 
+        // Session-level LLM throughput: sum emitted tokens over the total LLM
+        // step time. Each step's window excludes tool execution, so this is a
+        // clean generation rate across the whole conversation.
+        var totalOutput = 0
+        var totalSeconds = 0.0
+        for m in messages where m.info.isAssistant {
+            guard let completed = m.info.time.completed else { continue }
+            let ms = completed - m.info.time.created
+            guard ms > 0 else { continue }
+            let gen = m.info.generatedTokens
+            guard gen > 0 else { continue }
+            totalOutput += gen
+            totalSeconds += Double(ms) / 1000.0
+        }
+        let avgThroughput: Double? = (totalSeconds > 0 && totalOutput > 0)
+            ? Double(totalOutput) / totalSeconds
+            : nil
+
         return ContextUsageSnapshot(
             sessionID: sessionID,
             sessionTitle: session.title,
@@ -50,7 +71,10 @@ extension AppState {
             contextLimit: contextLimit,
             tokens: tokens,
             latestMessageCost: last.info.cost,
-            totalSessionCost: totalCost
+            totalSessionCost: totalCost,
+            totalOutputTokens: totalOutput,
+            totalGenerationSeconds: totalSeconds > 0 ? totalSeconds : nil,
+            averageThroughput: avgThroughput
         )
     }
 }
@@ -158,6 +182,19 @@ private struct ContextUsageDetailView: View {
                     LabeledContent(L10n.t(.contextUsageLimitLabel), value: String(s.contextLimit))
                 }
 
+                Section(L10n.t(.contextUsageSectionThroughput)) {
+                    if let avg = s.averageThroughput {
+                        LabeledContent(L10n.t(.contextUsageThroughputAvg), value: Message.throughputText(avg))
+                        LabeledContent(L10n.t(.contextUsageThroughputTokens), value: String(s.totalOutputTokens))
+                        if let sec = s.totalGenerationSeconds {
+                            LabeledContent(L10n.t(.contextUsageThroughputTime), value: formatSeconds(sec))
+                        }
+                    } else {
+                        Text(L10n.t(.contextUsageThroughputNoData))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 Section(L10n.t(.contextUsageSectionTokens)) {
                     LabeledContent(L10n.t(.contextUsageTotalLabel), value: String(s.tokens.total))
                     LabeledContent(L10n.t(.contextUsageInputLabel), value: String(s.tokens.input))
@@ -195,4 +232,12 @@ private struct ContextUsageDetailView: View {
         .navigationTitle(L10n.t(.contextUsageTitle))
         .navigationBarTitleDisplayMode(.inline)
     }
+}
+
+/// "1m 5s" / "48.2s" for the session's total LLM generation time.
+private func formatSeconds(_ seconds: Double) -> String {
+    if seconds < 60 { return String(format: "%.1fs", seconds) }
+    let minutes = Int(seconds / 60)
+    let remainder = Int(seconds.truncatingRemainder(dividingBy: 60))
+    return "\(minutes)m \(remainder)s"
 }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/ContextUsageView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/ContextUsageView.swift
@@ -45,19 +45,19 @@ extension AppState {
         let sumCost = messages.compactMap { $0.info.cost }.reduce(0.0, +)
         let totalCost: Double? = sumCost > 0 ? sumCost : nil
 
-        // Session-level LLM throughput: sum emitted tokens over the total LLM
-        // step time. Each step's window excludes tool execution, so this is a
-        // clean generation rate across the whole conversation.
+        // Session-level LLM throughput: sum emitted tokens over the total
+        // generation time. The step window (`created` -> `completed`) contains
+        // the step's tool execution, so each step's tool wall-clock is
+        // subtracted before the rate is computed.
         var totalOutput = 0
         var totalSeconds = 0.0
         for m in messages where m.info.isAssistant {
-            guard let completed = m.info.time.completed else { continue }
-            let ms = completed - m.info.time.created
-            guard ms > 0 else { continue }
+            guard let window = m.info.stepSeconds else { continue }
             let gen = m.info.generatedTokens
             guard gen > 0 else { continue }
+            let generation = window - m.toolRunSeconds
             totalOutput += gen
-            totalSeconds += Double(ms) / 1000.0
+            totalSeconds += generation > 0 ? generation : window
         }
         let avgThroughput: Double? = (totalSeconds > 0 && totalOutput > 0)
             ? Double(totalOutput) / totalSeconds

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -31,14 +31,18 @@ struct MessageRowView: View {
         Array(repeating: GridItem(.flexible(), spacing: DesignSpacing.sm), count: cardGridColumnCount)
     }
 
-    /// Assistant footer line: "provider/model", plus " | X t/s" when the step
-    /// finished and emitted tokens. The model alone is shown while a step is
-    /// still generating (no `completed` timestamp yet).
-    private static func modelFooter(model: Message.ModelInfo, throughput: String?) -> String {
-        let base = "\(model.providerID)/\(model.modelID)"
-        guard let throughput else { return base }
-        return "\(base) | \(throughput)"
-    }
+    /// Assistant footer line: "provider/model", then the general (persisted)
+/// throughput when present, then best-effort SSE-derived "TTFT" and "decoding"
+/// throughput when the client observed the live stream for this step. Each
+/// optional segment is omitted when nil, so a message loaded purely from REST
+/// (no SSE) shows only the model plus general throughput.
+private static func modelFooter(model: Message.ModelInfo, general: String?, ttft: String?, decode: String?) -> String {
+    var parts: [String] = ["\(model.providerID)/\(model.modelID)"]
+    if let general { parts.append(general) }
+    if let ttft { parts.append("TTFT: \(ttft)") }
+    if let decode { parts.append(decode) }
+    return parts.joined(separator: " | ")
+}
 
     enum AssistantBlock: Identifiable {
         case text(Part)
@@ -502,7 +506,15 @@ struct MessageRowView: View {
             if message.info.resolvedModel != nil || !copyableText.isEmpty {
                 HStack {
                     if let model = message.info.resolvedModel {
-                        Text(Self.modelFooter(model: model, throughput: message.info.throughputLabel))
+                        let timing = state.stepTimings[message.info.id]
+                        Text(
+                            Self.modelFooter(
+                                model: model,
+                                general: message.info.throughputLabel,
+                                ttft: timing?.ttftLabel,
+                                decode: timing?.decodeLabel
+                            )
+                        )
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -32,14 +32,18 @@ struct MessageRowView: View {
     }
 
     /// Assistant footer line: "provider/model", then the general (persisted)
-    /// throughput when present, then best-effort SSE-derived "TTFT" and "decoding"
+    /// throughput when present, then the best-effort SSE-derived "decoding"
     /// throughput when the client observed the live stream for this step. Each
     /// optional segment is omitted when nil, so a message loaded purely from REST
     /// (no SSE) shows only the model plus general throughput.
-    private static func modelFooter(model: Message.ModelInfo, general: String?, ttft: String?, decode: String?) -> String {
+    ///
+    /// The general segment excludes the step's tool wall-clock: the step window
+    /// (`created` -> `completed`) contains tool execution on both server
+    /// lineages, which otherwise collapses a 2000-token write call whose tool
+    /// ran 48s into single-digit t/s.
+    private static func modelFooter(model: Message.ModelInfo, general: String?, decode: String?) -> String {
         var parts: [String] = ["\(model.providerID)/\(model.modelID)"]
         if let general { parts.append(general) }
-        if let ttft { parts.append("TTFT: \(ttft)") }
         if let decode { parts.append(decode) }
         return parts.joined(separator: " | ")
     }
@@ -510,8 +514,7 @@ struct MessageRowView: View {
                         Text(
                             Self.modelFooter(
                                 model: model,
-                                general: message.info.throughputLabel,
-                                ttft: timing?.ttftLabel,
+                                general: message.info.throughputLabelExcludingToolSeconds(message.toolRunSeconds),
                                 decode: timing?.decodeLabel
                             )
                         )

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -32,17 +32,17 @@ struct MessageRowView: View {
     }
 
     /// Assistant footer line: "provider/model", then the general (persisted)
-/// throughput when present, then best-effort SSE-derived "TTFT" and "decoding"
-/// throughput when the client observed the live stream for this step. Each
-/// optional segment is omitted when nil, so a message loaded purely from REST
-/// (no SSE) shows only the model plus general throughput.
-private static func modelFooter(model: Message.ModelInfo, general: String?, ttft: String?, decode: String?) -> String {
-    var parts: [String] = ["\(model.providerID)/\(model.modelID)"]
-    if let general { parts.append(general) }
-    if let ttft { parts.append("TTFT: \(ttft)") }
-    if let decode { parts.append(decode) }
-    return parts.joined(separator: " | ")
-}
+    /// throughput when present, then best-effort SSE-derived "TTFT" and "decoding"
+    /// throughput when the client observed the live stream for this step. Each
+    /// optional segment is omitted when nil, so a message loaded purely from REST
+    /// (no SSE) shows only the model plus general throughput.
+    private static func modelFooter(model: Message.ModelInfo, general: String?, ttft: String?, decode: String?) -> String {
+        var parts: [String] = ["\(model.providerID)/\(model.modelID)"]
+        if let general { parts.append(general) }
+        if let ttft { parts.append("TTFT: \(ttft)") }
+        if let decode { parts.append(decode) }
+        return parts.joined(separator: " | ")
+    }
 
     enum AssistantBlock: Identifiable {
         case text(Part)

--- a/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
+++ b/OpenCodeClient/OpenCodeClient/Views/Chat/MessageRowView.swift
@@ -31,6 +31,15 @@ struct MessageRowView: View {
         Array(repeating: GridItem(.flexible(), spacing: DesignSpacing.sm), count: cardGridColumnCount)
     }
 
+    /// Assistant footer line: "provider/model", plus " | X t/s" when the step
+    /// finished and emitted tokens. The model alone is shown while a step is
+    /// still generating (no `completed` timestamp yet).
+    private static func modelFooter(model: Message.ModelInfo, throughput: String?) -> String {
+        let base = "\(model.providerID)/\(model.modelID)"
+        guard let throughput else { return base }
+        return "\(base) | \(throughput)"
+    }
+
     enum AssistantBlock: Identifiable {
         case text(Part)
         case cards([Part])
@@ -493,7 +502,7 @@ struct MessageRowView: View {
             if message.info.resolvedModel != nil || !copyableText.isEmpty {
                 HStack {
                     if let model = message.info.resolvedModel {
-                        Text("\(model.providerID)/\(model.modelID)")
+                        Text(Self.modelFooter(model: model, throughput: message.info.throughputLabel))
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }

--- a/OpenCodeClient/OpenCodeClientTests/ModelsTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/ModelsTests.swift
@@ -47,60 +47,129 @@ struct MessageThroughputTests {
     @Test func throughputBasic() throws {
         // 2000ms window, 200 output tokens -> 100 t/s
         let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":3000},\"tokens\":{\"output\":200,\"reasoning\":0}")
-        #expect(m.throughput == 100.0)
+        #expect(m.throughputExcludingToolSeconds(0) == 100.0)
     }
 
     @Test func throughputIncludesReasoning() throws {
         // 3000ms window, 200 output + 100 reasoning = 300 tokens -> 100 t/s
         let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":4000},\"tokens\":{\"output\":200,\"reasoning\":100}")
         #expect(m.generatedTokens == 300)
-        #expect(m.throughput == 100.0)
+        #expect(m.throughputExcludingToolSeconds(0) == 100.0)
     }
 
     @Test func throughputNilWhileRunning() throws {
         let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":null},\"tokens\":{\"output\":200}")
-        #expect(m.throughput == nil)
+        #expect(m.throughputExcludingToolSeconds(0) == nil)
     }
 
     @Test func throughputNilZeroWindow() throws {
         let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":1000},\"tokens\":{\"output\":200}")
-        #expect(m.throughput == nil)
+        #expect(m.throughputExcludingToolSeconds(0) == nil)
     }
 
     @Test func throughputNilNoTokens() throws {
         let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":3000},\"tokens\":{\"output\":0,\"reasoning\":0}")
         #expect(m.generatedTokens == 0)
-        #expect(m.throughput == nil)
+        #expect(m.throughputExcludingToolSeconds(0) == nil)
     }
 
     @Test func throughputLabelInteger() throws {
         // 1460 tokens / 10s = 146 t/s -> "146 t/s"
         let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":11000},\"tokens\":{\"output\":1460}")
-        #expect(m.throughputLabel == "146 t/s")
+        #expect(m.throughputLabelExcludingToolSeconds(0) == "146 t/s")
     }
 
     @Test func throughputLabelDecimal() throws {
         // 83 tokens / 10s = 8.3 t/s -> "8.3 t/s"
         let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":11000},\"tokens\":{\"output\":83}")
-        #expect(m.throughputLabel == "8.3 t/s")
+        #expect(m.throughputLabelExcludingToolSeconds(0) == "8.3 t/s")
     }
 
     @Test func throughputLabelNilWhenUncomputed() throws {
         let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":null}")
-        #expect(m.throughputLabel == nil)
+        #expect(m.throughputLabelExcludingToolSeconds(0) == nil)
     }
 
     @Test func throughputNilWhenTokensMissing() throws {
         // Valid 2s window but no tokens field at all -> generatedTokens 0 -> nil
         let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":3000}")
         #expect(m.generatedTokens == 0)
-        #expect(m.throughput == nil)
+        #expect(m.throughputExcludingToolSeconds(0) == nil)
     }
 
     @Test func throughputNilNegativeWindow() throws {
         // completed before created (bad data) -> nil, never a negative rate
         let m = try makeMessage("\"time\":{\"created\":3000,\"completed\":1000},\"tokens\":{\"output\":200}")
-        #expect(m.throughput == nil)
+        #expect(m.throughputExcludingToolSeconds(0) == nil)
+    }
+
+    @Test func throughputExcludesToolSeconds() throws {
+        // Real case: 529 tokens, 56.157s step window of which a write tool ran
+        // 48.345s -> 67.7 t/s instead of 9.4 t/s.
+        let m = try makeMessage("\"time\":{\"created\":0,\"completed\":56157},\"tokens\":{\"output\":529}")
+        let value = m.throughputExcludingToolSeconds(48.345)
+        #expect(abs((value ?? -1) - 67.72) < 0.05)
+        // Zero tool time is the raw step window: 529 / 56.157s = 9.42 t/s.
+        #expect(abs((m.throughputExcludingToolSeconds(0) ?? -1) - 9.42) < 0.01)
+    }
+
+    @Test func throughputFallsBackWhenToolTimeExceedsWindow() throws {
+        // Clock skew can make tool time swallow the window; never divide by a
+        // non-positive window, fall back to the raw step window.
+        let m = try makeMessage("\"time\":{\"created\":0,\"completed\":5000},\"tokens\":{\"output\":500}")
+        #expect(m.throughputExcludingToolSeconds(9.0) == 100.0)
+    }
+
+    @Test func throughputExcludingToolSecondsNilWhileRunning() throws {
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":null},\"tokens\":{\"output\":200}")
+        #expect(m.throughputExcludingToolSeconds(1.0) == nil)
+    }
+
+    @Test func throughputLabelExcludesToolSeconds() throws {
+        let m = try makeMessage("\"time\":{\"created\":0,\"completed\":56157},\"tokens\":{\"output\":529}")
+        #expect(m.throughputLabelExcludingToolSeconds(48.345) == "68 t/s")
+    }
+}
+
+// MARK: - Tool timing extraction tests
+
+struct MessageToolTimingTests {
+
+    private func messageWithParts(_ parts: String) throws -> MessageWithParts {
+        let json = """
+        {"info":{"id":"m1","sessionID":"s1","role":"assistant","time":{"created":0,"completed":60000},"tokens":{"output":600}},"parts":[\(parts)]}
+        """
+        return try JSONDecoder().decode(MessageWithParts.self, from: json.data(using: .utf8)!)
+    }
+
+    @Test func sumsToolStateTime() throws {
+        // Two completed tools: 48s + 5s = 53s. Step window 60s -> 7s of
+        // generation, so 600 tokens / 7s = 85.7 t/s.
+        let m = try messageWithParts("""
+        {"id":"p1","messageID":"m1","sessionID":"s1","type":"tool","tool":"write","state":{"status":"completed","time":{"start":1000,"end":49000},"input":{"path":"a"},"output":"ok"}},
+        {"id":"p2","messageID":"m1","sessionID":"s1","type":"tool","tool":"read","state":{"status":"completed","time":{"start":50000,"end":55000}}}
+        """)
+        #expect(abs(m.toolRunSeconds - 53.0) < 0.001)
+        #expect(abs((m.info.throughputExcludingToolSeconds(m.toolRunSeconds) ?? -1) - (600.0 / 7.0)) < 0.01)
+    }
+
+    @Test func toolRunSecondsZeroWithoutStateTime() throws {
+        // Older payloads carry no state.time; the correction must degrade to the
+        // raw step window instead of dropping tool time it cannot see.
+        let m = try messageWithParts("""
+        {"id":"p1","messageID":"m1","sessionID":"s1","type":"tool","tool":"write","state":{"status":"completed","input":{"path":"a"},"output":"ok"}},
+        {"id":"p2","messageID":"m1","sessionID":"s1","type":"text","text":"hi"}
+        """)
+        #expect(m.toolRunSeconds == 0)
+        #expect(m.info.throughputExcludingToolSeconds(m.toolRunSeconds) == 10.0)
+    }
+
+    @Test func runningToolWithoutEndDoesNotCount() throws {
+        // start but no end -> still running -> no measurable tool time yet.
+        let m = try messageWithParts("""
+        {"id":"p1","messageID":"m1","sessionID":"s1","type":"tool","tool":"bash","state":{"status":"running","time":{"start":1000},"input":{"command":"sleep 60"}}}
+        """)
+        #expect(m.toolRunSeconds == 0)
     }
 }
 
@@ -152,6 +221,36 @@ struct ContextUsageThroughputTests {
     }
 
     @Test @MainActor
+    func excludesToolTimeFromAggregate() async throws {
+        let state = AppState()
+        let session = try JSONDecoder().decode(Session.self, from: """
+        {"id":"ses_x","slug":"ses_x","projectID":"p1","directory":"/workspace","title":"S","version":"1","time":{"created":1,"updated":2}}
+        """.data(using: .utf8)!)
+        state.sessions = [session]
+        state.currentSessionID = "ses_x"
+        state.providerModelsIndex["openai/gpt-4"] = ProviderModel(
+            id: "gpt-4", name: "G", providerID: "openai",
+            limit: ProviderModelLimit(context: 100_000, input: nil, output: nil)
+        )
+
+        // A: 2s step, 200 out, no tools. B: 60s step, 600 out, 53s inside tools.
+        // Generation time = 2 + 7 = 9s, tokens = 800 -> 88.9 t/s. Counting the
+        // raw step windows would report 12.9 t/s.
+        let withTool = try JSONDecoder().decode(MessageWithParts.self, from: """
+        {"info":{"id":"mB","sessionID":"ses_x","role":"assistant","model":{"providerID":"openai","modelID":"gpt-4"},"time":{"created":0,"completed":60000},"tokens":{"output":600,"reasoning":0}},"parts":[{"id":"p1","messageID":"mB","sessionID":"ses_x","type":"tool","tool":"write","state":{"status":"completed","time":{"start":1000,"end":54000},"input":{"path":"a"}}}]}
+        """.data(using: .utf8)!)
+        state.messages = [
+            try message("mA", "assistant", 1000, "3000", 200, 0),
+            withTool,
+        ]
+
+        let snap = state.contextUsageSnapshot
+        #expect(snap?.totalOutputTokens == 800)
+        #expect(abs((snap?.totalGenerationSeconds ?? -1) - 9.0) < 0.001)
+        #expect(abs((snap?.averageThroughput ?? -1) - (800.0 / 9.0)) < 0.01)
+    }
+
+    @Test @MainActor
     func snapshotNilWithoutAnyCompletedStep() async throws {
         let state = AppState()
         let session = try JSONDecoder().decode(Session.self, from: """
@@ -172,67 +271,61 @@ struct ContextUsageThroughputTests {
     }
 }
 
-// MARK: - StepTiming (SSE-derived TTFT + decoding) Tests
+// MARK: - StepTiming (SSE-derived decoding) Tests
 
 struct StepTimingTests {
 
     private func timing(
-        _ start: TimeInterval,
         _ first: TimeInterval?,
-        _ finish: TimeInterval?,
+        _ last: TimeInterval?,
         _ output: Int?
     ) -> MessageStore.StepTiming {
         MessageStore.StepTiming(
             sessionID: "s1",
-            stepStart: Date(timeIntervalSinceReferenceDate: start),
-            firstTextAt: first.map { Date(timeIntervalSinceReferenceDate: $0) },
-            finishAt: finish.map { Date(timeIntervalSinceReferenceDate: $0) },
+            firstVisibleAt: first.map { Date(timeIntervalSinceReferenceDate: $0) },
+            lastVisibleAt: last.map { Date(timeIntervalSinceReferenceDate: $0) },
             outputTokens: output
         )
     }
 
-    @Test func ttftFromStepStartToFirstText() {
-        let t = timing(0, 3.2, nil, nil)
-        #expect(abs((t.ttft ?? -1) - 3.2) < 0.001)
-        #expect(t.ttftLabel == "3.2s")
-    }
-
-    @Test func ttftNilWithoutFirstText() {
-        let t = timing(0, nil, nil, nil)
-        #expect(t.ttft == nil)
-        #expect(t.ttftLabel == nil)
-    }
-
-    @Test func ttftNilWhenFirstTextNotAfterStart() {
-        // first token stamped before step start (bad data) -> no negative TTFT
-        let t = timing(5, 2, nil, nil)
-        #expect(t.ttft == nil)
-    }
-
-    @Test func decodeOverFirstTextToFinishWindow() {
-        // 100 output tokens over (4.7 - 3.2) = 1.5s -> 66.67 t/s
-        let t = timing(0, 3.2, 4.7, 100)
+    @Test func decodeOverVisibleWindow() {
+        // 100 output tokens over (4.7 - 3.2) = 1.5s.
+        let t = timing(3.2, 4.7, 100)
         #expect(abs((t.decode ?? -1) - (100.0 / 1.5)) < 0.01)
         #expect(t.decodeLabel == "67 t/s decoding")
     }
 
+    @Test func decodeEndsAtLastVisibleTokenNotStepFinish() {
+        // Generated tokens stopped at 4.0s; the step-finish part only arrived
+        // after the step's tool ran. The window must end at the last token.
+        let t = timing(3.2, 4.0, 100)
+        #expect(abs((t.decode ?? -1) - 125.0) < 0.01)
+    }
+
+    @Test func decodeCoversToolCallOnlyStep() {
+        // No text at all: the visible window is the tool-call JSON input stream.
+        let t = timing(1.0, 3.0, 200)
+        #expect(abs((t.decode ?? -1) - 100.0) < 0.01)
+    }
+
     @Test func decodeLabelDecimalBelowTen() {
         // 15 output over 3.0s -> 5.0 t/s -> one decimal
-        let t = timing(0, 0, 3.0, 15)
+        let t = timing(0, 3.0, 15)
         #expect(t.decodeLabel == "5.0 t/s decoding")
     }
 
-    @Test func decodeNilMissingFinishOrTokens() {
-        #expect(timing(0, 3.2, nil, 100).decode == nil)
-        #expect(timing(0, 3.2, 4.7, nil).decode == nil)
-        #expect(timing(0, 3.2, 4.7, 0).decode == nil)
-        #expect(timing(0, nil, 4.7, 100).decode == nil)
+    @Test func decodeNilMissingEitherEndOrTokens() {
+        #expect(timing(3.2, 4.7, nil).decode == nil)
+        #expect(timing(3.2, 4.7, 0).decode == nil)
+        #expect(timing(nil, 4.7, 100).decode == nil)
+        // Only one visible token: no measurable window, so no number.
+        #expect(timing(3.2, nil, 100).decode == nil)
     }
 
     @Test func decodeNilOnNonPositiveWindow() {
-        // finish before or equal to first text -> no window
-        #expect(timing(0, 3.2, 3.2, 100).decode == nil)
-        #expect(timing(0, 3.2, 3.1, 100).decode == nil)
+        // end before or equal to the first visible token -> no window
+        #expect(timing(3.2, 3.2, 100).decode == nil)
+        #expect(timing(3.2, 3.1, 100).decode == nil)
     }
 }
 

--- a/OpenCodeClient/OpenCodeClientTests/ModelsTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/ModelsTests.swift
@@ -33,6 +33,145 @@ struct MessageRoleTests {
     }
 }
 
+// MARK: - Message Throughput Tests
+
+struct MessageThroughputTests {
+
+    private func makeMessage(_ extra: String) throws -> Message {
+        let json = """
+        {"id":"m1","sessionID":"s1","role":"assistant","parentID":null,"model":{"providerID":"openai","modelID":"gpt-4"},\(extra)}
+        """
+        return try JSONDecoder().decode(Message.self, from: json.data(using: .utf8)!)
+    }
+
+    @Test func throughputBasic() throws {
+        // 2000ms window, 200 output tokens -> 100 t/s
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":3000},\"tokens\":{\"output\":200,\"reasoning\":0}")
+        #expect(m.throughput == 100.0)
+    }
+
+    @Test func throughputIncludesReasoning() throws {
+        // 3000ms window, 200 output + 100 reasoning = 300 tokens -> 100 t/s
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":4000},\"tokens\":{\"output\":200,\"reasoning\":100}")
+        #expect(m.generatedTokens == 300)
+        #expect(m.throughput == 100.0)
+    }
+
+    @Test func throughputNilWhileRunning() throws {
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":null},\"tokens\":{\"output\":200}")
+        #expect(m.throughput == nil)
+    }
+
+    @Test func throughputNilZeroWindow() throws {
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":1000},\"tokens\":{\"output\":200}")
+        #expect(m.throughput == nil)
+    }
+
+    @Test func throughputNilNoTokens() throws {
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":3000},\"tokens\":{\"output\":0,\"reasoning\":0}")
+        #expect(m.generatedTokens == 0)
+        #expect(m.throughput == nil)
+    }
+
+    @Test func throughputLabelInteger() throws {
+        // 1460 tokens / 10s = 146 t/s -> "146 t/s"
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":11000},\"tokens\":{\"output\":1460}")
+        #expect(m.throughputLabel == "146 t/s")
+    }
+
+    @Test func throughputLabelDecimal() throws {
+        // 83 tokens / 10s = 8.3 t/s -> "8.3 t/s"
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":11000},\"tokens\":{\"output\":83}")
+        #expect(m.throughputLabel == "8.3 t/s")
+    }
+
+    @Test func throughputLabelNilWhenUncomputed() throws {
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":null}")
+        #expect(m.throughputLabel == nil)
+    }
+
+    @Test func throughputNilWhenTokensMissing() throws {
+        // Valid 2s window but no tokens field at all -> generatedTokens 0 -> nil
+        let m = try makeMessage("\"time\":{\"created\":1000,\"completed\":3000}")
+        #expect(m.generatedTokens == 0)
+        #expect(m.throughput == nil)
+    }
+
+    @Test func throughputNilNegativeWindow() throws {
+        // completed before created (bad data) -> nil, never a negative rate
+        let m = try makeMessage("\"time\":{\"created\":3000,\"completed\":1000},\"tokens\":{\"output\":200}")
+        #expect(m.throughput == nil)
+    }
+}
+
+// MARK: - ContextUsage Throughput Aggregation Tests
+
+struct ContextUsageThroughputTests {
+
+    private func message(
+        _ id: String,
+        _ role: String,
+        _ created: Int,
+        _ completed: String,
+        _ output: Int,
+        _ reasoning: Int = 0
+    ) throws -> MessageWithParts {
+        let json = """
+        {"info":{"id":"\(id)","sessionID":"ses_x","role":"\(role)","model":{"providerID":"openai","modelID":"gpt-4"},"time":{"created":\(created),"completed":\(completed)},"tokens":{"output":\(output),"reasoning":\(reasoning)}},"parts":[]}
+        """
+        return try JSONDecoder().decode(MessageWithParts.self, from: json.data(using: .utf8)!)
+    }
+
+    @Test @MainActor
+    func aggregatesThroughputAndExcludesRunning() async throws {
+        let state = AppState()
+        let session = try JSONDecoder().decode(Session.self, from: """
+        {"id":"ses_x","slug":"ses_x","projectID":"p1","directory":"/workspace","title":"S","version":"1","time":{"created":1,"updated":2}}
+        """.data(using: .utf8)!)
+        state.sessions = [session]
+        state.currentSessionID = "ses_x"
+        state.providerModelsIndex["openai/gpt-4"] = ProviderModel(
+            id: "gpt-4", name: "G", providerID: "openai",
+            limit: ProviderModelLimit(context: 100_000, input: nil, output: nil)
+        )
+
+        // user (ignored) + A (2s, 200 out) + B (3s, 300 out + 100 reasoning)
+        // + C (still running, no completed -> excluded).
+        state.messages = [
+            try message("mU", "user", 9000, "null", 0, 0),
+            try message("mA", "assistant", 1000, "3000", 200, 0),
+            try message("mB", "assistant", 4000, "7000", 300, 100),
+            try message("mC", "assistant", 8000, "null", 500, 0),
+        ]
+
+        let snap = state.contextUsageSnapshot
+        #expect(snap != nil)
+        #expect(snap?.totalOutputTokens == 600)
+        #expect(snap?.totalGenerationSeconds == 5.0)
+        #expect(snap?.averageThroughput == 120.0)
+    }
+
+    @Test @MainActor
+    func snapshotNilWithoutAnyCompletedStep() async throws {
+        let state = AppState()
+        let session = try JSONDecoder().decode(Session.self, from: """
+        {"id":"ses_x","slug":"ses_x","projectID":"p1","directory":"/workspace","title":"S","version":"1","time":{"created":1,"updated":2}}
+        """.data(using: .utf8)!)
+        state.sessions = [session]
+        state.currentSessionID = "ses_x"
+        state.providerModelsIndex["openai/gpt-4"] = ProviderModel(
+            id: "gpt-4", name: "G", providerID: "openai",
+            limit: ProviderModelLimit(context: 100_000, input: nil, output: nil)
+        )
+        // Only an in-flight assistant (no completed) -> no LLM time to divide by.
+        state.messages = [try message("mA", "assistant", 1000, "null", 200, 0)]
+
+        let snap = state.contextUsageSnapshot
+        #expect(snap?.averageThroughput == nil)
+        #expect(snap?.totalGenerationSeconds == nil)
+    }
+}
+
 // MARK: - ModelPreset Tests
 
 struct ModelPresetTests {

--- a/OpenCodeClient/OpenCodeClientTests/ModelsTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/ModelsTests.swift
@@ -172,6 +172,70 @@ struct ContextUsageThroughputTests {
     }
 }
 
+// MARK: - StepTiming (SSE-derived TTFT + decoding) Tests
+
+struct StepTimingTests {
+
+    private func timing(
+        _ start: TimeInterval,
+        _ first: TimeInterval?,
+        _ finish: TimeInterval?,
+        _ output: Int?
+    ) -> MessageStore.StepTiming {
+        MessageStore.StepTiming(
+            sessionID: "s1",
+            stepStart: Date(timeIntervalSinceReferenceDate: start),
+            firstTextAt: first.map { Date(timeIntervalSinceReferenceDate: $0) },
+            finishAt: finish.map { Date(timeIntervalSinceReferenceDate: $0) },
+            outputTokens: output
+        )
+    }
+
+    @Test func ttftFromStepStartToFirstText() {
+        let t = timing(0, 3.2, nil, nil)
+        #expect(abs((t.ttft ?? -1) - 3.2) < 0.001)
+        #expect(t.ttftLabel == "3.2s")
+    }
+
+    @Test func ttftNilWithoutFirstText() {
+        let t = timing(0, nil, nil, nil)
+        #expect(t.ttft == nil)
+        #expect(t.ttftLabel == nil)
+    }
+
+    @Test func ttftNilWhenFirstTextNotAfterStart() {
+        // first token stamped before step start (bad data) -> no negative TTFT
+        let t = timing(5, 2, nil, nil)
+        #expect(t.ttft == nil)
+    }
+
+    @Test func decodeOverFirstTextToFinishWindow() {
+        // 100 output tokens over (4.7 - 3.2) = 1.5s -> 66.67 t/s
+        let t = timing(0, 3.2, 4.7, 100)
+        #expect(abs((t.decode ?? -1) - (100.0 / 1.5)) < 0.01)
+        #expect(t.decodeLabel == "67 t/s decoding")
+    }
+
+    @Test func decodeLabelDecimalBelowTen() {
+        // 15 output over 3.0s -> 5.0 t/s -> one decimal
+        let t = timing(0, 0, 3.0, 15)
+        #expect(t.decodeLabel == "5.0 t/s decoding")
+    }
+
+    @Test func decodeNilMissingFinishOrTokens() {
+        #expect(timing(0, 3.2, nil, 100).decode == nil)
+        #expect(timing(0, 3.2, 4.7, nil).decode == nil)
+        #expect(timing(0, 3.2, 4.7, 0).decode == nil)
+        #expect(timing(0, nil, 4.7, 100).decode == nil)
+    }
+
+    @Test func decodeNilOnNonPositiveWindow() {
+        // finish before or equal to first text -> no window
+        #expect(timing(0, 3.2, 3.2, 100).decode == nil)
+        #expect(timing(0, 3.2, 3.1, 100).decode == nil)
+    }
+}
+
 // MARK: - ModelPreset Tests
 
 struct ModelPresetTests {

--- a/OpenCodeClient/OpenCodeClientTests/SessionFlowTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/SessionFlowTests.swift
@@ -1636,6 +1636,58 @@ struct AppStateFlowTests {
         #expect(state.streamingPartTexts.isEmpty)
     }
 
+    @Test @MainActor func sseStreamCapturesStepTimingForCurrentSession() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.currentSessionID = "s1"
+
+        // Step start: assistant message.created.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.updated","properties":{"sessionID":"s1","info":{"id":"m1","role":"assistant","time":{"created":1000,"completed":null},"tokens":{"output":0,"reasoning":0}}}}}
+        """))
+        #expect(state.stepTimings["m1"] != nil)
+        #expect(state.stepTimings["m1"]?.sessionID == "s1")
+        #expect(state.stepTimings["m1"]?.firstTextAt == nil)
+
+        // A reasoning delta must not count as the first visible text token.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p-reason","field":"reasoning","delta":"think"}}}
+        """))
+        #expect(state.stepTimings["m1"]?.firstTextAt == nil)
+
+        // First text token.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p1","field":"text","delta":"H"}}}
+        """))
+        let first = state.stepTimings["m1"]?.firstTextAt
+        #expect(first != nil)
+
+        // Subsequent text deltas do not move the first-token stamp.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p1","field":"text","delta":"i"}}}
+        """))
+        #expect(state.stepTimings["m1"]?.firstTextAt == first)
+
+        // Step finish carries the output token count.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","messageID":"m1","sessionID":"s1","type":"step-finish","reason":"stop","tokens":{"output":100,"reasoning":0}}}}}
+        """))
+        #expect(state.stepTimings["m1"]?.outputTokens == 100)
+        #expect(state.stepTimings["m1"]?.finishAt != nil)
+        #expect(state.stepTimings["m1"]?.decode != nil)
+    }
+
+    @Test @MainActor func sseStepTimingIgnoresNonCurrentSession() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.currentSessionID = "s1"
+
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.delta","properties":{"sessionID":"s2","messageID":"m9","partID":"p9","field":"text","delta":"x"}}}
+        """))
+        #expect(state.stepTimings.isEmpty)
+    }
+
     @Test @MainActor func deleteCurrentSessionSelectsNextMostRecentSession() async throws {
         let apiClient = MockAPIClient()
         await apiClient.setMessagesResult([Self.makeMessageRow(messageID: "m-next", sessionID: "next", text: "next")])

--- a/OpenCodeClient/OpenCodeClientTests/SessionFlowTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/SessionFlowTests.swift
@@ -1649,13 +1649,29 @@ struct AppStateFlowTests {
         #expect(state.stepTimings["m1"]?.sessionID == "s1")
         #expect(state.stepTimings["m1"]?.firstTextAt == nil)
 
-        // A reasoning delta must not count as the first visible text token.
+        // Wire shape: the server emits `message.part.delta` with `field:"text"`
+        // for BOTH reasoning and text parts (see processor.ts reasoning-delta /
+        // text-delta). The part's `type` is carried by the `message.part.updated`
+        // that precedes each part's deltas, so the client tracks partID -> type.
+        // Reasoning part created first.
         await state.applySSEEventForTesting(Self.makeSSEEvent("""
-        {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p-reason","field":"reasoning","delta":"think"}}}
+        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p-reason","messageID":"m1","sessionID":"s1","type":"reasoning"}}}}
+        """))
+
+        // A reasoning delta (field "text", part type "reasoning") must NOT count
+        // as the first visible text token.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p-reason","field":"text","delta":"think"}}}
         """))
         #expect(state.stepTimings["m1"]?.firstTextAt == nil)
 
-        // First text token.
+        // Text part created.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","messageID":"m1","sessionID":"s1","type":"text"}}}}
+        """))
+        #expect(state.stepTimings["m1"]?.firstTextAt == nil)
+
+        // First text token (field "text", part type "text").
         await state.applySSEEventForTesting(Self.makeSSEEvent("""
         {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p1","field":"text","delta":"H"}}}
         """))
@@ -1668,9 +1684,9 @@ struct AppStateFlowTests {
         """))
         #expect(state.stepTimings["m1"]?.firstTextAt == first)
 
-        // Step finish carries the output token count.
+        // Step finish (its own part id) carries the output token count.
         await state.applySSEEventForTesting(Self.makeSSEEvent("""
-        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","messageID":"m1","sessionID":"s1","type":"step-finish","reason":"stop","tokens":{"output":100,"reasoning":0}}}}}
+        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p-fin","messageID":"m1","sessionID":"s1","type":"step-finish","reason":"stop","tokens":{"output":100,"reasoning":0}}}}}
         """))
         #expect(state.stepTimings["m1"]?.outputTokens == 100)
         #expect(state.stepTimings["m1"]?.finishAt != nil)
@@ -1682,6 +1698,11 @@ struct AppStateFlowTests {
         let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
         state.currentSessionID = "s1"
 
+        // A full step for a NON-current session: part created + text delta.
+        // Both are session-guarded, so nothing is recorded for it.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s2","part":{"id":"p9","messageID":"m9","sessionID":"s2","type":"text"}}}}
+        """))
         await state.applySSEEventForTesting(Self.makeSSEEvent("""
         {"payload":{"type":"message.part.delta","properties":{"sessionID":"s2","messageID":"m9","partID":"p9","field":"text","delta":"x"}}}
         """))

--- a/OpenCodeClient/OpenCodeClientTests/SessionFlowTests.swift
+++ b/OpenCodeClient/OpenCodeClientTests/SessionFlowTests.swift
@@ -1647,7 +1647,7 @@ struct AppStateFlowTests {
         """))
         #expect(state.stepTimings["m1"] != nil)
         #expect(state.stepTimings["m1"]?.sessionID == "s1")
-        #expect(state.stepTimings["m1"]?.firstTextAt == nil)
+        #expect(state.stepTimings["m1"]?.firstVisibleAt == nil)
 
         // Wire shape: the server emits `message.part.delta` with `field:"text"`
         // for BOTH reasoning and text parts (see processor.ts reasoning-delta /
@@ -1663,34 +1663,73 @@ struct AppStateFlowTests {
         await state.applySSEEventForTesting(Self.makeSSEEvent("""
         {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p-reason","field":"text","delta":"think"}}}
         """))
-        #expect(state.stepTimings["m1"]?.firstTextAt == nil)
+        #expect(state.stepTimings["m1"]?.firstVisibleAt == nil)
 
         // Text part created.
         await state.applySSEEventForTesting(Self.makeSSEEvent("""
         {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","messageID":"m1","sessionID":"s1","type":"text"}}}}
         """))
-        #expect(state.stepTimings["m1"]?.firstTextAt == nil)
+        #expect(state.stepTimings["m1"]?.firstVisibleAt == nil)
 
         // First text token (field "text", part type "text").
         await state.applySSEEventForTesting(Self.makeSSEEvent("""
         {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p1","field":"text","delta":"H"}}}
         """))
-        let first = state.stepTimings["m1"]?.firstTextAt
+        let first = state.stepTimings["m1"]?.firstVisibleAt
         #expect(first != nil)
 
         // Subsequent text deltas do not move the first-token stamp.
         await state.applySSEEventForTesting(Self.makeSSEEvent("""
         {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p1","field":"text","delta":"i"}}}
         """))
-        #expect(state.stepTimings["m1"]?.firstTextAt == first)
+        #expect(state.stepTimings["m1"]?.firstVisibleAt == first)
 
-        // Step finish (its own part id) carries the output token count.
+        // Step finish (its own part id) carries the output token count, and
+        // must not move the decoding window's end.
+        let last = state.stepTimings["m1"]?.lastVisibleAt
         await state.applySSEEventForTesting(Self.makeSSEEvent("""
         {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p-fin","messageID":"m1","sessionID":"s1","type":"step-finish","reason":"stop","tokens":{"output":100,"reasoning":0}}}}}
         """))
         #expect(state.stepTimings["m1"]?.outputTokens == 100)
-        #expect(state.stepTimings["m1"]?.finishAt != nil)
-        #expect(state.stepTimings["m1"]?.decode != nil)
+        #expect(state.stepTimings["m1"]?.lastVisibleAt == last)
+    }
+
+    @Test @MainActor func sseToolCallOnlyStepGetsDecodingWindow() async {
+        let apiClient = MockAPIClient()
+        let state = AppState(apiClient: apiClient, sseClient: MockSSEClient(), sshTunnelManager: SSHTunnelManager())
+        state.currentSessionID = "s1"
+
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.updated","properties":{"sessionID":"s1","info":{"id":"m1","role":"assistant","time":{"created":1000,"completed":null},"tokens":{"output":0,"reasoning":0}}}}}
+        """))
+
+        // A step whose only output is a tool call: the tool part carries its JSON
+        // input as deltas on `message.part.updated`, which must count as visible
+        // output or the step has no decoding window at all.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p-tool","messageID":"m1","sessionID":"s1","type":"tool","tool":"write"}}}}
+        """))
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","delta":"{\\"path\\":\\"a","part":{"id":"p-tool","messageID":"m1","sessionID":"s1","type":"tool","tool":"write"}}}}
+        """))
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","delta":"\\",\\"content\\":\\"x\\"}","part":{"id":"p-tool","messageID":"m1","sessionID":"s1","type":"tool","tool":"write"}}}}
+        """))
+        let first = state.stepTimings["m1"]?.firstVisibleAt
+        let last = state.stepTimings["m1"]?.lastVisibleAt
+        if let first, let last {
+            #expect(last >= first)
+        } else {
+            Issue.record("tool-input deltas did not stamp the visible window")
+        }
+
+        // Step finish arrives only after the tool ran; it carries the token
+        // count but must not stretch the decoding window to itself.
+        await state.applySSEEventForTesting(Self.makeSSEEvent("""
+        {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p-fin","messageID":"m1","sessionID":"s1","type":"step-finish","reason":"tool-calls","tokens":{"output":2048,"reasoning":0}}}}}
+        """))
+        #expect(state.stepTimings["m1"]?.outputTokens == 2048)
+        #expect(state.stepTimings["m1"]?.lastVisibleAt == last)
     }
 
     @Test @MainActor func sseStepTimingIgnoresNonCurrentSession() async {

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -4,10 +4,10 @@
 
 ## 当前状态
 
-- **最后更新**：2026-08-24
-- **分支**：`master` @ `b420f9d`（PR #149）
-- **编译/测试**：build 通过；shortlist 单测与 `ModelShortlistUITests` 通过
-- **Phase**：聊天栏模型选择改为设备本地 shortlist（Settings → Models）
+- **最后更新**：2026-09-13
+- **分支**：`master`（PR #165 合并）
+- **编译/测试**：build 通过；throughput 相关 5 个 suite 29 条单测通过（Xcode 27 beta / iOS 27.0 模拟器）
+- **Phase**：LLM throughput 显示（per-message 脚注 + Context sheet）；分母已扣除 tool 执行时间，TTFT 已删
 
 ### 2026-09-12 — LLM throughput 显示（per-message 脚注 + Context sheet）
 
@@ -30,7 +30,7 @@
   - 测试：SessionFlow 三条（SSE 流捕获：reasoning delta 不进可见窗口、tool-input delta 建立窗口且 step-finish 不移动窗口右端、非当前 session 忽略）+ `StepTimingTests`（decode 计算与 label、窗口两端/宽度为 0/token 缺失各 nil 边界）。
   - **已知边界**：decoding 仅当前 app 会话内、观察到流的那一步有效；重启或纯历史消息回退为 general only。若需历史回溯纯 decode，必须 patch server 给 assistant 消息加 first-token 时间戳并落库。
 - **已知边界**：~~tool 耗时本次不做（用户明确不感兴趣）；实时 SSE 带 tool 时间戳，但持久化 history 的 V1 message list 不存 tool `time`，故历史无法回溯 tool 耗时~~ → **2026-09-13 更正：tool part 的 `state.time` 在持久化 payload 里存在（本地 DB 全量 2 万+ tool part 均有 start/end），且必须从分母里扣掉，见下方修正段**。
-- **分支**：`feat/llm-throughput`（PR 待 review，未 merge）。
+- **合并**：PR #165（分支 `feat/llm-throughput`）。
 
 #### 2026-09-13 修正：tool 执行时间在 step 窗口内，必须从分母扣除
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -9,6 +9,20 @@
 - **编译/测试**：build 通过；shortlist 单测与 `ModelShortlistUITests` 通过
 - **Phase**：聊天栏模型选择改为设备本地 shortlist（Settings → Models）
 
+### 2026-09-12 — LLM throughput 显示（per-message 脚注 + Context sheet）
+
+- **动机**：想看 LLM 工作时的真实生成速率（"x 秒生成 y 个 token"）。在 live server（4096）上实测确认：每条 assistant 消息（= 一个 LLM step）已带 `time.created` / `time.completed` / `tokens`，且相邻 step 间隔仅 1–3ms、单步耗时跟随 output token 数而非 tool 数量——说明该窗口是干净的 LLM 生成时间（tool 执行落在 step 之间，不计入）。纯客户端可算，server 零改动。
+- **口径**：分母 = step 的 wall-clock（`completed - created`，含 prefill + 生成，不含 tool 执行）；分子 = `output + reasoning`（模型实际吐出的 token，不含 input/prefill，也不含 cache read/write）。`completed` 为 nil（生成中）、窗口为 0 或 token 为 0 时不出数。
+- **实现**：
+  - `Message.generatedTokens` / `Message.throughput` / `Message.throughputLabel`（`Models/Message.swift`）：核心计算；label "≥10 取整、<10 一位小数"。
+  - 每条 assistant 消息 footer（`MessageRowView`）：`provider/model` 后追加 ` | X t/s`；生成中只显示 model（无 completed 时间戳）。
+  - Context sheet（`ContextUsageView`）顶部新增 Throughput section：session 级平均速率（总 token / 总 LLM 时长）、生成 token 数（output+reasoning）、生成总耗时。
+  - L10n 新增 5 个 key（en/zh）。
+- **测试**：新增 12 个单测——`MessageThroughputTests` 10 个（basic / 含 reasoning / 生成中 nil / 零窗口 nil / 无 token nil / 缺 tokens 字段 nil / 负窗口 nil / label 整数 / label 小数 / label nil）+ `ContextUsageThroughputTests` 2 个（session 聚合并排除生成中 / 无已完成 step 时 nil）全过；全量单测回归 427/427（signed build）。
+- **Review**：GLM-5.3 subagent 一审 approve-with-nits，无 correctness 问题；据 review 收敛两处：throughput 数字格式抽成 `Message.throughputText` 单一实现（footer 与 sheet 共用，避免漂移）；sheet 的 "Output tokens" 标签改为 "Generated tokens"（因口径是 output+reasoning，避免与 Tokens section 的 Output 行混淆）。
+- **已知边界**：tool 耗时本次不做（用户明确不感兴趣）；实时 SSE 带 tool 时间戳，但持久化 history 的 V1 message list 不存 tool `time`，故历史无法回溯 tool 耗时——后续如需再 patch server。
+- **分支**：`feat/llm-throughput`（PR 待 review，未 merge）。
+
 ### 2026-09-10 — iPhone 文件预览左缘右滑关闭
 
 - compact-width Chat 里，点文件 tool call 打开的 docked `ChatInlineFilePreview` 除 toolbar `xmark` 外，可用标准 iOS 返回手势关闭：从屏幕物理左缘起手、向右拖够距离。

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -11,8 +11,8 @@
 
 ### 2026-09-12 — LLM throughput 显示（per-message 脚注 + Context sheet）
 
-- **动机**：想看 LLM 工作时的真实生成速率（"x 秒生成 y 个 token"）。在 live server（4096）上实测确认：每条 assistant 消息（= 一个 LLM step）已带 `time.created` / `time.completed` / `tokens`，且相邻 step 间隔仅 1–3ms、单步耗时跟随 output token 数而非 tool 数量——说明该窗口是干净的 LLM 生成时间（tool 执行落在 step 之间，不计入）。纯客户端可算，server 零改动。
-- **口径**：分母 = step 的 wall-clock（`completed - created`，含 prefill + 生成，不含 tool 执行）；分子 = `output + reasoning`（模型实际吐出的 token，不含 input/prefill，也不含 cache read/write）。`completed` 为 nil（生成中）、窗口为 0 或 token 为 0 时不出数。
+- **动机**：想看 LLM 工作时的真实生成速率（"x 秒生成 y 个 token"）。在 live server（4096）上实测确认：每条 assistant 消息（= 一个 LLM step）已带 `time.created` / `time.completed` / `tokens`。纯客户端可算，server 零改动。~~相邻 step 间隔仅 1–3ms、单步耗时跟随 output token 数而非 tool 数量——说明该窗口是干净的 LLM 生成时间（tool 执行落在 step 之间，不计入）~~ → **该判断 2026-09-13 证伪，见下方修正段**。
+- **口径**：分母 = step 的 wall-clock（`completed - created`，含 prefill + 生成 + **tool 执行**）；分子 = `output + reasoning`（模型实际吐出的 token，不含 input/prefill，也不含 cache read/write）。`completed` 为 nil（生成中）、窗口为 0 或 token 为 0 时不出数。
 - **实现**：
   - `Message.generatedTokens` / `Message.throughput` / `Message.throughputLabel`（`Models/Message.swift`）：核心计算；label "≥10 取整、<10 一位小数"。
   - 每条 assistant 消息 footer（`MessageRowView`）：`provider/model` 后追加 ` | X t/s`；生成中只显示 model（无 completed 时间戳）。
@@ -20,16 +20,31 @@
   - L10n 新增 5 个 key（en/zh）。
 - **测试**：新增 12 个单测——`MessageThroughputTests` 10 个（basic / 含 reasoning / 生成中 nil / 零窗口 nil / 无 token nil / 缺 tokens 字段 nil / 负窗口 nil / label 整数 / label 小数 / label nil）+ `ContextUsageThroughputTests` 2 个（session 聚合并排除生成中 / 无已完成 step 时 nil）全过；全量单测回归 427/427（signed build）。
 - **Review**：GLM-5.3 subagent 一审 approve-with-nits，无 correctness 问题；据 review 收敛两处：throughput 数字格式抽成 `Message.throughputText` 单一实现（footer 与 sheet 共用，避免漂移）；sheet 的 "Output tokens" 标签改为 "Generated tokens"（因口径是 output+reasoning，避免与 Tokens section 的 Output 行混淆）。
-- **SSE 扩展：best-effort TTFT + decoding（2026-09-12 追加）**：
-  - 背景：单一 general throughput 把 prefill 和 decode 揉在一起（分母 `created→completed` 含 prefill）。标准 LLM 测量要拆成 TTFT（首个可见 text token）+ decoding（纯文本生成速率）。
-  - 数据源：server **不持久化 first-token 时间**（`message-updater` 只写 `created`/`completed`），所以历史消息算不出 TTFT/decoding；但实时 SSE 流有 `message.part.delta`（逐 token，`field`/`messageID`，无 server 时间戳）和 `message.part.updated`（step-finish，带 `tokens.output`）。
-  - **best-effort 口径**：只看"是否观察到 SSE"。观察到就分开，没观察到（翻历史 / 重启 / 纯 REST 加载）就不分开，footer 只留 general。
-  - **时钟**：全部用 client 接收时间（stepStart=首个 assistant `message.updated` 到达、firstText=首个 `field==text` delta 到达、finish=step-finish part 到达），避免 server/client 时钟 skew（SSH 远端场景）。TTFT = firstText - stepStart；decoding = `tokens.output` / (finish - firstText)（分子只算 output，窗口从首个 text token 起，prefill 与 reasoning 都落在 firstText 之前被排除）。
-  - 实现：`MessageStore.StepTiming`（per assistant messageID，`stepStart`/`firstTextAt`/`finishAt`/`outputTokens` + `ttft`/`decode` + 两个 label）；`handleSSEEvent` 新增 `message.part.delta` case、`message.updated` 记 stepStart、`message.part.updated` step-finish 记 finish+tokens；`stepTimings` **不**随 `resetStreaming()` 清空（那在每条 message 更新都会触发，含本 step 自身），改为 session-scoped clear（`clearCurrentSessionViewState` / `removeTimings(forSession:)`）时清理。footer（`MessageRowView`）：`provider/model | <general> t/s | TTFT: 3.2s | 128 t/s decoding`，后两段仅在 SSE 观察到时出现。
-  - 测试：新增 `StepTimingTests`（ttft/decode 计算与 label、各 nil 边界）+ SessionFlow 两条（SSE 流捕获：reasoning delta 不算首 token、首 token 只记一次、step-finish 带 tokens；非当前 session 忽略）。
-  - **已知边界**：TTFT/decoding 仅当前 app 会话内、观察到流的那一步有效；重启或纯历史消息回退为 general only。若需历史回溯 TTFT/decoding，必须 patch server 给 assistant 消息加 first-token 时间戳并落库。
-- **已知边界**：tool 耗时本次不做（用户明确不感兴趣）；实时 SSE 带 tool 时间戳，但持久化 history 的 V1 message list 不存 tool `time`，故历史无法回溯 tool 耗时——后续如需再 patch server。
+- **SSE 扩展：best-effort decoding（2026-09-12 追加，2026-09-13 收敛为 decoding-only）**：
+  - 背景：单一 general throughput 把 prefill 和 decode 揉在一起（分母 `created→completed` 含 prefill）。目标是拆出一个纯生成速率。
+  - 数据源：server **不持久化 first-token 时间**（`message-updater` 只写 `created`/`completed`），所以历史消息算不出纯 decode；但实时 SSE 流有逐 token 的 `message.part.delta`（`field`/`messageID`，无 server 时间戳）和 `message.part.updated`（part 创建/收尾、step-finish 带 `tokens.output`）。
+  - **best-effort 口径**：只看"是否观察到 SSE"。观察到就给 decoding，没观察到（翻历史 / 重启 / 纯 REST 加载）就不给，footer 只留 general。
+  - **时钟**：全部用 client 接收时间（firstVisible=首个可见 token 到达、lastVisible=最后一个可见 token 到达），避免 server/client 时钟 skew（SSH 远端场景）。decoding = `tokens.output` / (lastVisible - firstVisible)；分子只算 output，prefill 与 reasoning 都落在窗口之前被排除，tool 执行落在窗口之后被排除。step-finish 的到达时间**不**参与窗口（它在 tool 跑完之后才到），只提供 `tokens.output`；只观测到一个可见 token（窗口宽度为 0）时不出数，不编造。
+  - 实现：`MessageStore.StepTiming`（per assistant messageID，`firstVisibleAt`/`lastVisibleAt`/`outputTokens` + `decode`/`decodeLabel`）；`handleSSEEvent` 新增 `message.part.delta` case、`message.updated` 建 step 条目、`message.part.updated` 收 delta 与 step-finish；`stepTimings` **不**随 `resetStreaming()` 清空（那在每条 message 更新都会触发，含本 step 自身），改为 session-scoped clear（`clearCurrentSessionViewState` / `removeTimings(forSession:)`）时清理。footer（`MessageRowView`）：`provider/model | <general> t/s | <decode> t/s decoding`，最后一段仅在 SSE 观察到时出现。
+  - **TTFT 已删除（2026-09-13）**：原设计在 footer 里带 `TTFT: 3.2s`（firstVisible - stepStart）。实机跑下来这条几乎从不出现（客户端看到 assistant `message.updated` 与首个 token 到达之间的窗口不可靠，且它不影响使用者要的"真实生成速率"），按"没用的东西不留"删掉：`StepTiming` 去掉 `stepStart` / `ttft` / `ttftLabel`，footer 去掉该段，相关单测一并删除。`recordStepStart` 保留，作用改为"标记这个 step 从开头就被观察到"，仍是 decoding 窗口的前置条件。
+  - 测试：SessionFlow 三条（SSE 流捕获：reasoning delta 不进可见窗口、tool-input delta 建立窗口且 step-finish 不移动窗口右端、非当前 session 忽略）+ `StepTimingTests`（decode 计算与 label、窗口两端/宽度为 0/token 缺失各 nil 边界）。
+  - **已知边界**：decoding 仅当前 app 会话内、观察到流的那一步有效；重启或纯历史消息回退为 general only。若需历史回溯纯 decode，必须 patch server 给 assistant 消息加 first-token 时间戳并落库。
+- **已知边界**：~~tool 耗时本次不做（用户明确不感兴趣）；实时 SSE 带 tool 时间戳，但持久化 history 的 V1 message list 不存 tool `time`，故历史无法回溯 tool 耗时~~ → **2026-09-13 更正：tool part 的 `state.time` 在持久化 payload 里存在（本地 DB 全量 2 万+ tool part 均有 start/end），且必须从分母里扣掉，见下方修正段**。
 - **分支**：`feat/llm-throughput`（PR 待 review，未 merge）。
+
+#### 2026-09-13 修正：tool 执行时间在 step 窗口内，必须从分母扣除
+
+- **触发**：实机跑出"LLM 输出了一个很大的 write tool call，但 throughput 特别低"。
+- **结论：分子没问题，tool call 的 token 一直在算。** `output` = provider 的 output tokens − reasoning，模型为 tool call 生成的 JSON 参数属于 output tokens。用本地 OpenCode DB（`~/.local/share/opencode/opencode.db`）复核：910 个 tool part 中 901 个的所属 step `tokens.output` 与 tool input 体量一致（其余 9 个是 `shell`/synthetic 路径，output 恒为 0）；write 类最大样本 5426 字符 input 对应 2748 output tokens。所以"没算 tool token"是误诊。
+- **真因**：分母 `created → completed` **包含 tool 的执行时间**。两个 server 路径都如此：legacy processor 在 stream 内执行 tool、`completed` 在 tool 结束后才写；V2 runner 先 `awaitToolFibers` 再发 `SessionEvent.Step.Ended`。实测证据：`msg_085d6384a001` 的 bash tool 跑了 417,204ms，step 窗口 419,309ms，output 63 tokens → 显示 0.1 t/s；`msg_dbd74d5d0001` 的 write tool 跑 48,345ms，step 窗口 56,157ms，529 tokens → 显示 9.4 t/s（扣掉 tool 时间应为 67.7 t/s）。
+- **修复（客户端，仍零 server 改动）**：
+  - `PartStateBridge` 解析 `state.time.start/end`，`Part.toolRunSeconds` / `MessageWithParts.toolRunSeconds` 汇总；`Message.throughputExcludingToolSeconds` = `generatedTokens / (stepSeconds - toolRunSeconds)`（tool 时间 ≥ 窗口时回退原始窗口，不产生负分母）。
+  - footer 与 Context sheet 的 general 数字都改用扣 tool 后的口径；sheet 的 session 平均同样逐 step 扣除。
+  - SSE decoding 窗口的右端点从"step-finish part 到达"改为"最后一个可见 delta 到达"（step-finish 在 tool 跑完之后才到，用它收尾等于把 tool 时间加回 decode）；同时 tool-input delta 记入可见 token，使"只输出 tool call、没有正文"的 step 也能算出 decoding，而不是只剩被 tool 时间污染的 general。
+  - `StepTiming.firstTextAt` 更名 `firstVisibleAt`，新增 `lastVisibleAt`；TTFT 相关字段（`stepStart`/`ttft`/`ttftLabel`）随后删除，见上节。
+- **残留边界**：persisted 口径仍含 prefill（历史数据无法拆出首 token 时间），SSE 观察到的 step 才能给出纯 decode 速率；Context sheet 的 session 平均只覆盖当前已加载的消息（分页外的历史不计）；tool 时间缺失（running、老 payload）时回退原始窗口。
+- **测试**：`MessageThroughputTests` +3（扣 tool / tool 时间超窗口回退 / 运行中 nil）、新增 `MessageToolTimingTests` 3 条（state.time 汇总、缺 timing 为 0、running 无 end 不计）、`ContextUsageThroughputTests` +1（聚合扣 tool）、`StepTimingTests` +2（decode 用 lastVisibleAt 收尾、tool-only step 有窗口）、`AppStateFlowTests` +1 并改写既有 1 条（tool-input delta 建立窗口、step-finish 不移动窗口右端）。**聚焦 5 个 suite 29 条全过**（Xcode 27 beta + iOS 27.0 模拟器，`test-without-building`）。
+- **测试环境坑**：`/Applications/Xcode.app`（26.6）缺 iOS platform 组件，iOS 模拟器 destination 全部不可用；Xcode 27 beta 能跑，但 `AIUsageQuotaTests.swift` 与 beta 的默认 isolation 不兼容（actor 无法 conform 被推断为 global-actor-isolated 的 protocol），跑测试时临时移出该文件、跑完复原，未改动其内容。
 
 ### 2026-09-10 — iPhone 文件预览左缘右滑关闭
 

--- a/docs/WORKING.md
+++ b/docs/WORKING.md
@@ -20,6 +20,14 @@
   - L10n 新增 5 个 key（en/zh）。
 - **测试**：新增 12 个单测——`MessageThroughputTests` 10 个（basic / 含 reasoning / 生成中 nil / 零窗口 nil / 无 token nil / 缺 tokens 字段 nil / 负窗口 nil / label 整数 / label 小数 / label nil）+ `ContextUsageThroughputTests` 2 个（session 聚合并排除生成中 / 无已完成 step 时 nil）全过；全量单测回归 427/427（signed build）。
 - **Review**：GLM-5.3 subagent 一审 approve-with-nits，无 correctness 问题；据 review 收敛两处：throughput 数字格式抽成 `Message.throughputText` 单一实现（footer 与 sheet 共用，避免漂移）；sheet 的 "Output tokens" 标签改为 "Generated tokens"（因口径是 output+reasoning，避免与 Tokens section 的 Output 行混淆）。
+- **SSE 扩展：best-effort TTFT + decoding（2026-09-12 追加）**：
+  - 背景：单一 general throughput 把 prefill 和 decode 揉在一起（分母 `created→completed` 含 prefill）。标准 LLM 测量要拆成 TTFT（首个可见 text token）+ decoding（纯文本生成速率）。
+  - 数据源：server **不持久化 first-token 时间**（`message-updater` 只写 `created`/`completed`），所以历史消息算不出 TTFT/decoding；但实时 SSE 流有 `message.part.delta`（逐 token，`field`/`messageID`，无 server 时间戳）和 `message.part.updated`（step-finish，带 `tokens.output`）。
+  - **best-effort 口径**：只看"是否观察到 SSE"。观察到就分开，没观察到（翻历史 / 重启 / 纯 REST 加载）就不分开，footer 只留 general。
+  - **时钟**：全部用 client 接收时间（stepStart=首个 assistant `message.updated` 到达、firstText=首个 `field==text` delta 到达、finish=step-finish part 到达），避免 server/client 时钟 skew（SSH 远端场景）。TTFT = firstText - stepStart；decoding = `tokens.output` / (finish - firstText)（分子只算 output，窗口从首个 text token 起，prefill 与 reasoning 都落在 firstText 之前被排除）。
+  - 实现：`MessageStore.StepTiming`（per assistant messageID，`stepStart`/`firstTextAt`/`finishAt`/`outputTokens` + `ttft`/`decode` + 两个 label）；`handleSSEEvent` 新增 `message.part.delta` case、`message.updated` 记 stepStart、`message.part.updated` step-finish 记 finish+tokens；`stepTimings` **不**随 `resetStreaming()` 清空（那在每条 message 更新都会触发，含本 step 自身），改为 session-scoped clear（`clearCurrentSessionViewState` / `removeTimings(forSession:)`）时清理。footer（`MessageRowView`）：`provider/model | <general> t/s | TTFT: 3.2s | 128 t/s decoding`，后两段仅在 SSE 观察到时出现。
+  - 测试：新增 `StepTimingTests`（ttft/decode 计算与 label、各 nil 边界）+ SessionFlow 两条（SSE 流捕获：reasoning delta 不算首 token、首 token 只记一次、step-finish 带 tokens；非当前 session 忽略）。
+  - **已知边界**：TTFT/decoding 仅当前 app 会话内、观察到流的那一步有效；重启或纯历史消息回退为 general only。若需历史回溯 TTFT/decoding，必须 patch server 给 assistant 消息加 first-token 时间戳并落库。
 - **已知边界**：tool 耗时本次不做（用户明确不感兴趣）；实时 SSE 带 tool 时间戳，但持久化 history 的 V1 message list 不存 tool `time`，故历史无法回溯 tool 耗时——后续如需再 patch server。
 - **分支**：`feat/llm-throughput`（PR 待 review，未 merge）。
 


### PR DESCRIPTION
Adds LLM generation throughput (tokens/second) display, computed entirely client-side from data already on the wire. No server changes.

## What
Each assistant message is one LLM step and already carries `time.created` / `time.completed` / `tokens`.

**Definition**
- Numerator: `tokens.output + tokens.reasoning` — every token the model emitted. Tool-call argument tokens are part of `output`; `input`/prefill and cache read/write are excluded.
- Denominator: the step's wall-clock `time.completed - time.created` **minus the wall-clock of the tools that step ran** (`state.time` on each tool part).
- Falls back to the raw window when the server recorded no tool timing (running tool, older payload), or when subtracting would leave no positive window.
- No number while a step is still generating (`completed == nil`), when the window is 0ms, or when no tokens were emitted.

**Correction to the original definition (2026-09-13)**: the first version of this PR claimed tool execution happens between steps and is therefore not counted. That was wrong — a step's window contains its own tool execution, on both server lineages (`Step.Ended` / `step-finish` is published only after the tools have run). Measured on real sessions: a `write` tool that ran 48s inside a 56s step made a 529-token step read as 9.4 t/s instead of 67.7 t/s; a `bash` tool that ran 417s inside a 419s step made a 63-token step read as 0.1 t/s. The tool-call tokens were always counted (verified against ~900 tool parts in a local OpenCode DB: the step's `tokens.output` matches the tool input's size) — only the denominator was inflated.

## Where
1. **Per-message footer** — after `provider/model`, append ` | X t/s`. While generating (no `completed` yet) only the model shows. When this app session observed the live stream for that step, a ` | X t/s decoding` segment follows.
2. **Context sheet** — new "Throughput" section: session-level average throughput (generated tokens / generation time, tool time subtracted per step), generated tokens, and total generation time.

## Notes
- Token count uses `output + reasoning` (labeled "Generated tokens", not "Output", to avoid confusion with the Tokens section's Output row).
- SSE-derived decoding is best-effort: the window runs from the first visible output token (text or tool-call JSON input) to the last one, so prefill and tool execution are both excluded. It is only available for steps whose stream this app session observed; everything else falls back to the tool-corrected general rate.
- A step that emitted only one visible token has a zero-width window and shows no decoding number rather than a fabricated one.
- TTFT was removed: on device it almost never produced a value, and it is not needed for the generation rate.
- The persisted rate still includes prefill — the server does not persist a first-token timestamp, so reconstructing pure decode for history would need a server-side timestamp.

## Tests
- `MessageThroughputTests` — tool time subtracted, fallback when tool time exceeds the window, running step, label formatting.
- `MessageToolTimingTests` — `state.time` parsing and summation, running tools, payloads without timing.
- `StepTimingTests` — decoding window boundaries, last-visible-token end, tool-call-only steps, zero-width window.
- `ContextUsageThroughputTests` — session aggregate subtracts per-step tool time.
- `AppStateFlowTests` — SSE coverage: reasoning deltas stay out of the visible window, tool-input deltas open it, step-finish does not move its end, non-current sessions ignored.

Ready for manual testing on device/simulator — not merged.
